### PR TITLE
screen.c: Refine definition of a fullscreen monitor

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3824,8 +3824,7 @@ check_fullscreen_func (gpointer data)
           if (meta_window_is_monitor_sized (window))
             covers_monitors = TRUE;
         }
-      else if (window->maximized_horizontally &&
-               window->maximized_vertically)
+      else
         {
           int monitor_index = meta_window_get_monitor (window);
           /* + 1 to avoid NULL */


### PR DESCRIPTION
Redefine a fullscreen monitor as one where there is a
fullscreen window *and* that window is the topmost on that monitor.

Currently, when a window is fullscreen, and the user switches to
another window, the panels remain hidden, still affected by the
no-longer-focused fullscreen window.