### PR TITLE
constraints.c: Invert some of the logic used to detect a legacy fullscreen window.

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -444,7 +444,7 @@ setup_constraint_info (ConstraintInfo      *info,
    * fullscreen themselves properly.
    */
   if (meta_prefs_get_force_fullscreen() &&
-      (window->decorated || !meta_window_is_client_decorated (window)) &&
+      !(!window->decorated || meta_window_is_client_decorated (window)) &&
       meta_rectangle_equal (new, &monitor_info->rect) &&
       window->has_fullscreen_func &&
       !window->fullscreen)


### PR DESCRIPTION
This should be checked against as many programs as possible... I'm still trying to figure out if this makes sense or not.

This is to mainly fix Chrome windows going fullscreen.  They're normally
self-decorated (there is an option to turn on wm decorations, but irrelevant),
but they don't currently report custom frame extents like gtk3 apps can now.
So they are undecorated (officially, to turn off wm decos), but they don't use
GTK client-side-decorations, or pretend to.

Before client side decorations in GTK, we only checked if the window was decorated.
Chrome failed this check, so the legacy code was skipped, and fullscreen worked fine.

But now currently we have:

if the window is EITHER decorated OR it's not gtk c-s-decorated
    treat the window like a legacy app

So it fails the decorated check, but passes the not-gtk-c-s-decorated check,
and gets into the legacy code, breaking the window.

This patch reverses the logic:

if window is NEITHER undecorated NOR gtk-c-s-decorated
    treat the window like a legacy app

This grabs windows that pass a decorated check, or a non-gtk-c-s-decorated
check (which is the same as current behavior), but kicks out an undecorated,
non-gtk-c-s-decorated window (like chrome).
