### PR TITLE
remove deprecated unnecessary g_type_init calls

### DIFF
--- a/src/core/muffin.c
+++ b/src/core/muffin.c
@@ -71,8 +71,6 @@ main (int argc, char **argv)
 
   g_setenv ("CLUTTER_BACKEND", "x11", TRUE);
 
-  g_type_init ();
-
   ctx = meta_get_option_context ();
   g_option_context_add_main_entries (ctx, muffin_options, GETTEXT_PACKAGE);
   if (!g_option_context_parse (ctx, &argc, &argv, &error))

--- a/src/tools/muffin-grayscale.c
+++ b/src/tools/muffin-grayscale.c
@@ -80,8 +80,6 @@ main (int argc, char **argv)
       g_printerr ("specify a single image on the command line\n");
       return 1;
     }
-
-  g_type_init ();
   
   err = NULL;
   pixbuf = gdk_pixbuf_new_from_file (argv[1], &err);


### PR DESCRIPTION
removes some distracting deprecation warnings