### PR TITLE
Put the rest of  override redirect window types into the top window group, fix Japanese Input Problem.

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1513,7 +1513,10 @@ meta_window_actor_new (MetaWindow *window)
   
   if (window->type == META_WINDOW_DROPDOWN_MENU ||
       window->type == META_WINDOW_POPUP_MENU ||
-      window->type == META_WINDOW_COMBO){
+      window->type == META_WINDOW_COMBO ||
+      window->type == META_WINDOW_NOTIFICATION ||
+      window->type == META_WINDOW_DND ||
+      window->type == META_WINDOW_OVERRIDE_OTHER){
     clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
 			       CLUTTER_ACTOR (self));
   }


### PR DESCRIPTION
Put the rest of  redirect window types into the top window group

META_WINDOW_NOTIFICATION
META_WINDOW_DND
META_WINDOW_OVERRIDE_OTHER

This commit can fix this issue; https://github.com/linuxmint/Cinnamon/issues/1070
This issue ;https://github.com/linuxmint/Cinnamon/issues/1071 is fixed by https://github.com/linuxmint/Cinnamon/pull/1637

![ibus2](https://f.cloud.github.com/assets/1858413/70376/c0f2427a-5f9c-11e2-9689-61a6c7602c5f.png)
