### PR TITLE
remove unused description https://github.com/GNOME/mutter/commit/51ac…

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -68,8 +68,6 @@ struct _MetaWindowActorPrivate
   guint8            opacity;
   guint8            shadow_opacity;
 
-  gchar *           desc;
-
   /* If the window is shaped, a region that matches the shape */
   cairo_region_t   *shape_region;
   /* A rectangular region with the visible extents of the window */
@@ -366,9 +364,6 @@ window_decorated_notify (MetaWindow *mw,
       priv->damage = None;
     }
 
-  g_free (priv->desc);
-  priv->desc = NULL;
-
   priv->xwindow = new_xwindow;
 
   /*
@@ -529,11 +524,6 @@ meta_window_actor_dispose (GObject *object)
 static void
 meta_window_actor_finalize (GObject *object)
 {
-  MetaWindowActor        *self = META_WINDOW_ACTOR (object);
-  MetaWindowActorPrivate *priv = self->priv;
-
-  g_free (priv->desc);
-
   G_OBJECT_CLASS (meta_window_actor_parent_class)->finalize (object);
 }
 
@@ -932,25 +922,6 @@ gboolean
 meta_window_actor_is_override_redirect (MetaWindowActor *self)
 {
   return meta_window_is_override_redirect (self->priv->window);
-}
-
-const char *meta_window_actor_get_description (MetaWindowActor *self)
-{
-  /*
-   * For windows managed by the WM, we just defer to the WM for the window
-   * description. For override-redirect windows, we create the description
-   * ourselves, but only on demand.
-   */
-  if (self->priv->window)
-    return meta_window_get_description (self->priv->window);
-
-  if (G_UNLIKELY (self->priv->desc == NULL))
-    {
-      self->priv->desc = g_strdup_printf ("Override Redirect (0x%x)",
-                                         (guint) self->priv->xwindow);
-    }
-
-  return self->priv->desc;
 }
 
 /**

--- a/src/meta/meta-window-actor.h
+++ b/src/meta/meta-window-actor.h
@@ -63,7 +63,6 @@ gint               meta_window_actor_get_workspace        (MetaWindowActor *self
 MetaWindow *       meta_window_actor_get_meta_window      (MetaWindowActor *self);
 ClutterActor *     meta_window_actor_get_texture          (MetaWindowActor *self);
 gboolean           meta_window_actor_is_override_redirect (MetaWindowActor *self);
-const char *       meta_window_actor_get_description      (MetaWindowActor *self);
 gboolean       meta_window_actor_showing_on_its_workspace (MetaWindowActor *self);
 gboolean       meta_window_actor_is_destroyed (MetaWindowActor *self);
 


### PR DESCRIPTION
…c3ee3178754b16b17362bb9b0395ef9a4e9b#diff-5d2e6395ac2f32aae711a05663b64d18   please check to see this looks right for muffin, i.e that the same logic of no window actor without a metawindow holds.   No regressions seen