### PR TITLE
Focus the correct window when unshowing the desktop

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3329,6 +3329,10 @@ meta_screen_toggle_desktop (MetaScreen *screen,
       meta_workspace_focus_default_window (screen->active_workspace,
                                            not_this_one,
                                            timestamp);
+      // If there's only one window, make sure it gets the focus
+      meta_workspace_focus_default_window (screen->active_workspace,
+                                           NULL,
+                                           timestamp);
     }
   else
     meta_screen_show_desktop (screen, timestamp);


### PR DESCRIPTION
When showing the desktop, no matter if it's done via cinnamon's applet or via a hotkey, the most current window loses the focus, so the second window in the (old) MRU list got the focus when unshowing the desktop.
This ignores the new MRU window and focuses the correct window.
