### PR TITLE
window-actor: Keep in compositor's window list until destroyed

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1170,7 +1170,7 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
           old_actor = old_stack->data;
           old_window = meta_window_actor_get_meta_window (old_actor);
 
-          if (old_window->hidden &&
+          if ((old_window->hidden || old_window->unmanaging) &&
               !meta_window_actor_effect_in_progress (old_actor))
             {
               old_stack = g_list_delete_link (old_stack, old_stack);
@@ -1204,7 +1204,7 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
        * filtered out non-animating hidden windows above.
        */
       if (old_actor &&
-          (!stack_actor || old_window->hidden))
+          (!stack_actor || old_window->hidden || old_window->unmanaging))
         {
           actor = old_actor;
           window = old_window;

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1403,7 +1403,6 @@ LOCAL_SYMBOL void
 meta_window_actor_destroy (MetaWindowActor *self)
 {
   MetaWindow	      *window;
-  MetaCompScreen      *info;
   MetaWindowActorPrivate *priv;
   MetaWindowType window_type;
 
@@ -1412,13 +1411,6 @@ meta_window_actor_destroy (MetaWindowActor *self)
   window = priv->window;
   window_type = meta_window_get_window_type (window);
   meta_window_set_compositor_private (window, NULL);
-
-  /*
-   * We remove the window from internal lookup hashes and thus any other
-   * unmap events etc fail
-   */
-  info = meta_screen_get_compositor_data (priv->screen);
-  info->windows = g_list_remove (info->windows, (gconstpointer) self);
 
   if (window_type == META_WINDOW_DROPDOWN_MENU ||
       window_type == META_WINDOW_POPUP_MENU ||


### PR DESCRIPTION
You can see the issue if you open two windows and put one partly covering the other. Close the window in the back and it will flash on top. This fix prevents that from happening.