### PR TITLE
Fixes workspace animation direction for grid systems.

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -547,7 +547,7 @@ get_wrapped_horizontal_direction (gint                from,
           ret = (to - from) <= ((num_workspaces - to) + from) ? META_MOTION_LEFT : META_MOTION_RIGHT;
         else
           ret = META_MOTION_LEFT;
-      else
+      else if (from > to)
         if (wrap)
           ret = (from - to) <= ((num_workspaces - from) + to) ? META_MOTION_RIGHT : META_MOTION_LEFT;
         else
@@ -560,7 +560,7 @@ get_wrapped_horizontal_direction (gint                from,
           ret = (to - from) <= ((num_workspaces - to) + from) ? META_MOTION_RIGHT : META_MOTION_LEFT;
         else
           ret = META_MOTION_RIGHT;
-      else
+      else if (from > to)
         if (wrap)
           ret = (from - to) <= ((num_workspaces - from) + to) ? META_MOTION_LEFT : META_MOTION_RIGHT;
         else


### PR DESCRIPTION
Right now, up/down animations proceed at angled directions. This seems
to be because |get_wrapped_horizontal_direction| assumes that |from|
and |to| are always different values.

In theory, this should resolve issue #302. However, I'm having a hard time figuring out how to verify this in a full cinnamon runtime. Can I run my locally-built muffin replacement with my stable cinnamon build? Do I need to do a full cinnamon build + all of its dependencies to be able to verify this muffin change? Some pointers would be appreciated. Thanks!