### PR TITLE
change API string to avoid gnome-shell conflict

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -183,7 +183,11 @@ if test x$found_introspection != xno; then
   # parallel install, there's no real reason to change directories, filenames,
   # etc. as we change the Muffin tarball version. Note that this must match
   # api_version in src/Makefile.am
-  META_GIR=Meta_3_0_gir
+
+  # This is set to a magic number which is different from the API which
+  # Mutter uses.  Otherwise there will be dependency conflicts in RPM
+  # based distributions that automatically resolve typelib file dependencies.
+  META_GIR=Meta_Muffin_0_gir
   # META_GIR=[Meta_]muffin_major_version[_]muffin_minor_version[_gir]
   AC_SUBST(META_GIR)
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -206,8 +206,12 @@ include $(INTROSPECTION_MAKEFILE)
 # Since we don't make any guarantees about stability and we don't support
 # parallel install, there's no real reason to change directories, filenames,
 # etc. as we change the Muffin tarball version.
-#api_version = $(MUFFIN_MAJOR_VERSION).$(MUFFIN_MINOR_VERSION)
-api_version = 3.0
+# 
+# Change the api_version to a muffin specific number since setting it to
+# 3.0 causes major dependency issues with mutter on distributions which
+# auto generate typelib dependencies in RPMS
+api_version = Muffin.0
+#api_version = 3.0
 
 # These files are in package-private directories, even though they may be used
 # by plugins.  If you're writing a plugin, use g-ir-compiler --add-include-path


### PR DESCRIPTION
This pull request changes the Muffin API to avoid a conflict with the API for gnome shell.  It should be applied with the corresponding patch in cinnamon.

Although the API is private, having the Meta API set to 3.0 causes packaging issues with RPM based distros that automatically scan for gobject dependencies.  This can be worked around by a define in the RPM to avoid auto-dependencies, but this fix does things the right way by setting up a new API string that is unique to muffin.  Applying this patch removes the need for further internal name space changes.
