### PR TITLE
[core/workspace.c] Make negative-workspace-index error recoverable.

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -689,13 +689,8 @@ meta_workspace_activate (MetaWorkspace *workspace,
 int
 meta_workspace_index (MetaWorkspace *workspace)
 {
-  int ret;
-
-  ret = g_list_index (workspace->screen->workspaces, workspace);
-
-  if (ret < 0)
-    meta_bug ("Workspace does not exist to index!\n");
-
+  int ret = g_list_index (workspace->screen->workspaces, workspace);
+  /* return value is negative if the workspace is invalid */
   return ret;
 }
 


### PR DESCRIPTION
Asking a deleted workspace for its index is an operation that will instantly kill Cinnamon. IMO that's an unacceptable outcome of a simple query, especially since there is no other easily discoverable method to validate a given workspace. This patch remedies the situation by simple letting the query function return a negative index instead of aborting.

The potential downside is that code that previously relied on the application aborting on a negative index will not continue executing, possibly leading to undefined behavior later on. The upside is that such undefined behavior can now be more easily debugged.
