### PR TITLE
Add meta_window_is_demanding_attention and meta_window_is_urgent 

### DIFF
--- a/debian/libmuffin0.symbols
+++ b/debian/libmuffin0.symbols
@@ -845,6 +845,7 @@ libmuffin.so.0 libmuffin0 #MINVER#
  meta_window_has_focus@Base 1.1.2
  meta_window_is_ancestor_of_transient@Base 1.1.2
  meta_window_is_attached_dialog@Base 1.1.2
+ meta_window_is_demanding_attention@Base 1.1.2
  meta_window_is_fullscreen@Base 1.1.2
  meta_window_is_hidden@Base 1.1.2
  meta_window_is_mapped@Base 1.1.2
@@ -855,6 +856,7 @@ libmuffin.so.0 libmuffin0 #MINVER#
  meta_window_is_remote@Base 1.1.2
  meta_window_is_shaded@Base 1.1.2
  meta_window_is_skip_taskbar@Base 1.1.2
+ meta_window_is_urgent@Base 1.1.2
  meta_window_kill@Base 1.1.2
  meta_window_load_initial_properties@Base 1.1.2
  meta_window_located_on_workspace@Base 1.1.2

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -10146,6 +10146,34 @@ meta_window_set_demands_attention (MetaWindow *window)
     }
 }
 
+/**
+ * meta_window_is_demanding_attention:
+ * @window: A #MetaWindow
+ *
+ * Returns true if window has the demands-attention flag set.
+ *
+ * Return value: %TRUE if wm_state_demands_attention is set.
+ */
+gboolean
+meta_window_is_demanding_attention (MetaWindow *window)
+{
+  return window->wm_state_demands_attention;
+}
+
+/**
+ * meta_window_is_urgent:
+ * @window: A #MetaWindow
+ *
+ * Returns true if window has the urgent hint set.
+ *
+ * Return value: %TRUE if wm_hints_urgent is set.
+ */
+gboolean
+meta_window_is_urgent (MetaWindow *window)
+{
+  return window->wm_hints_urgent;
+}
+
 void
 meta_window_unset_demands_attention (MetaWindow *window)
 {

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -143,6 +143,8 @@ MetaMaximizeFlags meta_window_get_maximized (MetaWindow *window);
 gboolean          meta_window_is_fullscreen (MetaWindow *window);
 gboolean          meta_window_is_on_primary_monitor (MetaWindow *window);
 
+gboolean meta_window_is_demanding_attention (MetaWindow *window);
+gboolean meta_window_is_urgent (MetaWindow *window);
 gboolean meta_window_is_mapped (MetaWindow  *window);
 gboolean meta_window_toplevel_is_mapped (MetaWindow  *window);
 gboolean meta_window_get_icon_geometry (MetaWindow    *window,


### PR DESCRIPTION
This adds a couple of simple functions to query a metawindow whether it is marked urgent or otherwise seeking attention from the user. It is at this moment intended for use in Cinnamon's Scale view, but it can also be used in Expo and Alt-Tab, to single out windows that need attention.
