### PR TITLE
Add muffin gtk-doc building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,4 +5,6 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 EXTRA_DIST = HACKING MAINTAINERS rationales.txt
 
+DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc
+
 DISTCLEANFILES = intltool-extract intltool-merge intltool-update po/stamp-it po/.intltool-merge-cache

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_INIT([muffin], [muffin_version],
 AC_CONFIG_SRCDIR(src/core/display.c)
 AC_CONFIG_HEADERS(config.h)
 
+AC_CONFIG_MACRO_DIR(m4)
 AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz tar-ustar subdir-objects])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],)
 AM_MAINTAINER_MODE([enable])
@@ -99,6 +100,11 @@ AC_ARG_ENABLE(verbose-mode,
 if test x$enable_verbose_mode = xyes; then
     AC_DEFINE(WITH_VERBOSE_MODE,1,[Build with verbose mode support])
 fi
+
+AC_ARG_ENABLE([gtk-doc],
+  AC_HELP_STRING([--enable-gtk-doc],
+                 [use gtk-doc to build documentation [[default=yes]]]),,
+  enable_gtk_doc=yes)
 
 AC_ARG_ENABLE(sm,
   AC_HELP_STRING([--disable-sm],
@@ -413,6 +419,8 @@ AM_PATH_PYTHON([2.5])
 # Use gnome-doc-utils:
 GNOME_DOC_INIT([0.8.0])
 
+GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
+
 #### Warnings (last since -Werror can disturb other tests)
 
 # Stay command-line compatible with the gnome-common configure option. Here
@@ -479,6 +487,8 @@ Makefile
 data/Makefile
 doc/Makefile
 doc/man/Makefile
+doc/reference/Makefile
+doc/reference/muffin-docs.sgml
 src/Makefile
 src/wm-tester/Makefile
 src/libmuffin.pc

--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Build-Depends: debhelper (>= 9),
                libice-dev,
                zenity,
                gnome-doc-utils (>= 0.8),
+               gtk-doc-tools,
                gnome-pkg-tools (>= 0.10),
                libcinnamon-desktop-dev (>= 2.4.0)
 Standards-Version: 3.9.4
@@ -109,3 +110,13 @@ Description: GObject introspection data for Muffin
  .
  This package contains the GObject introspection data which may be
  used to generate dynamic bindings.
+
+Package: muffin-doc
+Section: doc
+Architecture: all
+Depends: ${misc:Depends}, devhelp
+Description: Muffin documentation
+ Muffin is a window manager performing compositing as well based on
+ GTK+ and Clutter and used in Cinnamon desktop environment.
+ .
+ This package contains the code documentation for Muffin.

--- a/debian/muffin-doc.install
+++ b/debian/muffin-doc.install
@@ -1,0 +1,1 @@
+/usr/share/gtk-doc

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,8 @@ override_dh_autoreconf:
 override_dh_auto_configure:
 	dh_auto_configure -- --disable-static \
 	                     --enable-startup-notification=yes \
-	                     --disable-silent-rules
+	                     --disable-silent-rules \
+			     --enable-gtk-doc
 
 override_dh_girepository:
 	dh_girepository /usr/lib/$(DEB_HOST_MULTIARCH)/muffin

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = man
+SUBDIRS = man reference
 
 EXTRA_DIST=theme-format.txt dialogs.txt code-overview.txt \
 	how-to-get-focus-right.txt

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -1,0 +1,165 @@
+## Process this file with automake to produce Makefile.in
+
+# We require automake 1.6 at least.
+AUTOMAKE_OPTIONS = 1.6
+
+# This is a blank Makefile.am for using gtk-doc.
+# Copy this to your project's API docs directory and modify the variables to
+# suit your project. See the GTK+ Makefiles in gtk+/docs/reference for examples
+# of using the various options.
+
+# The name of the module, e.g. 'glib'.
+DOC_MODULE=muffin
+
+# Uncomment for versioned docs and specify the version of the module, e.g. '2'.
+#DOC_MODULE_VERSION=2
+
+
+# The top-level SGML file. You can change this if you want to.
+DOC_MAIN_SGML_FILE=$(DOC_MODULE)-docs.sgml
+
+# Directories containing the source code, relative to $(srcdir).
+# gtk-doc will search all .c and .h files beneath these paths
+# for inline comments documenting functions and macros.
+# e.g. DOC_SOURCE_DIR=../../../gtk ../../../gdk
+DOC_SOURCE_DIR=../../src
+
+# Extra options to pass to gtkdoc-scangobj. Not normally needed.
+SCANGOBJ_OPTIONS=
+
+# Extra options to supply to gtkdoc-scan.
+# e.g. SCAN_OPTIONS=--deprecated-guards="GTK_DISABLE_DEPRECATED"
+SCAN_OPTIONS=--rebuild-types --rebuild-sections
+
+# Extra options to supply to gtkdoc-mkdb.
+# e.g. MKDB_OPTIONS=--xml-mode --output-format=xml
+MKDB_OPTIONS=--xml-mode --output-format=xml
+
+# Extra options to supply to gtkdoc-mktmpl
+# e.g. MKTMPL_OPTIONS=--only-section-tmpl
+MKTMPL_OPTIONS=
+
+# Extra options to supply to gtkdoc-mkhtml
+MKHTML_OPTIONS=
+
+# Extra options to supply to gtkdoc-fixref. Not normally needed.
+# e.g. FIXXREF_OPTIONS=--extra-dir=../gdk-pixbuf/html --extra-dir=../gdk/html
+FIXXREF_OPTIONS=
+
+# Used for dependencies. The docs will be rebuilt if any of these change.
+# e.g. HFILE_GLOB=$(top_srcdir)/gtk/*.h
+# e.g. CFILE_GLOB=$(top_srcdir)/gtk/*.c
+HFILE_GLOB=$(top_srcdir)/src/*/*.h
+CFILE_GLOB=$(top_srcdir)/src/*/*.c
+
+# Extra header to include when scanning, which are not under DOC_SOURCE_DIR
+# e.g. EXTRA_HFILES=$(top_srcdir}/contrib/extra.h
+EXTRA_HFILES=
+
+# Header files or dirs to ignore when scanning. Use base file/dir names
+# e.g. IGNORE_HFILES=gtkdebug.h gtkintl.h private_code
+IGNORE_HFILES= \
+	async-getprop.h \
+	atoms.h \
+	bell.h \
+	boxes-private.h \
+	clutter-utils.h \
+	cogl-utils.h \
+	compositor-private.h \
+	constraints.h \
+	core.h \
+	display-private.h \
+	draw-workspace.h \
+	edge-resistance.h \
+	eventqueue.h \
+	frame.h \
+	frames.h \
+	group-private.h \
+	group-props.h \
+	iconcache.h \
+	inlinepixbufs.h \
+	keybindings-private.h \
+	meta-background-actor-private.h \
+	meta-background-group-private.h \
+	meta-dbus-login1.h \
+	meta-module.h \
+	meta-plugin-manager.h \
+	meta-shadow-factory-private.h \
+	meta-texture-rectangle.h \
+	meta-texture-tower.h \
+	meta-window-actor-private.h \
+	meta-window-group.h \
+	meta-window-shape.h \
+	muffin-enum-types.h \
+	muffin-Xatomtype.h \
+	place.h \
+	preview-widget.h \
+	region-utils.h \
+	resizepopup.h \
+	screen-private.h \
+	session.h \
+	stack.h \
+	stack-tracker.h \
+	stamp-muffin-enum-types.h \
+	tabpopup.h \
+	theme.h \
+	theme-private.h \
+	tile-preview.h \
+	ui.h \
+	window-private.h \
+	window-props.h \
+	workspace-private.h \
+	xprops.h \
+	$(NULL)
+
+MKDB_OPTIONS+=--ignore-files="$(IGNORE_HFILES)"
+
+# Images to copy into HTML directory.
+# e.g. HTML_IMAGES=$(top_srcdir)/gtk/stock-icons/stock_about_24.png
+HTML_IMAGES=
+
+# Extra SGML files that are included by $(DOC_MAIN_SGML_FILE).
+# e.g. content_files=running.sgml building.sgml changes-2.0.sgml
+content_files= \
+	muffin-overview.xml \
+	running-muffin.xml \
+	$(NULL)
+
+# SGML files where gtk-doc abbrevations (#GtkWidget) are expanded
+# These files must be listed here *and* in content_files
+# e.g. expand_content_files=running.sgml
+expand_content_files= \
+	muffin-overview.xml \
+	running-muffin.xml \
+	$(NULL)
+
+# CFLAGS and LDFLAGS for compiling gtkdoc-scangobj with your library.
+# Only needed if you are using gtkdoc-scangobj to dynamically query widget
+# signals and properties.
+# e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
+# e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
+GTKDOC_CFLAGS=$(MUFFIN_CFLAGS)
+GTKDOC_LIBS=$(MUFFIN_LIBS) $(top_builddir)/src/libmuffin.la
+
+# This includes the standard gtk-doc make rules, copied by gtkdocize.
+include $(top_srcdir)/gtk-doc.make
+
+# Other files to distribute
+# e.g. EXTRA_DIST += version.xml.in
+EXTRA_DIST +=
+
+# Files not to distribute
+# for --rebuild-types in $(SCAN_OPTIONS), e.g. $(DOC_MODULE).types
+# for --rebuild-sections in $(SCAN_OPTIONS) e.g. $(DOC_MODULE)-sections.txt
+DISTCLEANFILES = $(DOC_MODULES).types $(DOC_MODULES)-sections.txt
+
+# Comment this out if you want 'make check' to test you doc status
+# and run some sanity checks
+if ENABLE_GTK_DOC
+TESTS_ENVIRONMENT = cd $(srcdir) && \
+  DOC_MODULE=$(DOC_MODULE) DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE) \
+  SRCDIR=$(abs_srcdir) BUILDDIR=$(abs_builddir)
+#TESTS = $(GTKDOC_CHECK)
+endif
+
+-include $(top_srcdir)/git.mk

--- a/doc/reference/muffin-docs.sgml.in
+++ b/doc/reference/muffin-docs.sgml.in
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+               "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd"
+[
+  <!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
+  <!ENTITY version "@VERSION@">
+]>
+<book id="index">
+  <bookinfo>
+    <title>Muffin Reference Manual</title>
+    <releaseinfo>
+      This document is for Muffin &version;.
+    </releaseinfo>
+  </bookinfo>
+
+  <xi:include href="xml/muffin-overview.xml"/>
+  <xi:include href="xml/running-muffin.xml"/>
+
+  <part id="core-reference">
+    <title>Muffin Core Reference</title>
+    <xi:include href="xml/main.xml"/>
+    <xi:include href="xml/common.xml"/>
+    <xi:include href="xml/prefs.xml"/>
+    <xi:include href="xml/util.xml"/>
+    <xi:include href="xml/errors.xml"/>
+    <xi:include href="xml/meta-plugin.xml"/>
+    <xi:include href="xml/boxes.xml"/>
+    <xi:include href="xml/compositor.xml"/>
+    <xi:include href="xml/display.xml"/>
+    <xi:include href="xml/group.xml"/>
+    <xi:include href="xml/keybindings.xml"/>
+    <xi:include href="xml/meta-background-actor.xml"/>
+    <xi:include href="xml/meta-shadow-factory.xml"/>
+    <xi:include href="xml/meta-shaped-texture.xml"/>
+    <xi:include href="xml/meta-window-actor.xml"/>
+    <xi:include href="xml/screen.xml"/>
+    <xi:include href="xml/window.xml"/>
+    <xi:include href="xml/workspace.xml"/>
+  </part>
+
+  <chapter id="object-tree">
+    <title>Object Hierarchy</title>
+     <xi:include href="xml/tree_index.sgml"/>
+  </chapter>
+  <index id="api-index-full">
+    <title>API Index</title>
+    <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
+  </index>
+  <index id="deprecated-api-index" role="deprecated">
+    <title>Index of deprecated API</title>
+    <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
+  </index>
+
+  <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
+</book>

--- a/doc/reference/muffin-overview.xml
+++ b/doc/reference/muffin-overview.xml
@@ -1,0 +1,15 @@
+<part id="muffin-overview">
+
+  <title>Overview</title>
+
+  <partintro>
+
+    <para>Muffin is a GObject-based library for creating compositing window managers.</para>
+
+    <para>Compositors that wish to use Mutter must implement a subclass of #MetaPlugin and register it with meta_plugin_manager_set_plugin_type() before calling meta_init() but after g_type_init().</para>
+
+    <para>#MetaPlugin provides virtual functions that allow to override default behavior in the window management code, such as the effect to perform when a window is created or when switching workspaces.</para>
+
+  </partintro>
+
+</part>

--- a/doc/reference/running-muffin.xml
+++ b/doc/reference/running-muffin.xml
@@ -1,0 +1,100 @@
+<part id="running-muffin">
+
+  <title>Running Muffin</title>
+
+  <partintro>
+
+    <section id="environment-variables">
+      <title>Environment Variables</title>
+
+      <para>
+        Muffin automatically checks environment variables during
+        its initialization. These environment variables are meant
+        as debug tools or overrides for default behaviours:
+      </para>
+
+      <variablelist>
+        <varlistentry>
+          <term>MUFFIN_VERBOSE</term>
+          <listitem>
+            <para>Enable verbose mode, in which more information is printed to the console. Muffin needs to be built with the --enable-verbose-mode option (enabled by default). For more fine-grained control of the output, see meta_add_verbose_topic().</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DEBUG</term>
+          <listitem>
+            <para>Traps and prints X errors to the console.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_G_FATAL_WARNINGS</term>
+          <listitem>
+            <para>Causes any logging from the domains Muffin, Gtk, Gdk, Pango or GLib to terminate the process (only when using the log functions in GLib).</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_USE_LOGFILE</term>
+          <listitem>
+            <para>Log all messages to a temporary file.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DEBUG_XINERAMA</term>
+          <listitem>
+            <para>Log extra information about support of the XINERAMA extension.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DEBUG_SM</term>
+          <listitem>
+            <para>Log extra information about session management.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DEBUG_BUTTON_GRABS</term>
+          <listitem>
+            <para>Log extra information about button grabs.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_SYNC</term>
+          <listitem>
+            <para>Call XSync after each X call.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DISPLAY</term>
+          <listitem>
+            <para>Name of the X11 display to use.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>META_DISABLE_MIPMAPS</term>
+          <listitem>
+            <para>Disable use of mipmaps for the textures that back window pixmaps.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_USE_STATIC_GRAVITY</term>
+          <listitem>
+            <para>Enable support for clients with static bit-gravity.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_WM_CLASS_FILTER</term>
+          <listitem>
+            <para>Comma-separated list of WM_CLASS names to which to restrict Muffin to.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>MUFFIN_DISABLE_FALLBACK_COLOR</term>
+          <listitem>
+            <para>Disable fallback for themed colors, for easier detection of typographical errors.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+
+    </section>
+
+  </partintro>
+</part>

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -589,15 +589,15 @@ add_builtin_keybinding (MetaDisplay          *display,
  * @user_data: the data to pass to @handler
  * @free_data: function to free @user_data
  *
- * Add a keybinding at runtime. The key @name in @schema needs to be of
- * type %G_VARIANT_TYPE_STRING_ARRAY, with each string describing a
- * keybinding in the form of "<Control>a" or "<Shift><Alt>F1". The parser
+ * Add a keybinding at runtime. The key @name in @schema needs to be of type
+ * %G_VARIANT_TYPE_STRING_ARRAY, with each string describing a keybinding in
+ * the form of "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser
  * is fairly liberal and allows lower or upper case, and also abbreviations
- * such as "<Ctl>" and "<Ctrl>". If the key is set to the empty list or a
- * list with a single element of either "" or "disabled", the keybinding is
- * disabled.
- * If %META_KEY_BINDING_REVERSES is specified in @flags, the binding
- * may be reversed by holding down the "shift" key; therefore, "<Shift>"
+ * such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If the key is set to the empty
+ * list or a list with a single element of either "" or "disabled", the
+ * keybinding is disabled.  If %META_KEY_BINDING_REVERSES is specified in
+ * @flags, the binding may be reversed by holding down the "shift" key;
+ * therefore, "&lt;Shift&gt;"
  * cannot be one of the keys used. @handler is expected to check for the
  * "shift" modifier in this case and reverse its action.
  *


### PR DESCRIPTION
Inside the doc, muffin takes the module name "muffin" instead of "meta"
to avoid conflicts with mutter.

Since gtk-doc uses the mighty xml, all occurences of "<" and ">" in
comment blocks will make gtk-doc very sad, and must be converted to `&gt;`
and `&lt;`