### PR TITLE
fix an issue where window turns to a solid colored rectangle during the ...

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -156,7 +156,6 @@ meta_window_ensure_frame (MetaWindow *window)
    * style and background.
    */
   meta_ui_update_frame_style (window->screen->ui, frame->xwindow);
-  meta_ui_reset_frame_bg (window->screen->ui, frame->xwindow);
   
   if (window->title)
     meta_ui_set_frame_title (window->screen->ui,
@@ -379,15 +378,6 @@ meta_frame_sync_to_window (MetaFrame *frame,
               frame->rect.x + frame->rect.width,
               frame->rect.y + frame->rect.height);
 
-  /* set bg to none to avoid flicker */
-  if (need_resize)
-    {
-      meta_ui_unflicker_frame_bg (frame->window->screen->ui,
-                                  frame->xwindow,
-                                  frame->rect.width,
-                                  frame->rect.height);
-    }
-
   meta_ui_move_resize_frame (frame->window->screen->ui,
 			     frame->xwindow,
 			     frame->rect.x,
@@ -397,9 +387,6 @@ meta_frame_sync_to_window (MetaFrame *frame,
 
   if (need_resize)
     {
-      meta_ui_reset_frame_bg (frame->window->screen->ui,
-                              frame->xwindow);
-
       /* If we're interactively resizing the frame, repaint
        * it immediately so we don't start to lag.
        */

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -75,9 +75,6 @@ static void meta_frames_paint        (MetaFrames   *frames,
                                       MetaUIFrame  *frame,
                                       cairo_t      *cr);
 
-static void meta_frames_set_window_background (MetaFrames   *frames,
-                                               MetaUIFrame  *frame);
-
 static void meta_frames_calc_geometry (MetaFrames        *frames,
                                        MetaUIFrame         *frame,
                                        MetaFrameGeometry *fgeom);
@@ -432,12 +429,6 @@ queue_recalc_func (gpointer key, gpointer value, gpointer data)
   frames = META_FRAMES (data);
   frame = value;
 
-  /* If a resize occurs it will cause a redraw, but the
-   * resize may not actually be needed so we always redraw
-   * in case of color change.
-   */
-  meta_frames_set_window_background (frames, frame);
-  
   invalidate_whole_window (frames, frame);
   meta_core_queue_frame_resize (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                 frame->xwindow);
@@ -476,12 +467,6 @@ queue_draw_func (gpointer key, gpointer value, gpointer data)
 
   frames = META_FRAMES (data);
   frame = value;
-
-  /* If a resize occurs it will cause a redraw, but the
-   * resize may not actually be needed so we always redraw
-   * in case of color change.
-   */
-  meta_frames_set_window_background (frames, frame);
 
   invalidate_whole_window (frames, frame);
 }
@@ -708,11 +693,6 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->shape_applied = FALSE;
   frame->prelit_control = META_FRAME_CONTROL_NONE;
 
-  /* Don't set the window background yet; we need frame->xwindow to be
-   * registered with its MetaWindow, which happens after this function
-   * and meta_ui_create_frame_window() return to meta_window_ensure_frame().
-   */
-  
   meta_core_grab_buttons (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
   
   g_hash_table_replace (frames->frames, &frame->xwindow, frame);
@@ -855,42 +835,6 @@ meta_frames_get_corner_radiuses (MetaFrames *frames,
     *bottom_left = fgeom.bottom_left_corner_rounded_radius + sqrt(fgeom.bottom_left_corner_rounded_radius);
   if (bottom_right)
     *bottom_right = fgeom.bottom_right_corner_rounded_radius + sqrt(fgeom.bottom_right_corner_rounded_radius);
-}
-
-LOCAL_SYMBOL void
-meta_frames_reset_bg (MetaFrames *frames,
-                      Window  xwindow)
-{
-  MetaUIFrame *frame;
-  
-  frame = meta_frames_lookup_window (frames, xwindow);
-
-  meta_frames_set_window_background (frames, frame);
-}
-
-static void
-set_background_none (Display *xdisplay,
-                     Window   xwindow)
-{
-  XSetWindowAttributes attrs;
-
-  attrs.background_pixmap = None;
-  XChangeWindowAttributes (xdisplay, xwindow,
-                           CWBackPixmap, &attrs);
-}
-
-LOCAL_SYMBOL void
-meta_frames_unflicker_bg (MetaFrames *frames,
-                          Window      xwindow,
-                          int         target_width,
-                          int         target_height)
-{
-  MetaUIFrame *frame;
-  
-  frame = meta_frames_lookup_window (frames, xwindow);
-  g_return_if_fail (frame != NULL);
-
-  set_background_none (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
 }
 
 /* The client rectangle surrounds client window; it subtracts both
@@ -2449,52 +2393,6 @@ meta_frames_paint (MetaFrames   *frames,
                                     button_states,
                                     mini_icon, icon);
 }
-
-static void
-meta_frames_set_window_background (MetaFrames   *frames,
-                                   MetaUIFrame  *frame)
-{
-  MetaFrameFlags flags;
-  MetaFrameType type;
-  MetaFrameStyle *style = NULL;
-  gboolean frame_exists;
-
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow,
-                 META_CORE_WINDOW_HAS_FRAME, &frame_exists,
-                 META_CORE_GET_FRAME_FLAGS, &flags,
-                 META_CORE_GET_FRAME_TYPE, &type,
-                 META_CORE_GET_END);
-
-  if (frame_exists)
-    {
-      style = meta_theme_get_frame_style (meta_theme_get_current (),
-                                          type, flags);
-    }
-
-  if (frame_exists && style->window_background_color != NULL)
-    {
-      GdkRGBA color;
-      GdkVisual *visual;
-
-      meta_color_spec_render (style->window_background_color,
-                              frame->style,
-                              &color);
-
-      /* Set A in ARGB to window_background_alpha, if we have ARGB */
-
-      visual = gtk_widget_get_visual (GTK_WIDGET (frames));
-      if (gdk_visual_get_depth (visual) == 32) /* we have ARGB */
-        {
-          color.alpha = style->window_background_alpha / 255.0;
-        }
-
-      gdk_window_set_background_rgba (frame->window, &color);
-    }
-  else
-    {
-      gtk_style_context_set_background (frame->style, frame->window);
-    }
- }
 
 static gboolean
 meta_frames_enter_notify_event      (GtkWidget           *widget,

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -137,13 +137,6 @@ void meta_frames_get_borders (MetaFrames *frames,
                               Window xwindow,
                               MetaFrameBorders *borders);
 
-void meta_frames_reset_bg     (MetaFrames *frames,
-                               Window      xwindow);
-void meta_frames_unflicker_bg (MetaFrames *frames,
-                               Window      xwindow,
-                               int         target_width,
-                               int         target_height);
-
 cairo_region_t *meta_frames_get_frame_bounds (MetaFrames *frames,
                                               Window      xwindow,
                                               int         window_width,

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -333,6 +333,17 @@ meta_ui_get_corner_radiuses (MetaUI *ui,
                                    bottom_left, bottom_right);
 }
 
+LOCAL_SYMBOL void
+set_background_none (Display *xdisplay,
+                     Window   xwindow)
+{
+  XSetWindowAttributes attrs;
+
+  attrs.background_pixmap = None;
+  XChangeWindowAttributes (xdisplay, xwindow,
+                           CWBackPixmap, &attrs);
+}
+
 LOCAL_SYMBOL Window
 meta_ui_create_frame_window (MetaUI *ui,
                              Display *xdisplay,
@@ -399,6 +410,7 @@ meta_ui_create_frame_window (MetaUI *ui,
 		    &attrs, attributes_mask);
 
   gdk_window_resize (window, width, height);
+  set_background_none (xdisplay, GDK_WINDOW_XID (window));
   
   meta_frames_manage_window (ui->frames, GDK_WINDOW_XID (window), window);
 
@@ -452,16 +464,6 @@ meta_ui_unmap_frame (MetaUI *ui,
 }
 
 LOCAL_SYMBOL void
-meta_ui_unflicker_frame_bg (MetaUI *ui,
-                            Window  xwindow,
-                            int     target_width,
-                            int     target_height)
-{
-  meta_frames_unflicker_bg (ui->frames, xwindow,
-                            target_width, target_height);
-}
-
-LOCAL_SYMBOL void
 meta_ui_update_frame_style (MetaUI  *ui,
                             Window   xwindow)
 {
@@ -473,13 +475,6 @@ meta_ui_repaint_frame (MetaUI *ui,
                        Window xwindow)
 {
   meta_frames_repaint_frame (ui->frames, xwindow);
-}
-
-LOCAL_SYMBOL void
-meta_ui_reset_frame_bg (MetaUI *ui,
-                        Window xwindow)
-{
-  meta_frames_reset_bg (ui->frames, xwindow);
 }
 
 LOCAL_SYMBOL cairo_region_t *

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -88,13 +88,6 @@ void meta_ui_map_frame   (MetaUI *ui,
 void meta_ui_unmap_frame (MetaUI *ui,
                           Window  xwindow);
 
-void meta_ui_unflicker_frame_bg (MetaUI *ui,
-                                 Window  xwindow,
-                                 int     target_width,
-                                 int     target_height);
-void meta_ui_reset_frame_bg     (MetaUI *ui,
-                                 Window  xwindow);
-
 cairo_region_t *meta_ui_get_frame_bounds (MetaUI  *ui,
                                           Window   xwindow,
                                           int      window_width,


### PR DESCRIPTION
...destroy animation

Ported from this mutter fix: https://github.com/GNOME/mutter/commit/d0f2c6be6d6dc0c5d5db2ff1ee12874af720c5b8