### PR TITLE
Stop build spam

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 # Flag build for parallelism; see https://savannah.gnu.org/patch/?6905
 .AUTOPARALLEL:
+AUTOMAKE_OPTIONS = subdir-objects
 
 lib_LTLIBRARIES = libmuffin.la
 


### PR DESCRIPTION
```
src/Makefile.am:33: warning: source file 'core/async-getprop.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
src/Makefile.am:33: warning: source file 'core/bell.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/boxes.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/cogl-utils.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/compositor.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-background-actor.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-module.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-plugin.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-plugin-manager.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-shadow-factory.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-shaped-texture.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-texture-rectangle.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-texture-tower.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-window-actor.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-window-group.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/meta-window-shape.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'compositor/region-utils.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/above-tab-keycode.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/constraints.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/core.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/delete.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/display.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/draw-workspace.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/edge-resistance.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/errors.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/eventqueue.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/frame.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/gradient.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/group-props.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/group.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/iconcache.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/keybindings.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/main.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/place.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/prefs.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/screen.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/session.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/stack.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/stack-tracker.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/util.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/window-props.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/window.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/workspace.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'core/xprops.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/frames.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/tile-hud.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/menu.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/metaaccellabel.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/resizepopup.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/tabpopup.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/tile-preview.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/theme-parser.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/theme.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/ui.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:33: warning: source file 'ui/preview-widget.c' is in a subdirectory,
src/Makefile.am:33: but option 'subdir-objects' is disabled
src/Makefile.am:202: warning: source file 'core/muffin.c' is in a subdirectory,
src/Makefile.am:202: but option 'subdir-objects' is disabled
src/Makefile.am:197: warning: source file 'ui/theme-viewer.c' is in a subdirectory,
src/Makefile.am:197: but option 'subdir-objects' is disabled
src/Makefile.am:246: warning: source file 'core/testasyncgetprop.c' is in a subdirectory,
src/Makefile.am:246: but option 'subdir-objects' is disabled
src/Makefile.am:246: warning: source file 'core/async-getprop.c' is in a subdirectory,
src/Makefile.am:246: but option 'subdir-objects' is disabled
src/Makefile.am:244: warning: source file 'core/testboxes.c' is in a subdirectory,
src/Makefile.am:244: but option 'subdir-objects' is disabled
src/Makefile.am:244: warning: source file 'core/boxes.c' is in a subdirectory,
src/Makefile.am:244: but option 'subdir-objects' is disabled
src/Makefile.am:244: warning: source file 'core/util.c' is in a subdirectory,
src/Makefile.am:244: but option 'subdir-objects' is disabled
src/Makefile.am:245: warning: source file 'ui/testgradient.c' is in a subdirectory,
src/Makefile.am:245: but option 'subdir-objects' is disabled
```
