### PR TITLE
Put dropdown menus and combobox popups into the top window group

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1511,7 +1511,9 @@ meta_window_actor_new (MetaWindow *window)
   /* Hang our compositor window state off the MetaWindow for fast retrieval */
   meta_window_set_compositor_private (window, G_OBJECT (self));
   
-  if (window->type == META_WINDOW_POPUP_MENU){
+  if (window->type == META_WINDOW_DROPDOWN_MENU ||
+      window->type == META_WINDOW_POPUP_MENU ||
+      window->type == META_WINDOW_COMBO){
     clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
 			       CLUTTER_ACTOR (self));
   }


### PR DESCRIPTION
This adds windows with type META_WINDOW_DROPDOWN_MENU and META_WINDOW_COMBO into the top window group. Note: Some combobox popups are created with override-redirect. These are not handled by this commit.
