### PR TITLE
Fix for GTK utility windows (like the filter box in Nemo list view) showing

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1517,7 +1517,7 @@ meta_window_actor_new (MetaWindow *window)
     clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
 			       CLUTTER_ACTOR (self));
   }
-  else if (window->type == META_WINDOW_TOOLTIP) {
+  else if (window->type == META_WINDOW_TOOLTIP || window->type == META_WINDOW_OVERRIDE_OTHER) {
     meta_window_get_work_area_all_monitors(window, rectWorkArea);
     rectWindow = meta_window_get_rect(window);
     // move tooltip out of top panel if necessary


### PR DESCRIPTION
up under the bottom panel in Cinnamon.

I think?

See:

linuxmint/Cinnamon#1074
