### PR TITLE
Fix meta_screen_get_monitor_geometry override redirect

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3146,7 +3146,7 @@ queue_windows_showing (MetaScreen *screen)
    * active_workspace's window list, because the active_workspace's
    * window list may not contain the on_all_workspace windows.
    */
-  windows = meta_display_list_windows (screen->display, META_LIST_DEFAULT);
+  windows = meta_display_list_windows (screen->display, META_LIST_INCLUDE_OVERRIDE_REDIRECT);
 
   tmp = windows;
   while (tmp != NULL)

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -140,6 +140,8 @@ static void meta_window_move_between_rects (MetaWindow          *window,
 static void unmaximize_window_before_freeing (MetaWindow        *window);
 static void unminimize_window_and_all_transient_parents (MetaWindow *window);
 
+static void meta_window_update_monitor (MetaWindow *window);
+
 static void notify_tile_type (MetaWindow *window);
 
 static void normalize_tile_state (MetaWindow *window);
@@ -4807,6 +4809,12 @@ meta_window_update_for_monitors_changed (MetaWindow *window)
 {
   const MetaMonitorInfo *old, *new;
   int i;
+
+  if (window->override_redirect)
+    {
+      meta_window_update_monitor (window);
+      return;
+    }
 
   old = window->monitor;
 


### PR DESCRIPTION
* This is just a port of the [fix which was applied to mutter](https://git.gnome.org/browse/mutter/commit/?id=8ab136b) to solve [their bug](https://bugzilla.gnome.org/show_bug.cgi?id=702564)
* This (hopefully) closes #267 (which helped by referencing the above bug)

NB: I have been using Cinnamon for a couple of days (on Debian Unstable/experimental), and did this PR because - even worse than the case reported in #267 - for me the .xsession-errors was getting spammed at *hundreds* of lines per second, with *or* without a second monitor attached (or perhaps the logging was just still clearing its buffers when I checked after disconnecting the second monitor). After a few days the log had surpassed a hundred megabytes worth of `Window manager warning: Log level 8: meta_screen_get_monitor_geometry: assertion 'monitor >= 0 && monitor < screen->n_monitor_infos' failed`. Being a completely new user of cinnamon, I just naively ported the Gnome patch across (by hand), making an educated guess about how to resolve a slight change in context-lines, so even though it is a trivial-sized diff, I highly recommend someone double-check this PR with a strongly judgmental eye. Having said that, I applied the patch to the debian `muffin` source package and installed the built packages `gir1.2-meta-muffin-0.0_3.2.1-2_amd64.deb libmuffin0_3.2.1-2_amd64.deb muffin_3.2.1-2_amd64.deb muffin-common_3.2.1-2_all.deb` a few hours ago and my desktop has been running apparently fine (without the log-spamming) since then...