### PR TITLE
Unredirect fixes

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -925,7 +925,7 @@ meta_window_actor_get_texture (MetaWindowActor *self)
 gboolean
 meta_window_actor_is_destroyed (MetaWindowActor *self)
 {
-  return self->priv->disposed;
+  return self->priv->disposed || self->priv->needs_destroy;
 }
 
 gboolean

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1336,6 +1336,9 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   MetaWindow *metaWindow = meta_window_actor_get_meta_window (self);
   MetaWindowActorPrivate *priv = self->priv;
 
+  if (meta_window_actor_is_destroyed (self))
+    return FALSE;
+
   if (meta_window_requested_dont_bypass_compositor (metaWindow))
     return FALSE;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1063,7 +1063,12 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
                                      gboolean         no_delay_frame)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  FrameData *frame = g_slice_new0 (FrameData);
+  FrameData *frame;
+
+  if (meta_window_actor_is_destroyed (self))
+    return;
+
+  frame = g_slice_new0 (FrameData);
 
   priv->needs_frame_drawn = TRUE;
 
@@ -2447,6 +2452,9 @@ meta_window_actor_pre_paint (MetaWindowActor *self)
   MetaWindowActorPrivate *priv = self->priv;
   GList *l;
 
+  if (meta_window_actor_is_destroyed (self))
+    return;
+
   meta_window_actor_handle_updates (self);
 
   for (l = priv->frames; l != NULL; l = l->next)
@@ -2467,6 +2475,9 @@ meta_window_actor_post_paint (MetaWindowActor *self)
   MetaWindowActorPrivate *priv = self->priv;
 
   priv->repaint_scheduled = FALSE;
+
+  if (meta_window_actor_is_destroyed (self))
+    return;
 
   if (priv->needs_frame_drawn)
     {
@@ -2555,6 +2566,9 @@ meta_window_actor_frame_complete (MetaWindowActor *self,
 {
   MetaWindowActorPrivate *priv = self->priv;
   GList *l;
+
+  if (meta_window_actor_is_destroyed (self))
+    return;
 
   for (l = priv->frames; l;)
     {

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2113,8 +2113,8 @@ meta_window_actor_process_damage (MetaWindowActor    *self,
       MetaRectangle window_rect;
       meta_window_get_outer_rect (priv->window, &window_rect);
 
-      if (window_rect.x == event->area.x &&
-          window_rect.y == event->area.y &&
+      if (event->area.x == 0 &&
+          event->area.y == 0 &&
           window_rect.width == event->area.width &&
           window_rect.height == event->area.height)
         priv->full_damage_frames_count++;


### PR DESCRIPTION
837aeb1 fixes windows not being unredirected by the heuristic when located on a monitor that is not located at 0,0 in the screen.

The other 3 commits fix some misbehavior and a crash introduced with https://github.com/linuxmint/muffin/commit/e5460a3a8ccd81d9182755accf028075027b65c9

More info on the crash here:
https://bugzilla.gnome.org/show_bug.cgi?id=740133
https://bugzilla.redhat.com/show_bug.cgi?id=1149409

Edit: The application I reproduced the crash with locally was Universe Sandbox ²

Fixes #249