### PR TITLE
debian/control: change the package descriptions to make them more digestible

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,14 +42,8 @@ Depends: ${shlibs:Depends},
 Provides: x-window-manager
 Suggests: gnome-themes,
           xdg-user-dirs
-Description: lightweight GTK+ window manager
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
- .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
+Description: Muffin window manager
+ Muffin is the window manager used by Cinnamon.
  .
  This package contains the core binaries.
 
@@ -60,29 +54,16 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          muffin-common (= ${source:Version})
 Description: window manager library from the Muffin window manager
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
+ Muffin is the window manager used by Cinnamon.
  .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
- .
- This package contains the window manager shared library, used by muffin
- itself, and gnome-shell.
+ This package contains the window manager shared library.
 
 Package: muffin-common
 Section: misc
 Architecture: all
 Depends: ${misc:Depends}
 Description: shared files for the Muffin window manager
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
- .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
+ Muffin is the window manager used by Cinnamon.
  .
  This package contains the shared files.
 
@@ -95,13 +76,7 @@ Depends: ${misc:Depends},
          libclutter-1.0-dev (>= 1.0.0),
          libgtk-3-dev (>= 3.0.0)
 Description: Development files for the Muffin window manager
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
- .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
+ Muffin is the window manager used by Cinnamon.
  .
  This package contains the development files.
 
@@ -113,13 +88,7 @@ Depends: libmuffin0 (= ${binary:Version}),
          muffin (= ${binary:Version}),
          ${misc:Depends}
 Description: Debugging symbols for the Muffin window manager
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
- .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
+ Muffin is the window manager used by Cinnamon.
  .
  This package contains the debugging symbols.
 
@@ -130,13 +99,7 @@ Depends: ${gir:Depends},
          ${shlibs:Depends},
          ${misc:Depends}
 Description: GObject introspection data for Muffin
- Muffin is a small window manager, using GTK+ and Clutter to do
- everything.
- .
- Muffin is the clutter-based evolution of Metacity, which, as the
- author says, is a "Boring window manager for the adult in you. Many
- window managers are like Marshmallow Froot Loops; Metacity is like
- Cheerios."
+ Muffin is the window manager used by Cinnamon.
  .
  This package contains the GObject introspection data which may be
  used to generate dynamic bindings.


### PR DESCRIPTION
In particular, make Muffin's description title say "Muffin window manager". Also, remove the arguably meaningless mentions of "lightweight" and "small", and state that Muffin is used by Cinnamon.
