### PR TITLE
fix regression: meta_workspace_get_neighbor does not work with multiple workspace rows.

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -1183,7 +1183,7 @@ meta_workspace_get_neighbor (MetaWorkspace      *workspace,
 
   meta_screen_free_workspace_layout (&layout);
   
-  return meta_screen_get_workspace_by_index (workspace->screen, layout.current_col);
+  return meta_screen_get_workspace_by_index (workspace->screen, i);
 }
 
 const char*


### PR DESCRIPTION
The regression appears to have been introduced here:
622599d557429a3fe1a0babd6c2cb4abb7f64f3e  "Allow cycling through workspaces if the gsettings key is set"
