### PR TITLE
add all tooltips to top_window_group, not only the unmoved ones

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1510,7 +1510,6 @@ meta_window_actor_new (MetaWindow *window)
   Window		  top_window;
   MetaRectangle rectWorkArea[1];
   MetaRectangle *rectWindow;
-  int tooltipMoved = FALSE;
 
   frame = meta_window_get_frame (window);
   if (frame)
@@ -1550,23 +1549,14 @@ meta_window_actor_new (MetaWindow *window)
     // move tooltip out of top panel if necessary
     if (rectWindow->y < rectWorkArea->y) {
       meta_window_move(window, FALSE, rectWindow->x, rectWorkArea->y);
-      tooltipMoved = TRUE;
     }
     rectWindow = meta_window_get_rect(window);
     // move tooltip out of bottom panel if necessary
     if ((rectWindow->y + rectWindow->height) > (rectWorkArea->y  + rectWorkArea->height)) {
       meta_window_move(window, FALSE, rectWindow->x, rectWorkArea->y + rectWorkArea->height - rectWindow->height);
-      tooltipMoved = TRUE;
     }
-    
-    if (tooltipMoved) {
-      clutter_container_add_actor (CLUTTER_CONTAINER (info->window_group),
-			       CLUTTER_ACTOR (self));
-    }
-    else {
-      clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
-			       CLUTTER_ACTOR (self));
-    }
+    clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
+		       CLUTTER_ACTOR (self));
   }else{
     clutter_container_add_actor (CLUTTER_CONTAINER (info->window_group),
 			       CLUTTER_ACTOR (self));


### PR DESCRIPTION
This adds all tooltips to top_window_group, no matter if they are moved out of the panel region.
