### PR TITLE
[WIP] Cache the composite overlay window

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -217,11 +217,9 @@ get_output_window (MetaScreen *screen)
 {
   MetaDisplay *display = meta_screen_get_display (screen);
   Display     *xdisplay = meta_display_get_xdisplay (display);
-  Window       output, xroot;
+  Window       output;
   XWindowAttributes attr;
   long         event_mask;
-
-  xroot = meta_screen_get_xroot (screen);
 
   event_mask = FocusChangeMask |
                ExposureMask |
@@ -231,7 +229,7 @@ get_output_window (MetaScreen *screen)
                ButtonPressMask | ButtonReleaseMask |
                KeyPressMask | KeyReleaseMask;
 
-  output = XCompositeGetOverlayWindow (xdisplay, xroot);
+  output = display->composite_overlay_window;
 
   if (XGetWindowAttributes (xdisplay, output, &attr))
       {

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -84,6 +84,7 @@ struct _MetaDisplay
 
   Window leader_window;
   Window timestamp_pinging_window;
+  Window composite_overlay_window;
 
   /* Pull in all the names of atoms as fields; we will intern them when the
    * class is constructed.

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -549,6 +549,7 @@ meta_display_open (void)
   /* Offscreen unmapped window used for _NET_SUPPORTING_WM_CHECK,
    * created in screen_new
    */
+  the_display->composite_overlay_window = None;
   the_display->leader_window = None;
   the_display->timestamp_pinging_window = None;
 
@@ -868,6 +869,9 @@ meta_display_open (void)
       return FALSE;
     }
 
+  the_display->composite_overlay_window = XCompositeGetOverlayWindow (the_display->xdisplay,
+                                                                      ((MetaScreen*) the_display->screens->data)->xroot);
+
   /* We don't composite the windows here because they will be composited 
      faster with the call to meta_screen_manage_all_windows further down 
      the code */
@@ -1073,6 +1077,13 @@ meta_display_close (MetaDisplay *display,
 
   if (display->leader_window != None)
     XDestroyWindow (display->xdisplay, display->leader_window);
+  if (display->composite_overlay_window != None)
+    {
+      XCompositeReleaseOverlayWindow (display->xdisplay,
+                                      display->composite_overlay_window);
+
+      display->composite_overlay_window = None;
+    }
 
   XFlush (display->xdisplay);
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -944,8 +944,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
 	&& attrs->width == 1 && attrs->height == 1) ||
        xwindow == screen->wm_cm_selection_window ||
        xwindow == screen->guard_window ||
-       xwindow == XCompositeGetOverlayWindow (display->xdisplay,
-                                              screen->xroot)
+       xwindow == display->composite_overlay_window
       )
      ) {
     meta_verbose ("Not managing our own windows\n");


### PR DESCRIPTION
XCompositeGetOverlayWindow was getting called on every window mapped.

Partially based on:
https://github.com/GNOME/mutter/commit/05899596d10918df5359d89baa82e6fedd0ae208