### PR TITLE
backgrounds: Clean up a couple things

### DIFF
--- a/src/compositor/meta-background.c
+++ b/src/compositor/meta-background.c
@@ -1,3 +1,27 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * meta-background.c: Actor used to create a background fade effect
+ *
+ * Copyright 2016 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
+ * 02110-1335, USA.
+ *
+ * Portions adapted from gnome-shell/src/shell-global.c
+ * and meta-window-actor.c
+ */
 
 #include "config.h"
 
@@ -163,7 +187,7 @@ meta_background_new (MetaScreen *screen)
 
 void
 meta_background_set_layer (MetaBackground *self,
-                           CoglHandle *texture)
+                           CoglHandle      texture)
 {
   MetaBackgroundPrivate *priv = self->priv;
   MetaDisplay *display = meta_screen_get_display (priv->screen);

--- a/src/compositor/meta-background.h
+++ b/src/compositor/meta-background.h
@@ -35,7 +35,7 @@ GType meta_background_get_type (void);
 ClutterActor * meta_background_new (MetaScreen *screen);
 
 void meta_background_set_layer           (MetaBackground       *self,
-                                          CoglHandle           *texture);
+                                          CoglHandle           texture);
 void meta_background_set_layer_wrap_mode (MetaBackground       *self,
                                           CoglMaterialWrapMode  wrap_mode);
 void meta_background_set_visible_region  (MetaBackground       *self,


### PR DESCRIPTION
Fix the use of a wrong type and add a generic gpl header to meta-background.c