### PR TITLE
[3.0] Keyboard tiling fixes

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -985,7 +985,7 @@ constrain_tiling (MetaWindow         *window,
     return TRUE;
 
   /* Determine whether constraint applies; exit if it doesn't */
-  if (!META_WINDOW_TILED_OR_SNAPPED (window))
+  if (!META_WINDOW_TILED_OR_SNAPPED (window) || window->resizing_tile_type != META_WINDOW_TILE_TYPE_NONE)
     return TRUE;
 
   /* Calculate target_size - as the tile previews need this as well, we

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -415,6 +415,7 @@ gboolean meta_display_window_has_pending_pings (MetaDisplay        *display,
 						MetaWindow         *window);
 
 int meta_resize_gravity_from_grab_op (MetaGrabOp op);
+int meta_resize_gravity_from_tile_mode (MetaTileMode mode);
 
 gboolean meta_grab_op_is_moving   (MetaGrabOp op);
 gboolean meta_grab_op_is_resizing (MetaGrabOp op);

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3848,7 +3848,14 @@ meta_display_end_grab_op (MetaDisplay *display,
         meta_screen_ungrab_all_keys (display->grab_screen, timestamp);
     }
 
-  
+  if (display->grab_window &&
+      display->grab_window->resizing_tile_type != META_WINDOW_TILE_TYPE_NONE) {
+    display->grab_window->snap_queued = display->grab_window->resizing_tile_type == META_WINDOW_TILE_TYPE_SNAPPED;
+    display->grab_window->tile_mode = display->grab_window->resize_tile_mode;
+    display->grab_window->custom_snap_size = TRUE;
+    meta_window_real_tile (display->grab_window, TRUE);
+  }
+
   display->grab_window = NULL;
   display->grab_screen = NULL;
   display->grab_xwindow = None;
@@ -4878,6 +4885,45 @@ meta_resize_gravity_from_grab_op (MetaGrabOp op)
       break;
     default:
       break;
+    }
+
+  return gravity;
+}
+
+LOCAL_SYMBOL int
+meta_resize_gravity_from_tile_mode (MetaTileMode mode)
+{
+  int gravity;
+  
+  gravity = -1;
+  switch (mode)
+    {
+      case META_TILE_LEFT:
+        gravity = WestGravity;
+        break;
+      case META_TILE_RIGHT:
+        gravity = EastGravity;
+        break;
+      case META_TILE_TOP:
+        gravity = NorthGravity;
+        break;
+      case META_TILE_BOTTOM:
+        gravity = SouthGravity;
+        break;
+      case META_TILE_ULC:
+        gravity = NorthWestGravity;
+        break;
+      case META_TILE_LLC:
+        gravity = SouthWestGravity;
+        break;
+      case META_TILE_URC:
+        gravity = NorthEastGravity;
+        break;
+      case META_TILE_LRC:
+        gravity = SouthEastGravity;
+        break;
+      default:
+        break;
     }
 
   return gravity;

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1866,8 +1866,10 @@ event_callback (XEvent   *event,
                 meta_stack_set_positions (screen->stack,
                                           display->grab_old_window_stacking);
             }
-          meta_display_end_grab_op (display,
-                                    event->xbutton.time);
+
+          if (display->grab_window->tile_mode == META_TILE_NONE)
+              meta_display_end_grab_op (display,
+                                        event->xbutton.time);
         }
       else if (window && display->grab_op == META_GRAB_OP_NONE)
         {
@@ -3855,6 +3857,8 @@ meta_display_end_grab_op (MetaDisplay *display,
     display->grab_window->custom_snap_size = TRUE;
     meta_window_real_tile (display->grab_window, TRUE);
   }
+
+  meta_screen_hide_hud_and_preview (display->grab_screen);
 
   display->grab_window = NULL;
   display->grab_screen = NULL;

--- a/src/core/keybindings-private.h
+++ b/src/core/keybindings-private.h
@@ -65,6 +65,10 @@ gboolean meta_window_grab_all_keys          (MetaWindow  *window,
                                              guint32      timestamp);
 void     meta_window_ungrab_all_keys        (MetaWindow  *window,
                                              guint32      timestamp);
+
+gboolean meta_window_resize_or_move_allowed (MetaWindow *window,
+                                             MetaDirection dir);
+
 gboolean meta_display_process_key_event     (MetaDisplay *display,
                                              MetaWindow  *window,
                                              XEvent      *event);

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2134,7 +2134,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
   width = window->rect.width;
   height = window->rect.height;
 
-  gravity = meta_resize_gravity_from_grab_op (display->grab_op);
+  if (window->tile_mode != META_TILE_NONE)
+    gravity = meta_resize_gravity_from_tile_mode (window->tile_mode);
+  else
+    gravity = meta_resize_gravity_from_grab_op (display->grab_op);
 
   smart_snap = (event->xkey.state & ShiftMask) != 0;
   

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2585,9 +2585,6 @@ handle_tile_action (MetaDisplay    *display,
   if (new_mode == window->tile_mode)
     return;
 
-  if (!meta_window_can_tile (window, new_mode))
-    return;
-
   meta_window_tile (window, new_mode, snap);
 }
 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1887,19 +1887,15 @@ process_keyboard_move_grab (MetaDisplay *display,
     case XK_KP_Prior:
     case XK_Up:
     case XK_KP_Up:
-      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_UP)) {
-          y -= incr;
-          handled = TRUE;
-      }
+      y -= incr;
+      handled = TRUE;
       break;
     case XK_KP_End:
     case XK_KP_Next:
     case XK_Down:
     case XK_KP_Down:
-      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_DOWN)) {
-        y += incr;
-        handled = TRUE;
-      }
+      y += incr;
+      handled = TRUE;
       break;
     }
   
@@ -1909,19 +1905,15 @@ process_keyboard_move_grab (MetaDisplay *display,
     case XK_KP_End:
     case XK_Left:
     case XK_KP_Left:
-      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_LEFT)) {
-        x -= incr;
-        handled = TRUE;
-      }
+      x -= incr;
+      handled = TRUE;
       break;
     case XK_KP_Prior:
     case XK_KP_Next:
     case XK_Right:
     case XK_KP_Right:
-      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_RIGHT)) {
-        x += incr;
-        handled = TRUE;
-      }
+      x += incr;
+      handled = TRUE;
       break;
     }
 
@@ -1931,6 +1923,8 @@ process_keyboard_move_grab (MetaDisplay *display,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Computed new window location %d,%d due to keypress\n",
                   x, y);
+
+      meta_window_tile (window, META_TILE_NONE, FALSE);
 
       meta_window_get_client_root_coords (window, &old_rect);
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9875,17 +9875,22 @@ update_resize (MetaWindow *window,
     }
   else
     {
-      if ((new_unmaximize & ~window->display->grab_resize_unmaximize) != 0 || window->tile_type != META_WINDOW_TILE_TYPE_NONE)
+      if ((new_unmaximize & ~window->display->grab_resize_unmaximize) != 0)
         {
-          if (window->resizing_tile_type == META_WINDOW_TILE_TYPE_NONE)
-            window->resizing_tile_type = window->tile_type;
-          if (window->tile_mode != META_TILE_NONE) {
-            window->resize_tile_mode = window->tile_mode;
-          }
-
           meta_window_unmaximize_with_gravity (window,
                                                (new_unmaximize & ~window->display->grab_resize_unmaximize),
                                                new_w, new_h, gravity);
+        }
+
+      if (window->tile_type != META_WINDOW_TILE_TYPE_NONE)
+        {
+          if (window->tile_mode != META_TILE_NONE)
+            {
+              window->resize_tile_mode = window->tile_mode;
+              window->resizing_tile_type = window->tile_type;
+            }
+
+          meta_window_resize_with_gravity (window, TRUE, new_w, new_h, gravity);
         }
 
       if (window->resizing_tile_type == META_WINDOW_TILE_TYPE_NONE && (window->display->grab_resize_unmaximize & ~new_unmaximize))

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -122,8 +122,7 @@ static void     update_resize         (MetaWindow   *window,
                                        gboolean      snap,
                                        int           x,
                                        int           y,
-                                       gboolean      force,
-                                       gboolean      done);
+                                       gboolean      force);
 static gboolean update_resize_timeout (gpointer data);
 static gboolean should_be_on_all_workspaces (MetaWindow *window);
 
@@ -4791,8 +4790,7 @@ sync_request_timeout (gpointer data)
                      window->display->grab_last_user_action_was_snap,
                      window->display->grab_latest_motion_x,
                      window->display->grab_latest_motion_y,
-                     TRUE,
-                     FALSE);
+                     TRUE);
     }
 
   return FALSE;
@@ -8796,6 +8794,12 @@ menu_callback (MetaWindowMenu *menu,
           break;
 
         case META_MENU_OP_RESIZE:
+          if (window->tile_mode != META_TILE_NONE)
+            {
+              window->resize_tile_mode = window->tile_mode;
+              window->resizing_tile_type = window->tile_type;
+            }
+
           meta_window_begin_grab_op (window,
                                      META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN,
                                      TRUE,
@@ -9657,8 +9661,7 @@ update_resize_timeout (gpointer data)
                  window->display->grab_last_user_action_was_snap,
                  window->display->grab_latest_motion_x,
                  window->display->grab_latest_motion_y,
-                 TRUE,
-                 FALSE);
+                 TRUE);
   return FALSE;
 }
 
@@ -9666,8 +9669,7 @@ static void
 update_resize (MetaWindow *window,
                gboolean    snap,
                int x, int y,
-               gboolean force,
-               gboolean done)
+               gboolean force)
 {
   int dx, dy;
   int new_w, new_h;
@@ -9704,44 +9706,80 @@ update_resize (MetaWindow *window,
 
   if (window->display->grab_op == META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN)
     {
-      if ((dx > 0) && (dy > 0))
+      if (window->tile_mode == META_TILE_NONE)
         {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SE;
-          meta_window_update_keyboard_resize (window, TRUE);
+          if ((dx > 0) && (dy > 0))
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SE;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if ((dx < 0) && (dy > 0))
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SW;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if ((dx > 0) && (dy < 0))
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NE;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if ((dx < 0) && (dy < 0))
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NW;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if (dx < 0)
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_W;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if (dx > 0)
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_E;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if (dy > 0)
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_S;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
+          else if (dy < 0)
+            {
+              window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
+              meta_window_update_keyboard_resize (window, TRUE);
+            }
         }
-      else if ((dx < 0) && (dy > 0))
+      else
         {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SW;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if ((dx > 0) && (dy < 0))
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NE;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if ((dx < 0) && (dy < 0))
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NW;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if (dx < 0)
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_W;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if (dx > 0)
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_E;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if (dy > 0)
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_S;
-          meta_window_update_keyboard_resize (window, TRUE);
-        }
-      else if (dy < 0)
-        {
-          window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
+          switch (window->tile_mode) 
+            {
+              case META_TILE_LEFT:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_E;
+                break;
+              case META_TILE_RIGHT:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_W;
+                break;
+              case META_TILE_TOP:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_S;
+                break;
+              case META_TILE_BOTTOM:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
+                break;
+              case META_TILE_ULC:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SE;
+                break;
+              case META_TILE_LLC:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NE;
+                break;
+              case META_TILE_URC:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_SW;
+                break;
+              case META_TILE_LRC:
+                window->display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_NW;
+                break;
+              default:
+                break;
+            }
           meta_window_update_keyboard_resize (window, TRUE);
         }
     }
@@ -9756,7 +9794,8 @@ update_resize (MetaWindow *window,
     case META_GRAB_OP_KEYBOARD_RESIZING_SE:
     case META_GRAB_OP_KEYBOARD_RESIZING_NE:
     case META_GRAB_OP_KEYBOARD_RESIZING_E:
-      new_w += dx;
+      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_RIGHT))
+        new_w += dx;
       break;
 
     case META_GRAB_OP_RESIZING_NW:
@@ -9765,7 +9804,8 @@ update_resize (MetaWindow *window,
     case META_GRAB_OP_KEYBOARD_RESIZING_NW:
     case META_GRAB_OP_KEYBOARD_RESIZING_SW:
     case META_GRAB_OP_KEYBOARD_RESIZING_W:
-      new_w -= dx;
+      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_LEFT))
+        new_w -= dx;
       break;
 	default:
 	  break;
@@ -9779,7 +9819,8 @@ update_resize (MetaWindow *window,
     case META_GRAB_OP_KEYBOARD_RESIZING_SE:
     case META_GRAB_OP_KEYBOARD_RESIZING_S:
     case META_GRAB_OP_KEYBOARD_RESIZING_SW:
-      new_h += dy;
+      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_DOWN))
+        new_h += dy;
       break;
 
     case META_GRAB_OP_RESIZING_N:
@@ -9788,7 +9829,8 @@ update_resize (MetaWindow *window,
     case META_GRAB_OP_KEYBOARD_RESIZING_N:
     case META_GRAB_OP_KEYBOARD_RESIZING_NE:
     case META_GRAB_OP_KEYBOARD_RESIZING_NW:
-      new_h -= dy;
+      if (meta_window_resize_or_move_allowed (window, META_DIRECTION_UP))
+        new_h -= dy;
       break;
     default:
       break;
@@ -9836,11 +9878,15 @@ update_resize (MetaWindow *window,
     {
     case META_GRAB_OP_RESIZING_S:
     case META_GRAB_OP_RESIZING_N:
+    case META_GRAB_OP_KEYBOARD_RESIZING_S:
+    case META_GRAB_OP_KEYBOARD_RESIZING_N:
       new_w = old.width;
       break;
 
     case META_GRAB_OP_RESIZING_E:
     case META_GRAB_OP_RESIZING_W:
+    case META_GRAB_OP_KEYBOARD_RESIZING_E:
+    case META_GRAB_OP_KEYBOARD_RESIZING_W:
       new_h = old.height;
       break;
 
@@ -9849,7 +9895,11 @@ update_resize (MetaWindow *window,
     }
 
   /* compute gravity of client during operation */
-  gravity = meta_resize_gravity_from_grab_op (window->display->grab_op);
+  if (window->tile_mode != META_TILE_NONE)
+    gravity = meta_resize_gravity_from_tile_mode (window->tile_mode);
+  else
+    gravity = meta_resize_gravity_from_grab_op (window->display->grab_op);
+
   g_assert (gravity >= 0);
 
   /* Do any edge resistance/snapping */
@@ -9904,15 +9954,6 @@ update_resize (MetaWindow *window,
 
   window->display->grab_resize_unmaximize = new_unmaximize;
   /* Store the latest resize time, if we actually resized. */
-    if (done) {
-        if (window->resizing_tile_type != META_WINDOW_TILE_TYPE_NONE) {
-            window->snap_queued = window->resizing_tile_type == META_WINDOW_TILE_TYPE_SNAPPED;
-            window->tile_mode = window->resize_tile_mode;
-            window->custom_snap_size = TRUE;
-            meta_window_real_tile (window, TRUE);
-        }
-    }
-
 
   if (window->rect.width != old.width || window->rect.height != old.height)
     g_get_current_time (&window->display->grab_last_moveresize_time);
@@ -10052,8 +10093,7 @@ meta_window_update_sync_request_counter (MetaWindow *window,
                      window->display->grab_last_user_action_was_snap,
                      window->display->grab_latest_motion_x,
                      window->display->grab_latest_motion_y,
-                     TRUE,
-                     FALSE);
+                     TRUE);
     }
 
   /* If sync was previously disabled, turn it back on and hope
@@ -10111,8 +10151,7 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
                          window->display->grab_last_user_action_was_snap,
                          window->display->grab_latest_motion_x,
                          window->display->grab_latest_motion_y,
-                         TRUE,
-                         FALSE);
+                         TRUE);
           break;
 
         default:
@@ -10161,7 +10200,6 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
                                event->xbutton.state & ShiftMask,
                                event->xbutton.x_root,
                                event->xbutton.y_root,
-                               TRUE,
                                TRUE);
 
               /* If a tiled window has been dragged free with a
@@ -10206,7 +10244,6 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
                                event->xmotion.state & ShiftMask,
                                event->xmotion.x_root,
                                event->xmotion.y_root,
-                               FALSE,
                                FALSE);
             }
         }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2180,6 +2180,12 @@ set_net_wm_state (MetaWindow *window)
                      XA_CARDINAL,
                      32, PropModeReplace, (guchar*) data, 8);
     meta_error_trap_pop (window->display);
+  } else {
+    meta_error_trap_push (window->display);
+    XDeleteProperty (window->display->xdisplay,
+                     window->xwindow,
+                     window->display->atom__NET_WM_WINDOW_TILE_INFO);
+    meta_error_trap_pop (window->display);
   }
 }
 
@@ -3850,7 +3856,6 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
   }
 
   recalc_window_features (window);
-  set_net_wm_state (window);
 
   normalize_tile_state (window);
 
@@ -3880,6 +3885,8 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
        */
       meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
     }
