### PR TITLE
Remove invalid (transfer) annnotations

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -963,7 +963,7 @@ const char *meta_window_actor_get_description (MetaWindowActor *self)
  * This function is deprecated  and should not be used in newly written code;
  * meta_window_get_workspace() instead.
  *
- * Return value: (transfer none): index of workspace on which this window is
+ * Return value: index of workspace on which this window is
  * located.
  */
 gint

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -5595,7 +5595,7 @@ Atom meta_display_get_atom (MetaDisplay *display, MetaAtom meta_atom)
  * _NET_SUPPORTING_WM_CHECK mechanism of EWMH). For use by plugins that wish
  * to attach additional custom properties to this window.
  *
- * Return value: (transfer none): xid of the leader window.
+ * Return value: xid of the leader window.
  **/
 Window
 meta_display_get_leader_window (MetaDisplay *display)

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -10709,7 +10709,7 @@ find_ancestor_func (MetaWindow *window,
  * so by traversing the @transient's ancestors until it either locates @window
  * or reaches an ancestor that is not transient.
  *
- * Return Value: (transfer none): %TRUE if window is an ancestor of transient.
+ * Return Value: %TRUE if window is an ancestor of transient.
  */
 gboolean
 meta_window_is_ancestor_of_transient (MetaWindow *window,
@@ -11549,7 +11549,7 @@ meta_window_get_transient_for (MetaWindow *window)
  * parents. A typical usage of this hint is for a dialog that wants to stay
  * above its associated window.
  *
- * Return value: (transfer none): the window this window is transient for, or
+ * Return value: the window this window is transient for, or
  * None if the WM_TRANSIENT_FOR hint is unset.
  */
 Window
@@ -11565,7 +11565,7 @@ meta_window_get_transient_for_as_xid (MetaWindow *window)
  * Returns pid of the process that created this window, if known (obtained from
  * the _NET_WM_PID property).
  *
- * Return value: (transfer none): the pid, or -1 if not known.
+ * Return value: the pid, or -1 if not known.
  */
 int
 meta_window_get_pid (MetaWindow *window)
@@ -11618,7 +11618,7 @@ meta_window_is_remote (MetaWindow *window)
  * Queries whether the window is in a modal state as described by the
  * _NET_WM_STATE protocol.
  *
- * Return value: (transfer none): TRUE if the window is in modal state.
+ * Return value: TRUE if the window is in modal state.
  */
 gboolean
 meta_window_is_modal (MetaWindow *window)


### PR DESCRIPTION
Based on https://git.gnome.org/browse/mutter/patch/src/core/window.c?id=6190ae3873588aa1813ee4824bfff73bc1c75e5c

https://bugzilla.gnome.org/show_bug.cgi?id=752047

The change seems backwards compatible with older g-i versions