### PR TITLE
Add unique settings for edge tile and detach drag thresholds, instead of

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -97,6 +97,8 @@ static gboolean gnome_animations = TRUE;
 static char *cursor_theme = NULL;
 static int   cursor_size = 24;
 static int   draggable_border_width = 10;
+static int edge_tile_threshold = 48;
+static int edge_detach_threshold = 24;
 static gboolean resize_with_right_button = FALSE;
 static gboolean edge_tiling = FALSE;
 static gboolean force_fullscreen = TRUE;
@@ -459,6 +461,20 @@ static MetaIntPreference preferences_int[] =
         META_PREF_DRAGGABLE_BORDER_WIDTH,
       },
       &draggable_border_width
+    },
+    {
+      { "edge-tile-threshold",
+        SCHEMA_MUFFIN,
+        META_PREF_EDGE_TILE_THRESHOLD,
+      },
+      &edge_tile_threshold
+    },
+    {
+      { "edge-detach-threshold",
+        SCHEMA_MUFFIN,
+        META_PREF_EDGE_DETACH_THRESHOLD,
+      },
+      &edge_detach_threshold
     },
     { { NULL, 0, 0 }, NULL },
   };
@@ -1658,6 +1674,12 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_DRAGGABLE_BORDER_WIDTH:
       return "DRAGGABLE_BORDER_WIDTH";
 
+    case META_PREF_EDGE_TILE_THRESHOLD:
+      return "EDGE_TILE_THRESHOLD";
+
+    case META_PREF_EDGE_DETACH_THRESHOLD:
+      return "EDGE_DETACH_THRESHOLD";
+
     case META_PREF_DYNAMIC_WORKSPACES:
       return "DYNAMIC_WORKSPACES";
     }
@@ -2212,6 +2234,18 @@ int
 meta_prefs_get_draggable_border_width (void)
 {
   return draggable_border_width;
+}
+
+int
+meta_prefs_get_edge_tile_threshold (void)
+{
+  return edge_tile_threshold;
+}
+
+int
+meta_prefs_get_edge_detach_threshold (void)
+{
+  return edge_detach_threshold;
 }
 
 void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8613,9 +8613,7 @@ update_move (MetaWindow  *window,
    * for the zones at the sides of the monitor where trigger tiling
    * because it's about the right size
    */
-#define DRAG_THRESHOLD_TO_SHAKE_THRESHOLD_FACTOR 6
-  shake_threshold = meta_ui_get_drag_threshold (window->screen->ui) *
-    DRAG_THRESHOLD_TO_SHAKE_THRESHOLD_FACTOR;
+  shake_threshold = meta_prefs_get_edge_tile_threshold ();
 
   if (snap)
     {
@@ -8814,10 +8812,8 @@ check_resize_unmaximize(MetaWindow *window,
   int threshold;
   MetaMaximizeFlags new_unmaximize;
 
-#define DRAG_THRESHOLD_TO_RESIZE_THRESHOLD_FACTOR 3
+  threshold = meta_prefs_get_edge_detach_threshold ();
 
-  threshold = meta_ui_get_drag_threshold (window->screen->ui) *
-    DRAG_THRESHOLD_TO_RESIZE_THRESHOLD_FACTOR;
   new_unmaximize = 0;
 
   if (window->maximized_horizontally ||

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -67,7 +67,9 @@ typedef enum
   META_PREF_LIVE_HIDDEN_WINDOWS,
   META_PREF_WORKSPACES_ONLY_ON_PRIMARY,
   META_PREF_NO_TAB_POPUP,
-  META_PREF_DRAGGABLE_BORDER_WIDTH
+  META_PREF_DRAGGABLE_BORDER_WIDTH,
+  META_PREF_EDGE_TILE_THRESHOLD,
+  META_PREF_EDGE_DETACH_THRESHOLD
 } MetaPreference;
 
 typedef void (* MetaPrefsChangedFunc) (MetaPreference pref,
@@ -148,6 +150,10 @@ gboolean meta_prefs_get_no_tab_popup (void);
 void     meta_prefs_set_no_tab_popup (gboolean whether);
 
 int      meta_prefs_get_draggable_border_width (void);
+
+int      meta_prefs_get_edge_tile_threshold (void);
+int      meta_prefs_get_edge_detach_threshold (void);
+
 
 /* XXX FIXME This should be x-macroed, but isn't yet because it would be
  * difficult (or perhaps impossible) to add the suffixes using the current

--- a/src/org.cinnamon.muffin.gschema.xml.in
+++ b/src/org.cinnamon.muffin.gschema.xml.in
@@ -93,6 +93,30 @@
       </_description>
     </key>
 
+    <key name="edge-tile-threshold" type="i">
+      <default>48</default>
+      <range min="1" max="400"/>
+      <_summary>Window edge snap threshold</_summary>
+      <_description>
+          The region size in pixels, from the edge of the screen, where a dragged
+          window will be registered as 'sticky'
+      </_description>
+    </key>
+
+    <key name="edge-detach-threshold" type="i">
+      <default>24</default>
+      <range min="1" max="400"/>
+      <_summary>Window edge detach threshold</_summary>
+      <_description>
+          The region size in pixels, from the edge of the screen, where a tiled or
+          maximized window will be registered as a drag
+      </_description>
+    </key>
+
+
+
+
+
     <child name="keybindings" schema="org.cinnamon.muffin.keybindings"/>
 
   </schema>

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1024,20 +1024,6 @@ meta_stock_icons_init (void)
   g_object_unref (G_OBJECT (factory));
 }
 
-LOCAL_SYMBOL int
-meta_ui_get_drag_threshold (MetaUI *ui)
-{
-  GtkSettings *settings;
-  int threshold;
-
-  settings = gtk_widget_get_settings (GTK_WIDGET (ui->frames));
-
-  threshold = 8;
-  g_object_get (G_OBJECT (settings), "gtk-dnd-drag-threshold", &threshold, NULL);
-
-  return threshold;
-}
-
 LOCAL_SYMBOL MetaUIDirection
 meta_ui_get_direction (void)
 {

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -182,8 +182,6 @@ gchar*   meta_ui_accelerator_name  (unsigned int        keysym,
 gboolean meta_ui_window_is_widget (MetaUI *ui,
                                    Window  xwindow);
 
-int      meta_ui_get_drag_threshold       (MetaUI *ui);
-
 MetaUIDirection meta_ui_get_direction (void);
 
 #include "tabpopup.h"


### PR DESCRIPTION
using Gtk drag threshold.  This has the benefit of allowing the user to
adjust the GTK dnd threshold without severly impacting window manager
functions due to the use of multipliers.

Goes with:
https://github.com/linuxmint/Cinnamon/pull/1751
