### PR TITLE
Fix for issue where GCC defines _GNU_SOURCE

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -23,7 +23,9 @@
  * 02110-1335, USA.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _SVID_SOURCE /* for putenv() */
 
 #include <config.h>

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -41,7 +41,9 @@
  * to investigate, read main(), meta_display_open(), and event_callback().
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _SVID_SOURCE /* for putenv() and some signal-related functions */
 
 #include <config.h>

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -22,7 +22,9 @@
  * 02110-1335, USA.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _POSIX_C_SOURCE 200112L /* for fdopen() */
 
 #include <config.h>

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -36,7 +36,9 @@
  * 02110-1335, USA.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _SVID_SOURCE /* for gethostname() */
 
 #include <config.h>

--- a/src/tools/muffin-mag.c
+++ b/src/tools/muffin-mag.c
@@ -19,7 +19,9 @@
  * 02110-1335, USA.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _XOPEN_SOURCE 600 /* C99 -- for rint() */
 
 #include <gtk/gtk.h>

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -21,7 +21,9 @@
  * 02110-1335, USA.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _XOPEN_SOURCE 600 /* for the maths routines over floats */
 
 #include <math.h>


### PR DESCRIPTION
I'm not sure why but some builds of GCC define _GNU_SOURCE. If it's defined again it errors out. I
added if's for define _GNU_SOURCE so it will build with those versions of GCC (like mine).
