### PR TITLE
theme.c: get style context state instead of using GTK_STATE_FLAG_NORMAL

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -5964,7 +5964,7 @@ meta_gtk_widget_get_font_desc (GtkWidget *widget,
   g_return_val_if_fail (gtk_widget_get_realized (widget), NULL);
 
   style = gtk_widget_get_style_context (widget);
-  gtk_style_context_get (style, GTK_STATE_FLAG_NORMAL,
+  gtk_style_context_get (style, gtk_style_context_get_state (style),
                          GTK_STYLE_PROPERTY_FONT, &font_desc,
                          NULL);
 


### PR DESCRIPTION
gtk 3.20 complains if the state passed doesn't match the context's current
state. This quiets a lot of log spam when window focus changes.

thanks to JosephM for finding this commit which turned out to be the exact
fix needed:
https://github.com/GNOME/mutter/commit/9b9083180f211cc4f19750de84c92dd8541c8848