### PR TITLE
Remove DND from top window group to allow dragging to the windowlist

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1515,7 +1515,6 @@ meta_window_actor_new (MetaWindow *window)
       window->type == META_WINDOW_POPUP_MENU ||
       window->type == META_WINDOW_COMBO ||
       window->type == META_WINDOW_NOTIFICATION ||
-      window->type == META_WINDOW_DND ||
       window->type == META_WINDOW_OVERRIDE_OTHER){
     clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
 			       CLUTTER_ACTOR (self));


### PR DESCRIPTION
Fixes linuxmint/Cinnamon#1819
