### PR TITLE
Upstream commit to let the right window get focus after closing one

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -1310,7 +1310,7 @@ focus_ancestor_or_top_window (MetaWorkspace *workspace,
 
   window = meta_stack_get_default_focus_window (workspace->screen->stack,
                                                 workspace,
-                                                NULL);
+                                                not_this_one);
 
   if (window)
     {


### PR DESCRIPTION
Commit `e257580b9484762064692b214114442243afa262` in Mutter

Fixes linuxmint/Cinnamon#1970 and linuxmint/Cinnamon#1257
