### PR TITLE
[Muffin] Set Tile Maximize key default to true

### DIFF
--- a/src/org.cinnamon.muffin.gschema.xml.in
+++ b/src/org.cinnamon.muffin.gschema.xml.in
@@ -154,7 +154,7 @@
     </key>
 
     <key name="tile-maximize" type="b">
-      <default>false</default>
+      <default>true</default>
       <_summary>Sets maximize as the tile action for the top edge of the screen</_summary>
       <_description>
         Makes tiling to the top maximize the window


### PR DESCRIPTION
This behavior is generally expected out of a desktops that snap, including Windews 7/8, KDE, and Gnome-Shell. It could be confusing for users to have the window take the top half of the screen instead of maximizing by default.
