### PR TITLE
Remove kill-switch-workspace signal

### DIFF
--- a/src/compositor/meta-plugin-manager.c
+++ b/src/compositor/meta-plugin-manager.c
@@ -115,16 +115,6 @@ meta_plugin_manager_kill_window_effects (MetaPluginManager *plugin_mgr,
         klass->kill_window_effects (plugin, actor);
 }
 
-static void
-meta_plugin_manager_kill_switch_workspace (MetaPluginManager *plugin_mgr)
-{
-    MetaPlugin        *plugin = plugin_mgr->plugin;
-    MetaPluginClass   *klass = META_PLUGIN_GET_CLASS (plugin);
-
-    if (klass->kill_switch_workspace)
-        klass->kill_switch_workspace (plugin);
-}
-
 /*
  * Public method that the compositor hooks into for events that require
  * no additional parameters.
@@ -284,7 +274,6 @@ meta_plugin_manager_switch_workspace (MetaPluginManager   *plugin_mgr,
     if (klass->switch_workspace)
     {
          retval = TRUE;
-         meta_plugin_manager_kill_switch_workspace (plugin_mgr);
 
          _meta_plugin_effect_started (plugin);
          klass->switch_workspace (plugin, from, to, direction);

--- a/src/compositor/plugins/default.c
+++ b/src/compositor/plugins/default.c
@@ -94,7 +94,6 @@ static void switch_workspace (MetaPlugin          *plugin,
 
 static void kill_window_effects   (MetaPlugin      *plugin,
                                    MetaWindowActor *actor);
-static void kill_switch_workspace (MetaPlugin      *plugin);
 
 static const MetaPluginInfo * plugin_info (MetaPlugin *plugin);
 
@@ -216,7 +215,6 @@ meta_default_plugin_class_init (MetaDefaultPluginClass *klass)
   plugin_class->switch_workspace = switch_workspace;
   plugin_class->plugin_info      = plugin_info;
   plugin_class->kill_window_effects   = kill_window_effects;
-  plugin_class->kill_switch_workspace = kill_switch_workspace;
 
   g_type_class_add_private (gobject_class, sizeof (MetaDefaultPluginPrivate));
 }
@@ -312,6 +310,13 @@ switch_workspace (MetaPlugin *plugin,
   ClutterActor *stage;
   int           screen_width, screen_height;
   ClutterAnimation *animation;
+
+  if (priv->tml_switch_workspace1)
+    {
+      clutter_timeline_stop (priv->tml_switch_workspace1);
+      clutter_timeline_stop (priv->tml_switch_workspace2);
+      g_signal_emit_by_name (priv->tml_switch_workspace1, "completed", NULL);
+    }
 
   screen = meta_plugin_get_screen (plugin);
   stage = meta_get_stage_for_screen (screen);
@@ -718,19 +723,6 @@ destroy (MetaPlugin *plugin, MetaWindowActor *window_actor)
     }
   else
     meta_plugin_destroy_completed (plugin, window_actor);
-}
-
-static void
-kill_switch_workspace (MetaPlugin     *plugin)
-{
-  MetaDefaultPluginPrivate *priv = META_DEFAULT_PLUGIN (plugin)->priv;
-
-  if (priv->tml_switch_workspace1)
-    {
-      clutter_timeline_stop (priv->tml_switch_workspace1);
-      clutter_timeline_stop (priv->tml_switch_workspace2);
-      g_signal_emit_by_name (priv->tml_switch_workspace1, "completed", NULL);
-    }
 }
 
 static void

--- a/src/meta/meta-plugin.h
+++ b/src/meta/meta-plugin.h
@@ -123,8 +123,6 @@ struct _MetaPluginClass
   void (*kill_window_effects)      (MetaPlugin      *plugin,
                                     MetaWindowActor *actor);
 
-  void (*kill_switch_workspace)    (MetaPlugin     *plugin);
-
   /* General XEvent filter. This is fired *before* meta itself handles
    * an event. Return TRUE to block any further processing.
    */


### PR DESCRIPTION
The kill-switch-workspace signal is used when before switch-workspace
signal is fired for the existing switch animation to be cancelled.
However, this mechanism is not ideal since the switch-workspace and
kill-switch-workspace events are separated.

Using the old model, say we switch to left workspace, and during that
animation, we press Ctrl-Alt-Right to switch back to the right
workspace. What would happen is that we will finish the animation early,
land on the left workspace, and start a new animation.

By letting the wm handle the killing work when receiving the
switch-workspace, we can do better. We can immediately halt the windows'
movement, and let them animate to where Ctrl-Alt-Right would bring them
to, from the position where they started, which would look smoother.

This new way of doing things is already implemented in previous commits,
and this commit removes the kill-switch-workspace signal completely.