### PR TITLE
cogl-utils: Don't set such a tight restriction on texture sizes

### DIFF
--- a/src/compositor/cogl-utils.c
+++ b/src/compositor/cogl-utils.c
@@ -147,8 +147,8 @@ clamp_sizes (gint *width,
         screen_height = gdk_screen_get_height (screen);
       }
 
-    *width = MIN (*width, screen_width);
-    *height = MIN (*height, screen_height);
+    *width = MIN (*width, screen_width * 2);
+    *height = MIN (*height, screen_height * 2);
 }
 
 /**


### PR DESCRIPTION
It's quite easy to create situations where limiting the texture to the screen size causes issues. Instead textures up to the screen size * 2.

Fixes https://github.com/linuxmint/Cinnamon/issues/5363