### PR TITLE
[WIP] window.c: Don't ever send ConfigureNotifies for OR windows

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1664,8 +1664,6 @@ meta_window_actor_new (MetaWindow *window)
   MetaWindowActorPrivate *priv;
   MetaFrame		 *frame;
   Window		  top_window;
-  MetaRectangle rectWorkArea[1];
-  MetaRectangle *rectWindow;
 
   frame = meta_window_get_frame (window);
   if (frame)
@@ -1708,25 +1706,6 @@ meta_window_actor_new (MetaWindow *window)
       window->type == META_WINDOW_POPUP_MENU ||
       window->type == META_WINDOW_COMBO) {
     clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
-			       CLUTTER_ACTOR (self));
-  }
-  else if (window->type == META_WINDOW_TOOLTIP) {
-    meta_window_get_work_area_all_monitors(window, rectWorkArea);
-    rectWindow = meta_window_get_rect(window);
-    // move tooltip out of top panel if necessary
-    if (rectWindow->y < rectWorkArea->y) {
-      meta_window_move(window, FALSE, rectWindow->x, rectWorkArea->y);
-    }
-    rectWindow = meta_window_get_rect(window);
-    // move tooltip out of bottom panel if necessary
-    if ((rectWindow->y + rectWindow->height) > (rectWorkArea->y  + rectWorkArea->height)) {
-      meta_window_move(window, FALSE, rectWindow->x, rectWorkArea->y + rectWorkArea->height - rectWindow->height);
-    }
-    clutter_container_add_actor (CLUTTER_CONTAINER (info->top_window_group),
-		       CLUTTER_ACTOR (self));
-  }
-  else if (window->type == META_WINDOW_DESKTOP) {
-    clutter_container_add_actor (CLUTTER_CONTAINER (info->bottom_window_group),
 			       CLUTTER_ACTOR (self));
   }else{
     clutter_container_add_actor (CLUTTER_CONTAINER (info->window_group),

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5029,9 +5029,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
   MetaRectangle new_rect;
   MetaRectangle old_rect;
 
-  if (window->type != META_WINDOW_TOOLTIP) {
-    g_return_if_fail (!window->override_redirect);
-  }
+  g_return_if_fail (!window->override_redirect);
 
   is_configure_request = (flags & META_IS_CONFIGURE_REQUEST) != 0;
   do_gravity_adjust = (flags & META_DO_GRAVITY_ADJUST) != 0;
@@ -5496,9 +5494,7 @@ meta_window_move (MetaWindow  *window,
 {
   MetaMoveResizeFlags flags;
 
-  if (window->type != META_WINDOW_TOOLTIP) {
-    g_return_if_fail (!window->override_redirect);
-  }
+  g_return_if_fail (!window->override_redirect);
 
   flags = (user_op ? META_IS_USER_ACTION : 0) | META_IS_MOVE_ACTION;
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1817,12 +1817,6 @@ meta_window_unmanage (MetaWindow  *window,
       window->tile_type != META_WINDOW_TILE_TYPE_NONE)
     unmaximize_window_before_freeing (window);
 
-  /* The XReparentWindow call in meta_window_destroy_frame() moves the
-   * window so we need to send a configure notify; see bug 399552.  (We
-   * also do this just in case a window got unmaximized.)
-   */
-  send_configure_notify (window);
-
   meta_window_unqueue (window, META_QUEUE_CALC_SHOWING |
                                META_QUEUE_MOVE_RESIZE |
                                META_QUEUE_UPDATE_ICON);
@@ -1859,7 +1853,15 @@ meta_window_unmanage (MetaWindow  *window,
   meta_window_destroy_sync_request_alarm (window);
 
   if (window->frame)
-    meta_window_destroy_frame (window);
+    {
+      /* The XReparentWindow call in meta_window_destroy_frame() moves the
+       * window so we need to send a configure notify; see bug 399552.  (We
+       * also do this just in case a window got unmaximized.)
+       */
+      send_configure_notify (window);
+
+      meta_window_destroy_frame (window);
+    }
 
   /* If an undecorated window is being withdrawn, that will change the
    * stack as presented to the compositing manager, without actually
@@ -7598,6 +7600,8 @@ static void
 send_configure_notify (MetaWindow *window)
 {
   XEvent event;
+
+  g_assert (!window->override_redirect);
 
   /* from twm */
 


### PR DESCRIPTION
Sorry for the duplicate pull request/emaIl spam. I missed a bracket and squashed the fix commit.

This is needed with gtk 3.20 for correct placement when the
OR is moved between hiding/showing, otherwise the behavior
described in the mutter commit occurs every time.

From mutter commit:
https://github.com/GNOME/mutter/commit/e3622275147181a2876e45397f5fc7ed063b8bb8

Fixes #224
Fixes linuxmint/Cinnamon#5202
Fixes linuxmint/Cinnamon#5195