### PR TITLE
Maximize windows that match the work area

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3095,6 +3095,18 @@ meta_window_show (MetaWindow *window)
 
   if (!window->placed)
     {
+      if (window->showing_for_first_time && window->has_maximize_func)
+        {
+          MetaRectangle work_area;
+          meta_window_get_work_area_for_monitor (window, window->monitor->number, &work_area);
+          /* Automaximize windows that match the bounds of the work area */
+          if (window->rect.x == work_area.x && window->rect.y == work_area.y &&
+              window->rect.width == work_area.width && window->rect.height == work_area.height)
+            {
+              window->maximize_horizontally_after_placement = TRUE;
+              window->maximize_vertically_after_placement = TRUE;
+            }
+        }
       meta_window_force_placement (window);
     }
 


### PR DESCRIPTION
Many applications are buggy: they save the bounds of their window for the next time, but not the maximized state. When you close such an app that is maximized, the next time a window opens that covers the exact size  of the work area, but is not maximized.

An example is Chromium; this is how it opens:

![Chromium, unmaximized](https://cloud.githubusercontent.com/assets/1177304/3749187/1c6e2f64-17e9-11e4-80d9-31cd7f084e57.png)

In these cases (a maximizable window shows up with a size set to the exact bounds of the work area), the window is automatically maximized. After the change, Chromium shows up as expected:

![Chromium, maximized](https://cloud.githubusercontent.com/assets/1177304/3749199/36030d6e-17e9-11e4-88c7-916b27def2bd.png)

Please note that, unless the irritating auto-maximize feature that was [removed long time ago](https://github.com/linuxmint/muffin/commit/16d5335ee9d5c4a48e214e98c18f896c1049e09a), this feature is really strict and should go unnoticed for most users. A setting can be created to turn it off, though.