### PR TITLE
compositor: map overlay window before redirecting windows

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -549,25 +549,16 @@ after_stage_paint (ClutterStage *stage,
     meta_window_actor_post_paint (l->data);
 }
 
-void
-meta_compositor_manage_screen (MetaCompositor *compositor,
-                               MetaScreen     *screen)
+static void
+redirect_windows (MetaCompositor *compositor,
+                  MetaScreen     *screen)
 {
-  MetaCompScreen *info;
-  MetaDisplay    *display       = meta_screen_get_display (screen);
-  Display        *xdisplay      = meta_display_get_xdisplay (display);
-  int             screen_number = meta_screen_get_screen_number (screen);
-  Window          xroot         = meta_screen_get_xroot (screen);
-  Window          xwin;
-  gint            width, height;
-  XWindowAttributes attr;
-  long            event_mask;
-  guint           n_retries;
-  guint           max_retries;
-
-  /* Check if the screen is already managed */
-  if (meta_screen_get_compositor_data (screen))
-    return;
+  MetaDisplay *display       = meta_screen_get_display (screen);
+  Display     *xdisplay      = meta_display_get_xdisplay (display);
+  Window       xroot         = meta_screen_get_xroot (screen);
+  int          screen_number = meta_screen_get_screen_number (screen);
+  guint        n_retries;
+  guint        max_retries;
 
   if (meta_get_replace_current_wm ())
     max_retries = 5;
@@ -600,6 +591,23 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
       n_retries++;
       g_usleep (G_USEC_PER_SEC);
     }
+}
+
+void
+meta_compositor_manage_screen (MetaCompositor *compositor,
+                               MetaScreen     *screen)
+{
+  MetaCompScreen *info;
+  MetaDisplay    *display       = meta_screen_get_display (screen);
+  Display        *xdisplay      = meta_display_get_xdisplay (display);
+  Window          xwin;
+  gint            width, height;
+  XWindowAttributes attr;
+  long            event_mask;
+
+  /* Check if the screen is already managed */
+  if (meta_screen_get_compositor_data (screen))
+    return;
 
   info = g_new0 (MetaCompScreen, 1);
   /*
@@ -702,6 +710,13 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
 
   clutter_actor_show (info->overlay_group);
   clutter_actor_show (info->stage);
+
+  /* Map overlay window before redirecting windows offscreen so we catch their
+   * contents until we show the stage.
+   */
+  XMapWindow (xdisplay, info->output);
+
+  redirect_windows (compositor, screen);
 
   compositor->have_x11_sync_object = meta_sync_ring_init (xdisplay);
 }


### PR DESCRIPTION
Based on
https://github.com/GNOME/mutter/commit/e15bc372255ac0954b22218a38427dde34c23118