### PR TITLE
Manual window placement.

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -149,6 +149,8 @@ static void     do_override               (char *key, char *schema);
 static void     init_bindings             (void);
 static void     init_workspace_names      (void);
 
+static MetaPlacementMode placement_mode = META_PLACEMENT_MODE_AUTOMATIC;
+
 
 typedef struct
 {
@@ -264,6 +266,13 @@ static MetaEnumPreference preferences_enum[] =
         META_PREF_ACTION_RIGHT_CLICK_TITLEBAR,
       },
       &action_right_click_titlebar,
+    },
+    {
+      { "placement-mode",
+        SCHEMA_MUFFIN,
+        META_PREF_PLACEMENT_MODE,
+      },
+      &placement_mode,
     },
     { { NULL, 0, 0 }, NULL },
   };
@@ -1771,6 +1780,10 @@ meta_preference_to_string (MetaPreference pref)
 
     case META_PREF_TILE_MAXIMIZE:
       return "TILE_MAXIMIZE";
+
+    case META_PREF_PLACEMENT_MODE:
+      return "PLACEMENT_MODE";
+
     }
 
   return "(unknown)";
@@ -2414,4 +2427,10 @@ gboolean
 meta_prefs_get_tile_maximize (void)
 {
     return tile_maximize;
+}
+
+MetaPlacementMode
+meta_prefs_get_placement_mode (void)
+{
+  return placement_mode;
 }

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -175,6 +175,7 @@ struct _MetaWindow
   guint maximize_vertically_after_placement : 1;
   guint minimize_after_placement : 1;
   guint tile_after_placement : 1;
+  guint move_after_placement : 1;
 
   /* The current or requested tile mode. If maximized_vertically is true,
    * this is the current mode. If not, it is the mode which will be

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1095,6 +1095,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   window->maximize_vertically_after_placement = FALSE;
   window->minimize_after_placement = FALSE;
   window->tile_after_placement = FALSE;
+  window->move_after_placement = FALSE;
   window->fullscreen = FALSE;
   window->fullscreen_after_placement = FALSE;
   window->fullscreen_monitors[0] = -1;
@@ -3237,6 +3238,14 @@ meta_window_show (MetaWindow *window)
           timestamp = meta_display_get_current_time_roundtrip (window->display);
 
           meta_window_focus (window, timestamp);
+
+          if (window->move_after_placement)
+            {
+              timestamp = meta_display_get_current_time_roundtrip (window->display);
+              meta_window_begin_grab_op(window, META_GRAB_OP_KEYBOARD_MOVING,
+                                        FALSE, timestamp);
+              window->move_after_placement = FALSE;
+            }
         }
       else
         {

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -392,4 +392,16 @@ typedef enum
   META_LAYER_LAST	       = 8
 } MetaStackLayer;
 
+
+/*
+ * Placement mode
+ */
+typedef enum
+{
+  META_PLACEMENT_MODE_AUTOMATIC,
+  META_PLACEMENT_MODE_POINTER,
+  META_PLACEMENT_MODE_MANUAL
+} MetaPlacementMode;
+
+
 #endif

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -74,7 +74,8 @@ typedef enum
   META_PREF_SNAP_MODIFIER,
   META_PREF_LEGACY_SNAP,
   META_PREF_INVERT_WORKSPACE_FLIP_DIRECTION,
-  META_PREF_TILE_MAXIMIZE
+  META_PREF_TILE_MAXIMIZE,
+  META_PREF_PLACEMENT_MODE
 } MetaPreference;
 
 typedef void (* MetaPrefsChangedFunc) (MetaPreference pref,
@@ -336,6 +337,8 @@ gboolean           meta_prefs_bell_is_audible      (void);
 CDesktopVisualBellType meta_prefs_get_visual_bell_type (void);
 
 #endif
+
+MetaPlacementMode meta_prefs_get_placement_mode (void);
 
 
 

--- a/src/org.cinnamon.muffin.gschema.xml.in
+++ b/src/org.cinnamon.muffin.gschema.xml.in
@@ -1,4 +1,10 @@
 <schemalist>
+  <enum id="placement_type">
+    <value value="0" nick="automatic"/>
+    <value value="1" nick="pointer"/>
+    <value value="2" nick="manual"/>
+  </enum>
+
   <schema id="org.cinnamon.muffin" path="/org/cinnamon/muffin/"
           gettext-domain="@GETTEXT_DOMAIN">
 
@@ -153,6 +159,18 @@
       <_description>
         Makes tiling to the top maximize the window
       </_description>
+    </key>
+
+    <key name="placement-mode" enum="placement_type">
+      <default>'automatic'</default>
+      <_summary>Window placement mode</_summary>
+      <_description>The window placement mode indicates how new windows
+      are positioned. "automatic" means the system chooses a location
+      automatically based on the space available on the desktop, or by
+      a simple cascade if there is no space; "pointer" means that new
+      windows are placed according to the mouse pointer position;
+      "manual" means that the user must manually place the new window
+      with the mouse or keyboard.</_description>
     </key>
 
     <child name="keybindings" schema="org.cinnamon.muffin.keybindings"/>


### PR DESCRIPTION
This adds two new window placement options. "pointer" places new windows so they are centred on the mouse pointer, or as close as possible to that; "manual" places new windows centred on the mouse pointer, and then behaves as if the user had selected a keyboard move operation, meaning the user can manually place the window where they wish. This provides a very similar user experience to the way many X window managers have behaved since twm.
