### PR TITLE
x11/xprops: Plug a memory leak

### DIFF
--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -873,7 +873,11 @@ size_hints_from_results (GetPropertyResults *results,
     return FALSE;
 
   if (results->n_items < OldNumPropSizeElements)
-    return FALSE;
+    {
+      XFree (results->prop);
+      results->prop = NULL;
+      return FALSE;
+    }
 
   raw = (xPropSizeHints*) results->prop;
 


### PR DESCRIPTION
https://github.com/GNOME/mutter/commit/5ba38a4ab6913fc5a4005ec3195df6bff5e89821#diff-b2af4604a281ca9065ebb6453a6dca38
adapted