### PR TITLE
Re-add WIN+D as show desktop shortkey thingy

### DIFF
--- a/src/org.cinnamon.muffin.gschema.xml.in
+++ b/src/org.cinnamon.muffin.gschema.xml.in
@@ -337,7 +337,7 @@
       <_summary>Reverse switch system controls directly</_summary>
     </key>
     <key name="show-desktop" type="as">
-      <default>[]</default>
+      <default><![CDATA[['<Super>D']]]></default>
       <_summary>Hide all normal windows</_summary>
     </key>
     <key name="panel-main-menu" type="as">


### PR DESCRIPTION
fixes: "prefs: I miss the working WIN+D keyboard shortcut to go to desktop." on the roadmap
