### PR TITLE
debian/rules clean wasn't updating control due to a missing rule.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+DEB_AUTO_UPDATE_DEBIAN_CONTROL := yes
+
 include /usr/share/cdbs/1/rules/autoreconf.mk
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/gnome.mk


### PR DESCRIPTION
debian/rules was missing DEB_AUTO_UPDATE_DEBIAN_CONTROL := yes which prevents
changes to control.in being propagated properly during build.

Adding this directive let's debian/control be correctly updated from debian/control.in.
