### PR TITLE
Remove remaining deprecated Cogl 1.0 usage

### DIFF
--- a/src/compositor/cogl-utils.c
+++ b/src/compositor/cogl-utils.c
@@ -24,6 +24,7 @@
 #if HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <clutter/clutter.h>
 #include "cogl-utils.h"
 #include <meta/errors.h>
 
@@ -45,7 +46,7 @@
  *
  * Return value: (transfer full): a newly created Cogl texture
  */
-LOCAL_SYMBOL CoglHandle
+CoglTexture *
 meta_create_color_texture_4ub (guint8           red,
                                guint8           green,
                                guint8           blue,
@@ -70,49 +71,36 @@ meta_create_color_texture_4ub (guint8           red,
                                      4, pixel);
 }
 
-
-/* Based on gnome-shell/src/st/st-private.c:_st_create_texture_material.c */
-
-/**
- * meta_create_texture_material:
- * @src_texture: (allow-none): texture to use initially for the layer
- *
- * Creates a material with a single layer. Using a common template
- * allows sharing a shader for different uses in Muffin. To share the same
- * shader with all other materials that are just texture plus opacity
- * would require Cogl fixes.
- * (See http://bugzilla.clutter-project.org/show_bug.cgi?id=2425)
- *
- * Return value: (transfer full): a newly created Cogl material
- */
-LOCAL_SYMBOL CoglHandle
-meta_create_texture_material (CoglHandle src_texture)
+CoglPipeline *
+meta_create_texture_pipeline (CoglTexture *src_texture)
 {
-  static CoglHandle texture_material_template = COGL_INVALID_HANDLE;
-  CoglHandle material;
+  static CoglPipeline *texture_pipeline_template = NULL;
+  CoglPipeline *pipeline;
 
-  /* We use a material that has a dummy texture as a base for all
-     texture materials. The idea is that only the Cogl texture object
+  /* We use a pipeline that has a dummy texture as a base for all
+     texture pipelines. The idea is that only the Cogl texture object
      would be different in the children so it is likely that Cogl will
      be able to share GL programs between all the textures. */
-  if (G_UNLIKELY (texture_material_template == COGL_INVALID_HANDLE))
+  if (G_UNLIKELY (texture_pipeline_template == NULL))
     {
-      CoglHandle dummy_texture;
+      CoglTexture *dummy_texture;
+      CoglContext *ctx = clutter_backend_get_cogl_context (clutter_get_default_backend ());
 
       dummy_texture = meta_create_color_texture_4ub (0xff, 0xff, 0xff, 0xff,
                                                      COGL_TEXTURE_NONE);
 
-      texture_material_template = cogl_material_new ();
-      cogl_material_set_layer (texture_material_template, 0, dummy_texture);
-      cogl_handle_unref (dummy_texture);
+
+      texture_pipeline_template = cogl_pipeline_new (ctx);
+      cogl_pipeline_set_layer_texture (texture_pipeline_template, 0, dummy_texture);
+      cogl_object_unref (dummy_texture);
     }
 
-  material = cogl_material_copy (texture_material_template);
+  pipeline = cogl_pipeline_copy (texture_pipeline_template);
 
-  if (src_texture != COGL_INVALID_HANDLE)
-    cogl_material_set_layer (material, 0, src_texture);
+  if (src_texture != NULL)
+    cogl_pipeline_set_layer_texture (pipeline, 0, src_texture);
 
-  return material;
+  return pipeline;
 }
 
 /********************************************************************************************/
@@ -202,78 +190,3 @@ meta_cogl_texture_new_from_data_wrapper                (int  width,
 
     return texture;
 }
