### PR TITLE
meta_screen_get_mouse_window: change annotation to allow parameter not_this_one to be null

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -2020,7 +2020,7 @@ meta_screen_tile_preview_hide (MetaScreen *screen)
 /**
  * meta_screen_get_mouse_window:
  * @screen: an X screen structure.
- * @not_this_one: window to be excluded
+ * @not_this_one: (allow-none): window to be excluded
  *
  * Gets the #MetaWindow pointed by the mouse
  *


### PR DESCRIPTION
This is part of the fix for for linuxmint/Cinnamon#1945
