### PR TITLE
Report paint volumes

### DIFF
--- a/src/compositor/meta-background.c
+++ b/src/compositor/meta-background.c
@@ -146,6 +146,14 @@ meta_background_paint (ClutterActor *actor)
     }
 }
 
+static gboolean
+meta_background_get_paint_volume (ClutterActor       *actor,
+                                        ClutterPaintVolume *volume)
+{
+  return clutter_paint_volume_set_from_allocation (volume, actor);
+}
+
+
 static void
 meta_background_class_init (MetaBackgroundClass *klass)
 {
@@ -158,6 +166,7 @@ meta_background_class_init (MetaBackgroundClass *klass)
 
   actor_class->get_preferred_width = meta_background_get_preferred_width;
   actor_class->get_preferred_height = meta_background_get_preferred_height;
+  actor_class->get_paint_volume = meta_background_get_paint_volume;
   actor_class->paint = meta_background_paint;
 }
 

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -220,12 +220,20 @@ meta_window_group_paint (ClutterActor *actor)
   g_list_free (children);
 }
 
+static gboolean
+meta_window_group_get_paint_volume (ClutterActor       *actor,
+                                    ClutterPaintVolume *volume)
+{
+  return clutter_paint_volume_set_from_allocation (volume, actor);
+}
+
 static void
 meta_window_group_class_init (MetaWindowGroupClass *klass)
 {
   ClutterActorClass *actor_class = CLUTTER_ACTOR_CLASS (klass);
 
   actor_class->paint = meta_window_group_paint;
+  actor_class->get_paint_volume = meta_window_group_get_paint_volume;
 }
 
 static void


### PR DESCRIPTION
helps to avoid full stage redraws

see: https://bugzilla.gnome.org/show_bug.cgi?id=694988