### PR TITLE
[2.0] Upchain finalize() where not done yet

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -144,6 +144,8 @@ static void
 meta_screen_finalize (GObject *object)
 {
   /* Actual freeing done in meta_screen_free() for now */
+  
+  G_OBJECT_CLASS (meta_screen_parent_class)->finalize (object);
 }
 
 static void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -232,6 +232,8 @@ meta_window_finalize (GObject *object)
   g_free (window->gtk_window_object_path);
   g_free (window->gtk_app_menu_object_path);
   g_free (window->gtk_menubar_object_path);
+  
+  G_OBJECT_CLASS (meta_window_parent_class)->finalize (object);
 }
 
 static void

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -68,6 +68,8 @@ static void
 meta_workspace_finalize (GObject *object)
 {
   /* Actual freeing done in meta_workspace_remove() for now */
+  
+  G_OBJECT_CLASS (meta_workspace_parent_class)->finalize (object);
 }
 
 static void


### PR DESCRIPTION
Upchain finalize()-methods to the respective parents as described here:
https://developer.gnome.org/gobject/stable/gobject-memory.html

This is important for garbage collection.