-
-/**
- * meta_cogl_texture_new_from_file_wrapper: (skip)
- *
- * Decides whether to use the newer (apparently safer)
- * cogl_texture_2d_new_from_file or the older cogl_texture_new_from_file
- * depending on if the GPU supports it.
- */
-
-CoglTexture *
-meta_cogl_texture_new_from_file_wrapper         (const char *filename,
-                                           CoglTextureFlags  flags,
-                                            CoglPixelFormat  internal_format)
-{
-    CoglTexture *texture = NULL;
-    CoglError *error = NULL;
-
-    if (hardware_supports_npot_sizes ())
-      {
-        texture = COGL_TEXTURE (cogl_texture_2d_new_from_file (cogl_context,
-                                                               filename,
-                                                               &error));
-      }
-    else
-      {
-        texture = cogl_texture_new_from_file (filename,
-                                              flags,
-                                              internal_format,
-                                              &error);
-      }
-
-    if (error)
-      {
-        meta_verbose ("cogl_texture_(2d)_new_from_file failed: %s\n", error->message);
-        cogl_error_free (error);
-      }
-
-    return texture;
-}
-
-/**
- * meta_cogl_texture_new_with_size_wrapper: (skip)
- *
- * Decides whether to use the newer (apparently safer)
- * cogl_texture_2d_new_with_size or the older cogl_texture_new_with_size
- * depending on if the GPU supports it.
- */
-
-CoglTexture *
-meta_cogl_texture_new_with_size_wrapper           (int width,
-                                                   int height,
-                                      CoglTextureFlags flags,
-                                       CoglPixelFormat internal_format)
-{
-    CoglTexture *texture = NULL;
-
-    clamp_sizes (&width, &height);
-
-    if (hardware_supports_npot_sizes ())
-      {
-        texture = COGL_TEXTURE (cogl_texture_2d_new_with_size (cogl_context,
-                                                               width,
-                                                               height
-                                                              ));
-      }
-    else
-      {
-        texture = cogl_texture_new_with_size (width, height,
-                                              flags,
-                                              internal_format);
-      }
-
-    return texture;
-}
-

--- a/src/compositor/cogl-utils.h
+++ b/src/compositor/cogl-utils.h
@@ -26,12 +26,12 @@
 #include <cogl/cogl.h>
 #include <clutter/clutter.h>
 
-CoglHandle meta_create_color_texture_4ub (guint8           red,
-                                          guint8           green,
-                                          guint8           blue,
-                                          guint8           alpha,
-                                          CoglTextureFlags flags);
-CoglHandle meta_create_texture_material  (CoglHandle src_texture);
+CoglTexture * meta_create_color_texture_4ub (guint8           red,
+                                             guint8           green,
+                                             guint8           blue,
+                                             guint8           alpha,
+                                             CoglTextureFlags flags);
+CoglPipeline * meta_create_texture_pipeline (CoglTexture *texture);
 
 CoglTexture * meta_cogl_texture_new_from_data_wrapper                (int  width,
                                                                       int  height,
@@ -40,14 +40,5 @@ CoglTexture * meta_cogl_texture_new_from_data_wrapper                (int  width
                                                           CoglPixelFormat  internal_format,
                                                                       int  rowstride,
                                                             const uint8_t *data);
-
-CoglTexture * meta_cogl_texture_new_from_file_wrapper         (const char *filename,
-                                                         CoglTextureFlags  flags,
-                                                          CoglPixelFormat  internal_format);
-
-CoglTexture * meta_cogl_texture_new_with_size_wrapper                (int  width,
-                                                                      int  height,
-                                                         CoglTextureFlags  flags,
-                                                          CoglPixelFormat  internal_format);
 
 #endif /* __META_COGL_UTILS_H__ */

--- a/src/compositor/meta-background.h
+++ b/src/compositor/meta-background.h
@@ -35,9 +35,9 @@ GType meta_background_get_type (void);
 ClutterActor * meta_background_new (MetaScreen *screen);
 
 void meta_background_set_layer           (MetaBackground       *self,
-                                          CoglHandle           texture);
+                                          CoglTexture          *texture);
 void meta_background_set_layer_wrap_mode (MetaBackground       *self,
-                                          CoglMaterialWrapMode  wrap_mode);
+                                          CoglPipelineWrapMode  wrap_mode);
 void meta_background_set_visible_region  (MetaBackground       *self,
                                           cairo_region_t       *visible_region);
 

--- a/src/compositor/meta-shadow-factory-private.h
+++ b/src/compositor/meta-shadow-factory-private.h
@@ -40,7 +40,7 @@ typedef struct _MetaShadow MetaShadow;
 
 MetaShadow *meta_shadow_ref         (MetaShadow            *shadow);
 void        meta_shadow_unref       (MetaShadow            *shadow);
