### PR TITLE
Allow programmatic minimization without MWM_FUNC_MINIMIZE

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6865,8 +6865,7 @@ meta_window_client_message (MetaWindow *window,
     {
       meta_verbose ("WM_CHANGE_STATE client message, state: %ld\n",
                     event->xclient.data.l[0]);
-      if (event->xclient.data.l[0] == IconicState &&
-          window->has_minimize_func)
+      if (event->xclient.data.l[0] == IconicState)
         meta_window_minimize (window);
 
       return TRUE;


### PR DESCRIPTION
This fixes switching out of fullscreen Direct3D applications running in
Wine. See issue 169 for more details.