### PR TITLE
window.c: Don't ever send ConfigureNotifies for OR windows

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1817,12 +1817,6 @@ meta_window_unmanage (MetaWindow  *window,
       window->tile_type != META_WINDOW_TILE_TYPE_NONE)
     unmaximize_window_before_freeing (window);
 
-  /* The XReparentWindow call in meta_window_destroy_frame() moves the
-   * window so we need to send a configure notify; see bug 399552.  (We
-   * also do this just in case a window got unmaximized.)
-   */
-  send_configure_notify (window);
-
   meta_window_unqueue (window, META_QUEUE_CALC_SHOWING |
                                META_QUEUE_MOVE_RESIZE |
                                META_QUEUE_UPDATE_ICON);
@@ -1859,7 +1853,14 @@ meta_window_unmanage (MetaWindow  *window,
   meta_window_destroy_sync_request_alarm (window);
 
   if (window->frame)
-    meta_window_destroy_frame (window);
+    {
+      /* The XReparentWindow call in meta_window_destroy_frame() moves the
+       * window so we need to send a configure notify; see bug 399552.  (We
+       * also do this just in case a window got unmaximized.)
+       */
+      send_configure_notify (window);
+
+      meta_window_destroy_frame (window);
 
   /* If an undecorated window is being withdrawn, that will change the
    * stack as presented to the compositing manager, without actually
@@ -7598,6 +7599,8 @@ static void
 send_configure_notify (MetaWindow *window)
 {
   XEvent event;
+
+  g_assert (!window->override_redirect);
 
   /* from twm */
 


### PR DESCRIPTION
This is needed with gtk 3.20 for correct placement when the
OR is moved between hiding/showing, otherwise the behavior
described in the mutter commit occurs every time.

From mutter commit:
https://github.com/GNOME/mutter/commit/e3622275147181a2876e45397f5fc7ed063b8bb8

Fixes #224
Fixes linuxmint/Cinnamon#5202
Fixes linuxmint/Cinnamon#5195