### PR TITLE
window.c: don't send configure notifies for OR windows

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1817,12 +1817,6 @@ meta_window_unmanage (MetaWindow  *window,
       window->tile_type != META_WINDOW_TILE_TYPE_NONE)
     unmaximize_window_before_freeing (window);
 
-  /* The XReparentWindow call in meta_window_destroy_frame() moves the
-   * window so we need to send a configure notify; see bug 399552.  (We
-   * also do this just in case a window got unmaximized.)
-   */
-  send_configure_notify (window);
-
   meta_window_unqueue (window, META_QUEUE_CALC_SHOWING |
                                META_QUEUE_MOVE_RESIZE |
                                META_QUEUE_UPDATE_ICON);
@@ -1859,7 +1853,15 @@ meta_window_unmanage (MetaWindow  *window,
   meta_window_destroy_sync_request_alarm (window);
 
   if (window->frame)
-    meta_window_destroy_frame (window);
+    {
+      /* The XReparentWindow call in meta_window_destroy_frame() moves the
+       * window so we need to send a configure notify; see bug 399552.  (We
+       * also do this just in case a window got unmaximized.)
+       */
+      send_configure_notify (window);
+
+      meta_window_destroy_frame (window);
+    }
 
   /* If an undecorated window is being withdrawn, that will change the
    * stack as presented to the compositing manager, without actually


### PR DESCRIPTION
this causes popup placement issues with gtk 3.20 as described in the
mutter commit this is based on. the assertion is left out, as we still
need to send configure notifies for OR windows in other cases.

based on:
https://github.com/GNOME/mutter/commit/e3622275147181a2876e45397f5fc7ed063b8bb8

Fixes #224
Fixes linuxmint/Cinnamon#5202
Fixes linuxmint/Cinnamon#5195