+
+  set_net_wm_state (window);
 
   meta_screen_tile_preview_hide (window->screen);
   meta_window_get_outer_rect (window, &window->snapped_rect);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9256,8 +9256,6 @@ get_size_limits (const MetaWindow       *window,
     }
 }
 
-
-
 static void
 update_move (MetaWindow  *window,
              gboolean     legacy_snap,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3842,8 +3842,8 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
      meta_window_save_rect (window);
   }
 
-  window->maximized_horizontally = FALSE;
-  window->maximized_vertically = FALSE;
+  window->maximized_horizontally = FALSE || window->tile_mode == META_TILE_MAXIMIZE;
+  window->maximized_vertically = FALSE || window->tile_mode == META_TILE_MAXIMIZE;
 
   if (window->tile_mode != META_TILE_NONE) {
       if (window->snap_queued || window->resizing_tile_type == META_WINDOW_TILE_TYPE_SNAPPED) {
@@ -4032,11 +4032,16 @@ meta_window_unmaximize_internal (MetaWindow        *window,
    */
   if ((unmaximize_horizontally && window->maximized_horizontally) ||
       (unmaximize_vertically   && window->maximized_vertically) ||
-      window->tile_type != META_WINDOW_TILE_TYPE_NONE ||
+      window->tile_type == META_WINDOW_TILE_TYPE_NONE ||
       window->tile_mode == META_TILE_NONE)
     {
       MetaRectangle target_rect;
       MetaRectangle work_area;
+
+      window->last_tile_mode = META_TILE_NONE;
+      window->tile_mode = META_TILE_NONE;
+      window->resizing_tile_type = META_WINDOW_TILE_TYPE_NONE;
+      window->tile_type = META_WINDOW_TILE_TYPE_NONE;
 
       meta_window_get_work_area_for_monitor (window, window->monitor->number, &work_area);
 


### PR DESCRIPTION
- Fixes linuxmint/Cinnamon#4766
- Smooth tiled window resizing
- saner keyboard resize and moving when dealing with tiled windows