### PR TITLE
Made a few terminal output texts untranslateable

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -287,7 +287,7 @@ meta_debug_spew_real (const char *format, ...)
   out = logfile ? logfile : stderr;
   
   if (no_prefix == 0)
-    utf8_fputs (_("Window manager: "), out);
+    utf8_fputs ("Window manager: ", out);
   utf8_fputs (str, out);
 
   fflush (out);
@@ -435,7 +435,7 @@ meta_bug (const char *format, ...)
 #endif
 
   if (no_prefix == 0)
-    utf8_fputs (_("Bug in window manager: "), out);
+    utf8_fputs ("Bug in window manager: ", out);
   utf8_fputs (str, out);
 
   fflush (out);
@@ -468,7 +468,7 @@ meta_warning (const char *format, ...)
 #endif
 
   if (no_prefix == 0)
-    utf8_fputs (_("Window manager warning: "), out);
+    utf8_fputs ("Window manager warning: ", out);
   utf8_fputs (str, out);
 
   fflush (out);
@@ -496,7 +496,7 @@ meta_fatal (const char *format, ...)
 #endif
 
   if (no_prefix == 0)
-    utf8_fputs (_("Window manager error: "), out);
+    utf8_fputs ("Window manager error: ", out);
   utf8_fputs (str, out);
 
   fflush (out);


### PR DESCRIPTION
"Window manager warning: " console output now does not translate anymore. Many translators forgot the whitespace behind it and four other messages. Console output should rather be English.
