### PR TITLE
Remove is_ime_popup()

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8002,19 +8002,6 @@ meta_window_update_struts (MetaWindow *window)
     }
 }
 
-static gboolean
-is_ime_popup (MetaWindow *window)
-{
-    const gchar *icon = window->icon_name;
-    const gchar *wc_name = meta_window_get_wm_class (window);
-    gboolean is_target_name = g_strcmp0 (wc_name, "Main.py") == 0 ||
-                              g_strcmp0 (wc_name, "Ibus-ui-gtk3") == 0;
-
-    gboolean deco = meta_window_get_frame (window) != NULL;
-
-    return !deco && (icon == NULL) && is_target_name;
-}
-
 LOCAL_SYMBOL void
 meta_window_recalc_window_type (MetaWindow *window)
 {
@@ -8105,10 +8092,6 @@ recalc_window_type (MetaWindow *window)
         {
         /* Decorated types */
         case META_WINDOW_NORMAL:
-          if (is_ime_popup (window)) {
-            window->type = META_WINDOW_POPUP_MENU;
-            break;
-          }
         case META_WINDOW_DIALOG:
         case META_WINDOW_MODAL_DIALOG:
         case META_WINDOW_MENU:


### PR DESCRIPTION
Because both ibus-mozc and fcitx are fixed, this workaround is not needed.

https://code.google.com/p/mozc/issues/detail?id=195
https://github.com/fcitx/fcitx/pull/191