### PR TITLE
Reduce window shadow opacity

### DIFF
--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -127,17 +127,17 @@ static guint signals[LAST_SIGNAL] = { 0 };
 /* The first element in this array also defines the default parameters
  * for newly created classes */
 static MetaShadowClassInfo default_shadow_classes[] = {
-  { "normal",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
-  { "dialog",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
-  { "modal_dialog", { 6, -1, 0, 1, 210 }, { 3, -1, 0, 3, 128 } },
-  { "utility",      { 3, -1, 0, 1, 210 }, { 3, -1, 0, 1, 128 } },
-  { "border",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
-  { "menu",         { 6, -1, 0, 3, 210 }, { 3, -1, 0, 0, 128 } },
+  { "normal",       { 6, -1, 0, 3, 205 }, { 3, -1, 0, 3, 128 } },
+  { "dialog",       { 6, -1, 0, 3, 205 }, { 3, -1, 0, 3, 128 } },
+  { "modal_dialog", { 6, -1, 0, 1, 205 }, { 3, -1, 0, 3, 128 } },
+  { "utility",      { 3, -1, 0, 1, 205 }, { 3, -1, 0, 1, 128 } },
+  { "border",       { 6, -1, 0, 3, 205 }, { 3, -1, 0, 3, 128 } },
+  { "menu",         { 6, -1, 0, 3, 205 }, { 3, -1, 0, 0, 128 } },
 
   { "popup-menu",    { 1, -1, 0, 1, 128 }, { 1, -1, 0, 1, 128 } },
 
   { "dropdown-menu", { 1, 10, 0, 1, 128 }, { 1, 10, 0, 1, 128 } },
-  { "attached",      { 6, -1, 0, 1, 210 }, { 3, -1, 0, 3, 128 } }
+  { "attached",      { 6, -1, 0, 1, 205 }, { 3, -1, 0, 3, 128 } }
 };
 
 G_DEFINE_TYPE (MetaShadowFactory, meta_shadow_factory, G_TYPE_OBJECT);

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -127,17 +127,17 @@ static guint signals[LAST_SIGNAL] = { 0 };
 /* The first element in this array also defines the default parameters
  * for newly created classes */
 static MetaShadowClassInfo default_shadow_classes[] = {
-  { "normal",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "dialog",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "modal_dialog", { 6, -1, 0, 1, 255 }, { 3, -1, 0, 3, 128 } },
-  { "utility",      { 3, -1, 0, 1, 255 }, { 3, -1, 0, 1, 128 } },
-  { "border",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "menu",         { 6, -1, 0, 3, 255 }, { 3, -1, 0, 0, 128 } },
+  { "normal",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
+  { "dialog",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
+  { "modal_dialog", { 6, -1, 0, 1, 210 }, { 3, -1, 0, 3, 128 } },
+  { "utility",      { 3, -1, 0, 1, 210 }, { 3, -1, 0, 1, 128 } },
+  { "border",       { 6, -1, 0, 3, 210 }, { 3, -1, 0, 3, 128 } },
+  { "menu",         { 6, -1, 0, 3, 210 }, { 3, -1, 0, 0, 128 } },
 
   { "popup-menu",    { 1, -1, 0, 1, 128 }, { 1, -1, 0, 1, 128 } },
 
   { "dropdown-menu", { 1, 10, 0, 1, 128 }, { 1, 10, 0, 1, 128 } },
-  { "attached",      { 6, -1, 0, 1, 255 }, { 3, -1, 0, 3, 128 } }
+  { "attached",      { 6, -1, 0, 1, 210 }, { 3, -1, 0, 3, 128 } }
 };
 
 G_DEFINE_TYPE (MetaShadowFactory, meta_shadow_factory, G_TYPE_OBJECT);


### PR DESCRIPTION
Window shadows for selected windows are too opaque, they don't match most default themes. For instance, the title bar text on the default theme changes from #b2b2b2 -> #999999, a 10% difference. The window shadows however go from 50% opacity to 100% on selected windows. This change in opacity is especially noticeable when monitor brightness is set to low and should be reduced to make it easier on the eyes. This changes window shadows from 50% opacity on unselected to 80% opacity when selected, making them easier on the eyes without sacrificing any usability or clarity of which window is selected.

Before: https://i.imgur.com/YhqqCO8.png
After: https://i.imgur.com/01OXsLI.png