### PR TITLE
compositor: Rework handling of our top_window_group

### DIFF
--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -33,8 +33,7 @@ exec_prefix = @exec_prefix@
 datadir = @datadir@
 datarootdir = @datarootdir@
 libdir = @libdir@
-DATADIRNAME = @DATADIRNAME@
-itlocaledir = $(prefix)/$(DATADIRNAME)/locale
+localedir = @localedir@
 subdir = po
 install_sh = @install_sh@
 # Automake >= 1.8 provides @mkdir_p@.
@@ -80,7 +79,7 @@ INTLTOOL__v_MSGFMT_0 = @echo "  MSGFMT" $@;
 
 .po.pox:
 	$(MAKE) $(GETTEXT_PACKAGE).pot
-	$(MSGMERGE) $< $(GETTEXT_PACKAGE).pot -o $*.pox
+	$(MSGMERGE) $* $(GETTEXT_PACKAGE).pot -o $*.pox
 
 .po.mo:
 	$(INTLTOOL_V_MSGFMT)$(MSGFMT) -o $@ $<
@@ -108,7 +107,7 @@ install-data-no: all
 install-data-yes: all
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  dir=$(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES; \
+	  dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
 	  $(mkdir_p) $$dir; \
 	  if test -r $$lang.gmo; then \
 	    $(INSTALL_DATA) $$lang.gmo $$dir/$(GETTEXT_PACKAGE).mo; \
@@ -142,8 +141,8 @@ install-exec installcheck:
 uninstall:
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
 	done
 
 check: all $(GETTEXT_PACKAGE).pot

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -669,6 +669,7 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
 
   clutter_container_add (CLUTTER_CONTAINER (info->stage),
                          info->window_group,
+                         info->top_window_group,
                          info->overlay_group,
 			 info->hidden_group,
                          NULL);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5029,9 +5029,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
   MetaRectangle new_rect;
   MetaRectangle old_rect;
 
-  if (window->type != META_WINDOW_TOOLTIP) {
-    g_return_if_fail (!window->override_redirect);
-  }
+  g_return_if_fail (!window->override_redirect);
 
   is_configure_request = (flags & META_IS_CONFIGURE_REQUEST) != 0;
   do_gravity_adjust = (flags & META_DO_GRAVITY_ADJUST) != 0;
@@ -5496,9 +5494,7 @@ meta_window_move (MetaWindow  *window,
 {
   MetaMoveResizeFlags flags;
 
-  if (window->type != META_WINDOW_TOOLTIP) {
-    g_return_if_fail (!window->override_redirect);
-  }
+  g_return_if_fail (!window->override_redirect);
 
   flags = (user_op ? META_IS_USER_ACTION : 0) | META_IS_MOVE_ACTION;
 


### PR DESCRIPTION
remove the old tooltip placement code from https://github.com/linuxmint/muffin/commit/9bda8d2899a41809621ef9bef6db0c94d7ca0f02. This actually cause an issue where large tooltips that don't fit on-screen above or below the cursor flicker and then die. This allows them to draw and extend offscreen above the panel.
Requires: https://github.com/linuxmint/Cinnamon/pull/5222