### PR TITLE
window.c: queue a fullscreen check when a window leaves a monitor

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4890,8 +4890,10 @@ meta_window_update_monitor (MetaWindow *window)
           window->screen->active_workspace != window->workspace)
         meta_window_change_workspace (window, window->screen->active_workspace);
 
-      if (old)
+      if (old) {
+        meta_screen_queue_check_fullscreen (window->screen);
         g_signal_emit_by_name (window->screen, "window-left-monitor", old->number, window);
+      }
       g_signal_emit_by_name (window->screen, "window-entered-monitor", window->monitor->number, window);
 
       g_signal_emit_by_name (window->screen, "window-monitor-changed", window, window->monitor->number);


### PR DESCRIPTION
Otherwise we don't get the 'in-fullscreen-changed' signal from MetaScreen
in certain fullscreen cases when moving windows.