### PR TITLE
window-actor: fix leaked frame list

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -532,6 +532,7 @@ meta_window_actor_finalize (GObject *object)
   MetaWindowActor        *self = META_WINDOW_ACTOR (object);
   MetaWindowActorPrivate *priv = self->priv;
 
+  g_list_free_full (priv->frames, (GDestroyNotify) frame_data_free);
   g_free (priv->desc);
 
   G_OBJECT_CLASS (meta_window_actor_parent_class)->finalize (object);


### PR DESCRIPTION
https://github.com/GNOME/mutter/commit/4d437e32e069d348e9ff55bdaf34cfec60b0c7e3