### PR TITLE
Resolve deprecation warnings for XKeycodeToKeysym

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2922,7 +2922,7 @@ key_event_description (Display *xdisplay,
   KeySym keysym;
   const char *str;
   
-  keysym = XKeycodeToKeysym (xdisplay, event->xkey.keycode, 0);  
+  keysym = XkbKeycodeToKeysym (xdisplay, event->xkey.keycode, 0, 0);  
 
   str = XKeysymToString (keysym);
   

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -673,7 +673,7 @@ meta_display_get_keybinding_action (MetaDisplay  *display,
   MetaKeyBinding *binding;
   KeySym keysym;
 
-  keysym = XKeycodeToKeysym (display->xdisplay, keycode, 0);
+  keysym = XkbKeycodeToKeysym (display->xdisplay, keycode, 0, 0);
   mask = mask & 0xff & ~display->ignored_modifier_mask;
   binding = display_get_keybinding (display, keysym, keycode, mask);
 
@@ -1572,7 +1572,7 @@ meta_display_process_key_event (MetaDisplay *display,
   
   /* window may be NULL */
   
-  keysym = XKeycodeToKeysym (display->xdisplay, event->xkey.keycode, 0);
+  keysym = XkbKeycodeToKeysym (display->xdisplay, event->xkey.keycode, 0, 0);
 
   str = XKeysymToString (keysym);
   


### PR DESCRIPTION
XKeycodeToKeysym has been deprecated. This replaces it with XkbKeycodeToKeysym.
