### PR TITLE
Fix maximized windows jumping to a different monitor

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -567,6 +567,11 @@ place_window_if_needed(MetaWindow     *window,
                        .083 * info->work_area_monitor.height;
             }
 
+          /* idle_move_resize() uses the user_rect,
+           * so make sure it uses the placed coordinates.
+           */
+          window->user_rect = info->current;
+
           if (window->maximize_horizontally_after_placement ||
               window->maximize_vertically_after_placement)
             meta_window_maximize_internal (window,   


### PR DESCRIPTION
Fixes #102 - Chromium jumps to a different monitor if it opens maximized, other people reported this problem with Nemo too.

Ported from Mutter, original commit done by Alban Crequy.
