### PR TITLE
Only emit tiling-related signals when needed

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1943,7 +1943,7 @@ meta_screen_tile_preview_update_timeout (gpointer data)
                                                                  snap_osd_timeout,
                                                                  screen);
     }
-    else
+    else if (screen->tile_preview_visible)
     {
         meta_compositor_hide_tile_preview (screen->display->compositor,
                                            screen);
@@ -1988,6 +1988,9 @@ meta_screen_tile_preview_hide (MetaScreen *screen)
     screen->tile_preview_timeout_id = 0;
   }
 
+  if (!screen->tile_preview_visible)
+    return;
+
   meta_compositor_hide_tile_preview (screen->display->compositor,
                                      screen);
   screen->tile_preview_visible = FALSE;
@@ -2029,7 +2032,7 @@ meta_screen_tile_hud_update_timeout (gpointer data)
                                                                  snap_osd_timeout,
                                                                  screen);
     }
-    else
+    else if (screen->tile_hud_visible)
     {
         meta_compositor_hide_hud_preview (screen->display->compositor,
                                           screen);
@@ -2085,6 +2088,9 @@ meta_screen_tile_hud_hide (MetaScreen *screen)
     g_source_remove (screen->tile_hud_timeout_id);
     screen->tile_hud_timeout_id = 0;
   }
+
+  if (!screen->tile_hud_visible)
+    return;
 
   meta_compositor_hide_hud_preview (screen->display->compositor,
                                     screen);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9465,36 +9465,36 @@ update_move (MetaWindow  *window,
 
     window->mouse_on_edge = meta_window_mouse_on_edge (window, x, y);
 
-    if (meta_prefs_get_edge_tiling ()) {
-        if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
-            meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
-        else
-            meta_screen_tile_hud_update (window->screen, TRUE, TRUE);
-    }
-
     MetaRectangle min_size, max_size, target_size;
     gboolean hminbad = FALSE;
     gboolean vminbad = FALSE;
     if (window->tile_mode != META_TILE_NONE) {
-        get_size_limits (window, NULL, FALSE, &min_size, &max_size);
-        meta_window_get_current_tile_area (window, &target_size);
-        MetaFrameBorders borders;
-        meta_frame_calc_borders (window->frame, &borders);
-        meta_window_unextend_by_frame (window, &target_size, &borders);
-        hminbad = target_size.width < min_size.width;
-        vminbad = target_size.height < min_size.height;
+      if (meta_prefs_get_edge_tiling ()) {
+        if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
+            meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
+        else
+            meta_screen_tile_hud_update (window->screen, TRUE, TRUE);
+      }
+      get_size_limits (window, NULL, FALSE, &min_size, &max_size);
+      meta_window_get_current_tile_area (window, &target_size);
+      MetaFrameBorders borders;
+      meta_frame_calc_borders (window->frame, &borders);
+      meta_window_unextend_by_frame (window, &target_size, &borders);
+      hminbad = target_size.width < min_size.width;
+      vminbad = target_size.height < min_size.height;
+
+      /* Delay showing the tile preview slightly to make it more unlikely to
+        * trigger it unwittingly, e.g. when shaking loose the window or moving
+        * it to another monitor.
+        */
+
+        if (!hminbad && !vminbad)
+            meta_screen_tile_preview_update (window->screen,
+                                            window->tile_mode != META_TILE_NONE &&
+                                            !meta_screen_tile_preview_get_visible (window->screen));
+        else
+            meta_screen_tile_preview_hide (window->screen);
     }
-  /* Delay showing the tile preview slightly to make it more unlikely to
-   * trigger it unwittingly, e.g. when shaking loose the window or moving
-   * it to another monitor.
-   */
-    
-    if (!hminbad && !vminbad)
-        meta_screen_tile_preview_update (window->screen,
-                                         window->tile_mode != META_TILE_NONE &&
-                                         !meta_screen_tile_preview_get_visible (window->screen));
-    else
-        meta_screen_tile_preview_hide (window->screen);
 
   meta_window_get_client_root_coords (window, &old);
 


### PR DESCRIPTION
- In screen, `meta_compositor_hide_tile_preview` and `meta_compositor_hide_hud_preview` are now guarded by a check on `tile_preview_visible` and `tile_hud_visible` respectively.
- In window, in `update_move`, calls to those functions now only occur when `tile_mode` is not `META_TILE_NONE`.

Not seeing any regressions with tiling, snapping, and the rendering of their related OSDs in Cinnamon. I used the following proxy in windowManager.js to see what functions are getting called and when.

```js
let keys = Object.getOwnPropertyNames(WindowManager.prototype);
for (let i = 0; i < keys.length; i++) {
    if (typeof WindowManager.prototype[keys[i]] === 'function') {
      let orig = WindowManager.prototype[keys[i]];
      WindowManager.prototype[keys[i]] = new Proxy(orig, {
        apply(target, thisA, args) {
          log(new Error().stack)
          return target.apply(thisA, args);
        }
      });
    }
 }
```
Then changed the Lang.bind signal callbacks to arrow functions to remove `self-hosted` from the stack, and saw `hide-tile-preview`, `hide-hud-preview`, and `hide-snap-osd` signal callback invocations were occurring countless times per second when a window is being moved. While this isn't a major issue, JS function calls are more expensive and could block the main thread - especially noticeable when doing things the user changes in real time, like changing a window's position.