### PR TITLE
autoconf: remove unneeded check for python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,9 +413,6 @@ if test "x$enable_debug" = "xyes"; then
 	CFLAGS="$CFLAGS -g -O"
 fi
 
-# For fix-meta-rectangle.py
-AM_PATH_PYTHON([2.5])
-
 # Use gnome-doc-utils:
 GNOME_DOC_INIT([0.8.0])
 


### PR DESCRIPTION
python has never been used in muffin, this is a remnant from a
workaround that was introduced to mutter in 2010, and removed
before muffin was forked.

original commit which introduced it:
https://github.com/GNOME/mutter/commit/7853bb804273eb18faaf5b54cd82c11c066978bc