### PR TITLE
Make MetaButtonLayout usable from introspection

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -1584,8 +1584,11 @@ button_layout_handler (GVariant *value,
       g_strfreev (buttons);
     }
 
-  new_layout.left_buttons[i] = META_BUTTON_FUNCTION_LAST;
-  new_layout.left_buttons_has_spacer[i] = FALSE;
+  for (; i < MAX_BUTTONS_PER_CORNER; i++)
+    {
+      new_layout.left_buttons[i] = META_BUTTON_FUNCTION_LAST;
+      new_layout.left_buttons_has_spacer[i] = FALSE;
+    }
 
   i = 0;
   if (sides != NULL && sides[0] != NULL && sides[1] != NULL)
@@ -1643,8 +1646,11 @@ button_layout_handler (GVariant *value,
       g_strfreev (buttons);
     }
 
-  new_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
-  new_layout.right_buttons_has_spacer[i] = FALSE;
+  for (; i < MAX_BUTTONS_PER_CORNER; i++)
+    {
+      new_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
+      new_layout.right_buttons_has_spacer[i] = FALSE;
+    }
 
   g_strfreev (sides);
   

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -306,6 +306,14 @@ typedef enum {
 
 #define MAX_BUTTONS_PER_CORNER META_BUTTON_FUNCTION_LAST
 
+/* Keep array size in sync with MAX_BUTTONS_PER_CORNER */
+/**
+ * MetaButtonLayout:
+ * @left_buttons: (array fixed-size=10):
+ * @right_buttons: (array fixed-size=10):
+ * @left_buttons_has_spacer: (array fixed-size=10):
+ * @right_buttons_has_spacer: (array fixed-size=10):
+ */
 typedef struct _MetaButtonLayout MetaButtonLayout;
 struct _MetaButtonLayout
 {


### PR DESCRIPTION
Fix `meta_prefs_get_button_layout`, in continuation with 68307b8c120216a1c227cb571f9c7fc0e5a164a3.

See https://bugzilla.gnome.org/show_bug.cgi?id=689263