### PR TITLE
keybindings: fix erratic raise_or_lower behavior

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2963,7 +2963,7 @@ handle_raise_or_lower (MetaDisplay    *display,
     {
       MetaRectangle tmp, win_rect, above_rect;
       
-      if (above->mapped)
+      if (above->mapped && meta_window_should_be_showing(above))
         {
           meta_window_get_outer_rect (window, &win_rect);
           meta_window_get_outer_rect (above, &above_rect);


### PR DESCRIPTION
Function "handle_raise_or_lower (src/core/keybindings.c)" is called
when running 'raise-or-lower' on a window. This function iterates
through all the windows in the stack to determine if our window is
already on top or obscured. The problem is that the window stack
includes windows in another workspaces and also windows that are
minimized.

https://github.com/linuxmint/muffin/issues/277

gnome/mutter was also affected by this problem. I submitted this patch to them too and it has already been accepted.
bug report: https://bugzilla.gnome.org/show_bug.cgi?id=705200
commit: https://git.gnome.org/browse/mutter/commit/?id=58669e7