### PR TITLE
Fix tile maximize when vertical tiling is not possible

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8968,7 +8968,12 @@ meta_window_get_current_zone (MetaWindow   *window,
                 zone = ZONE_6;
             break;
         case ZONE_TOP:
-            if (meta_window_can_tile_top_bottom (window))
+            if (meta_prefs_get_tile_maximize() || window->maybe_retile_maximize)
+              {
+                if (meta_window_can_tile_maximized(window))
+                    zone = ZONE_0;
+              }
+            else if (meta_window_can_tile_top_bottom (window))
                 zone = ZONE_0;
             break;
         case ZONE_BOTTOM:


### PR DESCRIPTION
When tiling to the top edge should maximize the window (either because of the setting or due to the window being dragged from a maximized state), but the window is unable to tile vertically, maximizing doesn't work as expected. This pull request adds some additional logic to make maximize always work as expected when dragging to the top edge.

Fixes at least one of the issues in https://github.com/linuxmint/Cinnamon/issues/2863