-CoglHandle  meta_shadow_get_texture (MetaShadow            *shadow);
+CoglTexture*meta_shadow_get_texture (MetaShadow            *shadow);
 void        meta_shadow_paint       (MetaShadow            *shadow,
                                      int                    window_x,
                                      int                    window_y,

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -72,8 +72,8 @@ struct _MetaShadow
 
   MetaShadowFactory *factory;
   MetaShadowCacheKey key;
-  CoglHandle texture;
-  CoglHandle material;
+  CoglTexture *texture;
+  CoglPipeline *pipeline;
 
   /* The outer order is the distance the shadow extends outside the window
    * shape; the inner border is the unscaled portion inside the window
@@ -182,8 +182,8 @@ meta_shadow_unref (MetaShadow *shadow)
         }
 
       meta_window_shape_unref (shadow->key.shape);
-      cogl_handle_unref (shadow->texture);
-      cogl_handle_unref (shadow->material);
+      cogl_object_unref (shadow->texture);
+      cogl_object_unref (shadow->pipeline);
 
       g_slice_free (MetaShadow, shadow);
     }
@@ -225,10 +225,10 @@ meta_shadow_paint (MetaShadow     *shadow,
   int dest_y[4];
   int n_x, n_y;
 
-  cogl_material_set_color4ub (shadow->material,
+  cogl_pipeline_set_color4ub (shadow->pipeline,
                               opacity, opacity, opacity, opacity);
 
-  cogl_set_source (shadow->material);
+  cogl_set_source (shadow->pipeline);
 
   if (shadow->scale_width)
     {
@@ -808,7 +808,7 @@ make_shadow (MetaShadow     *shadow,
   cairo_region_destroy (column_convolve_region);
   g_free (buffer);
 
-  shadow->material = meta_create_texture_material (shadow->texture);
+  shadow->pipeline = meta_create_texture_pipeline (shadow->texture);
 }
 
 static MetaShadowParams *

--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -327,9 +327,8 @@ meta_shaped_texture_paint (ClutterActor *actor)
   guint tex_width, tex_height;
   ClutterActorBox alloc;
 
-  static CoglPipeline *pipeline_template = NULL;
-  static CoglPipeline *pipeline_unshaped_template = NULL;
-
+  CoglPipeline *pipeline_template = NULL;
+  CoglPipeline *pipeline_unshaped_template = NULL;
   CoglPipeline *pipeline;
 
   if (priv->clip_region && cairo_region_is_empty (priv->clip_region))

--- a/src/compositor/meta-texture-tower.h
+++ b/src/compositor/meta-texture-tower.h
@@ -56,13 +56,13 @@ typedef struct _MetaTextureTower MetaTextureTower;
 MetaTextureTower *meta_texture_tower_new               (void);
 void              meta_texture_tower_free              (MetaTextureTower *tower);
 void              meta_texture_tower_set_base_texture  (MetaTextureTower *tower,
-                                                        CoglHandle        texture);
+                                                        CoglTexture      *texture);
 void              meta_texture_tower_update_area       (MetaTextureTower *tower,
                                                         int               x,
                                                         int               y,
                                                         int               width,
                                                         int               height);
-CoglHandle        meta_texture_tower_get_paint_texture (MetaTextureTower *tower);
+CoglTexture     *meta_texture_tower_get_paint_texture (MetaTextureTower *tower);
 
 G_BEGIN_DECLS
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -964,7 +964,7 @@ static void
 meta_window_actor_damage_all (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  CoglHandle texture;
+  CoglTexture *texture;
 
   if (!priv->needs_damage_all)
     return;
@@ -1888,7 +1888,7 @@ check_needs_pixmap (MetaWindowActor *self)
 
   if (priv->back_pixmap == None)
     {
-      CoglHandle texture;
+      CoglTexture *texture;
 
       meta_error_trap_push (display);
 

--- a/src/meta/meta-shaped-texture.h
+++ b/src/meta/meta-shaped-texture.h
@@ -70,7 +70,7 @@ void meta_shaped_texture_update_area (MetaShapedTexture *stex,
 void meta_shaped_texture_set_pixmap (MetaShapedTexture *stex,
                                      Pixmap             pixmap);
 
-CoglHandle meta_shaped_texture_get_texture (MetaShapedTexture *stex);
+CoglTexture *meta_shaped_texture_get_texture (MetaShapedTexture *stex);
 
 void meta_shaped_texture_set_shape_region (MetaShapedTexture *stex,
                                            cairo_region_t    *region);


### PR DESCRIPTION
Partially based on:
https://github.com/gnome/mutter/commit/7f6a77232faa0560080e03834b8cec7aeb505be7

This is a straight-forward API update with no upstream refactoring. Adapting the changes directly breaks shadows.