### PR TITLE
clutter: Improve smoothness of visuals

### DIFF
--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -69,10 +69,8 @@ struct _ClutterMasterClockDefault
   /* the previous state of the clock, in usecs, used to compute the delta */
   gint64 prev_tick;
 
-  /* the ideal frame interval in usecs (inverse of your max refresh rate) */
-  gint64 frame_interval;
-
 #ifdef CLUTTER_ENABLE_DEBUG
+  gint64 frame_budget;
   gint64 remaining_budget;
 #endif
 
@@ -266,41 +264,6 @@ master_clock_reschedule_stage_updates (ClutterMasterClockDefault *master_clock,
     }
 }
 
-static gint64
-estimate_next_presentation_time (ClutterMasterClockDefault *master_clock)
-{
-  gint64 frame_phase, now, now_phase, undershoot;
-
-  /* In future if this was updated from the backend's (maximum) refresh rate
-   * then that would fix: https://bugzilla.gnome.org/show_bug.cgi?id=781296
-   */
-  master_clock->frame_interval = G_USEC_PER_SEC /
-                                 clutter_get_default_frame_rate ();
-
-  now = g_source_get_time (master_clock->source);
-  now_phase = now % master_clock->frame_interval;
-
-  /* To be precise we would like to use:
-   *   frame_phase = a_recent_hardware_presentation_time % frame_interval;
-   * where hardware_presentation_time must be using the same clock as
-   * g_source_get_time. Unfortunately they're different clocks right now
-   * so we can't.
-   *   Alternatively, we could replace g_source_get_time in future with the
-   * current time in the clutter/cogl presentation clock, but that function
-   * also doesn't exist yet.
-   *   Until we can get either of those, zero is fine. It just means latency
-   * will be suboptimal by half a frame on average. We still get maximum
-   * smoothness this way...
-   */
-  frame_phase = 0;
-
-  undershoot = frame_phase - now_phase;
-  if (undershoot < 0)
-    undershoot += master_clock->frame_interval;
-
-  return now + undershoot;
-}
-
 /*
  * master_clock_next_frame_delay:
  * @master_clock: a #ClutterMasterClock
@@ -313,8 +276,7 @@ estimate_next_presentation_time (ClutterMasterClockDefault *master_clock)
 static gint
 master_clock_next_frame_delay (ClutterMasterClockDefault *master_clock)
 {
-  gint64 now, target_presentation_time, ideal_render_start;  /* timestamps */
-  gint64 ideal_prerender_time, lateness;  /* deltas */
+  gint64 now, next;
   gint swap_delay;
 
   if (!master_clock_is_running (master_clock))
@@ -345,45 +307,46 @@ master_clock_next_frame_delay (ClutterMasterClockDefault *master_clock)
       return 0;
     }
 
-  now = g_source_get_time (master_clock->source);
-
-  /* As first preference, try to carry on smoothly from the previous frame,
-   * even if that means we start rendering frame 2 before frame 1 has been
-   * presented. This is why we ignore estimate_next_presentation_time here...
-   */
-  target_presentation_time = master_clock->prev_tick +
-                             master_clock->frame_interval;
-  ideal_prerender_time = master_clock->frame_interval;
-  ideal_render_start = target_presentation_time - ideal_prerender_time;
-  lateness = now - ideal_render_start;
-
-  /* If we just woke from idle then try to improve the smoothness of the first
-   * two frames some more. Otherwise the first frame would appear too old
-   * relative to the second frame.
-   */
-  if (lateness >= master_clock->frame_interval)
+  if (master_clock->prev_tick == 0)
     {
-      target_presentation_time = estimate_next_presentation_time (master_clock);
-      ideal_render_start = target_presentation_time - ideal_prerender_time;
-      lateness = now - ideal_render_start;
+      /* If we weren't previously running, then draw the next frame
+       * immediately
+       */
+      CLUTTER_NOTE (SCHEDULER, "draw the first frame immediately");
+      return 0;
     }
 
-  if (lateness > 0)
+  /* Otherwise, wait at least 1/frame_rate seconds since we last
+   * started a frame
+   */
+  now = g_source_get_time (master_clock->source);
+
+  next = master_clock->prev_tick;
+
+  /* If time has gone backwards then there's no way of knowing how
+     long we should wait so let's just dispatch immediately */
+  if (now <= next)
     {
-      CLUTTER_NOTE (SCHEDULER, "No wait required. We're already late.");
+      CLUTTER_NOTE (SCHEDULER, "Time has gone backwards");
+
+      return 0;
+    }
+
+  next += (1000000L / clutter_get_default_frame_rate ());
+
+  if (next <= now)
+    {
+      CLUTTER_NOTE (SCHEDULER, "Less than %lu microsecs",
+                    1000000L / (gulong) clutter_get_default_frame_rate ());
+
       return 0;
     }
   else
     {
-      /* We +1 here to avoid premature dispatches that would otherwise occur
-       * repeatedly during the 1ms before 'ideal_render_start'. We don't care
-       * if this makes the final dispatch 1ms late because the smoothing
-       * algorithm corrects that, and it's much better than attempting to
-       * render more frames than the hardware can physically display...
-       */
-      gint millisec_delay = -lateness / 1000 + 1;
-      CLUTTER_NOTE (SCHEDULER, "Waiting %dms", millisec_delay);
-      return millisec_delay;
+      CLUTTER_NOTE (SCHEDULER, "Waiting %" G_GINT64_FORMAT " msecs",
+                   (next - now) / 1000);
+
+      return (next - now) / 1000;
     }
 }
 
@@ -569,34 +532,16 @@ clutter_clock_dispatch (GSource     *source,
   ClutterMasterClockDefault *master_clock = clock_source->master_clock;
   gboolean stages_updated = FALSE;
   GSList *stages;
-  gint64 smooth_tick;
+
+  CLUTTER_NOTE (SCHEDULER, "Master clock [tick]");
 
   _clutter_threads_acquire_lock ();
 
   /* Get the time to use for this frame */
-  smooth_tick = estimate_next_presentation_time (master_clock);
-  if (smooth_tick <= master_clock->prev_tick)
-    {
-      /* Ordinarily this will never happen. But after we fix bug 781296, it
-       * could happen in the rare case when the ideal frame_interval changes,
-       * such as video mode switching or hotplugging monitors. As such it is
-       * not considered a bug (unless it's happening without mode switching
-       * or hotplugging).
-       */
-      CLUTTER_NOTE (SCHEDULER, "Master clock [tick] was premature (skipped)");
-      _clutter_threads_release_lock ();
-      return G_SOURCE_CONTINUE;
-    }
-
-  master_clock->cur_tick = smooth_tick;
-  if (master_clock->prev_tick)
-    CLUTTER_NOTE (SCHEDULER, "Master clock [tick] %+ldus",
-                  (long) (master_clock->cur_tick - master_clock->prev_tick));
-  else
-    CLUTTER_NOTE (SCHEDULER, "Master clock [tick] startup");
+  master_clock->cur_tick = g_source_get_time (source);
 
 #ifdef CLUTTER_ENABLE_DEBUG
-  master_clock->remaining_budget = master_clock->frame_interval;
+  master_clock->remaining_budget = master_clock->frame_budget;
 #endif
 
   /* We need to protect ourselves against stages being destroyed during
@@ -635,7 +580,7 @@ clutter_clock_dispatch (GSource     *source,
 
   _clutter_threads_release_lock ();
 
-  return G_SOURCE_CONTINUE;
+  return TRUE;
 }
 
 static void
@@ -667,7 +612,10 @@ clutter_master_clock_default_init (ClutterMasterClockDefault *self)
   self->idle = FALSE;
   self->ensure_next_iteration = FALSE;
   self->paused = FALSE;
-  self->frame_interval = G_USEC_PER_SEC / 60; /* Will be refined at runtime */
+
+#ifdef CLUTTER_ENABLE_DEBUG
+  self->frame_budget = G_USEC_PER_SEC / 60;
+#endif
 
   g_source_set_priority (source, CLUTTER_PRIORITY_REDRAW);
   g_source_set_can_recurse (source, FALSE);

--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -39,7 +39,7 @@
 #include "clutter-private.h"
 #include "clutter-stage-manager-private.h"
 #include "clutter-stage-private.h"
-#include "clutter-mutter.h"
+#include "clutter-muffin.h"
 
 #ifdef CLUTTER_ENABLE_DEBUG
 #define clutter_warn_if_over_budget(master_clock,start_time,section)    G_STMT_START  { \

--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -39,6 +39,7 @@
 #include "clutter-private.h"
 #include "clutter-stage-manager-private.h"
 #include "clutter-stage-private.h"
+#include "clutter-mutter.h"
 
 #ifdef CLUTTER_ENABLE_DEBUG
 #define clutter_warn_if_over_budget(master_clock,start_time,section)    G_STMT_START  { \
@@ -614,7 +615,9 @@ clutter_master_clock_default_init (ClutterMasterClockDefault *self)
   source = clutter_clock_source_new (self);
   self->source = source;
 
-  self->preferred_sync_method = SYNC_PRESENTATION_TIME;
+  self->preferred_sync_method = _clutter_get_sync_to_vblank () ?
+                                SYNC_PRESENTATION_TIME :
+                                SYNC_NONE;
   self->active_sync_method = self->preferred_sync_method;
 
   self->idle = FALSE;

--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -56,11 +56,17 @@
 #endif
 
 typedef enum _SyncMethod /* In order of priority */
-{                        /* WORKS      LATENCY      SMOOTHNESS             */
+{                        /* SUPPORTED  LATENCY      SMOOTHNESS             */
   SYNC_NONE = 0,         /* Always     High         Poor                   */
   SYNC_FALLBACK,         /* Always     Medium       Medium                 */
-  SYNC_SWAP_THROTTLING,  /* Sometimes  Medium-high  Medium, sometimes best */
-  SYNC_PRESENTATION_TIME /* Sometimes  Low          Good, sometimes best   */
+  SYNC_SWAP_THROTTLING,  /* Usually    Medium-high  Medium, sometimes best */
+  SYNC_PRESENTATION_TIME /* Usually    Low          Good, sometimes best   */
+                         /* ^ As you can see SWAP_THROTTLING doesn't add much
+                              value. And it does create the the very real
+                              risk of blocking the main loop for up to 16ms
+                              at a time. So it might be a good idea to retire
+                              it in future and instead just make the backends
+                              use swap interval 0 + PRESENTATION_TIME. */
 } SyncMethod;
 
 typedef struct _ClutterClockSource              ClutterClockSource;

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -184,7 +184,10 @@ clutter_stage_cogl_schedule_update (ClutterStageWindow *stage_window,
 
   /* FIXME (?) - On X11 this is performing worse than swap throttling. */
 
-  refresh_interval = 0;//(gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
+  if (cogl_clutter_winsys_has_feature (COGL_WINSYS_FEATURE_SWAP_REGION))
+    refresh_interval = (gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
+  else
+    refresh_interval = 0;
 
   target_presentation_time = stage_cogl->last_presentation_time
                            + stage_cogl->pending_swaps * refresh_interval

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -151,53 +151,94 @@ clutter_stage_cogl_schedule_update (ClutterStageWindow *stage_window,
 {
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
   gint64 now;
-  float refresh_rate;
+  gint64 target_presentation_time;
   gint64 refresh_interval;
+  /*
+   * want_prerender_frames must be at least 1 (double buffered).
+   * Feel free to try triple buffering: want_prerender_frames = 2
+   * but it's not a good idea to default to that yet because filling all the
+   * buffers will cause the backend to block and throttle buffer releases even
+   * to unthrottled clients (swap interval 0).
+   */
+  gint want_prerender_frames = 1;
+  gint can_prerender_frames;
+  gint will_prerender_frames;
+  gint64 prerender_time;
 
   if (stage_cogl->update_time != -1)
     return;
 
   now = g_get_monotonic_time ();
 
-  if (sync_delay < 0)
-    {
-      stage_cogl->update_time = now;
-      return;
-    }
-
-  /* We only extrapolate presentation times for 150ms  - this is somewhat
-   * arbitrary. The reasons it might not be accurate for larger times are
-   * that the refresh interval might be wrong or the vertical refresh
-   * might be downclocked if nothing is going on onscreen.
+  /* This has been seen on Ironlake + X11 + DRI3 systems.
+   * TODO: Investigate more, but this workaround also works fine...
    */
-  if (stage_cogl->last_presentation_time == 0||
-      stage_cogl->last_presentation_time < now - 150000)
+  if (stage_cogl->pending_swaps > 4 && !stage_cogl->broken_driver)
     {
-      stage_cogl->update_time = now;
+      g_warning ("BUG: Runaway pending swap count. This may be a bug in your "
+                 "graphics driver, or in mutter.");
+      stage_cogl->broken_driver = TRUE;
+    }
+
+  if (sync_delay < 0 ||
+      stage_cogl->broken_driver ||
+      stage_cogl->last_presentation_time <= 0 ||
+      stage_cogl->refresh_rate <= 0.0)
+    {
+      /* -1 now means that hardware presentation times are unsupported and
+       * that the caller needs to find a different way to achieve frame
+       * scheduling.
+       */
+      stage_cogl->update_time = -1;
       return;
     }
 
-  refresh_rate = stage_cogl->refresh_rate;
-  if (refresh_rate == 0.0)
-    refresh_rate = 60.0;
+  refresh_interval = (gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
 
-  refresh_interval = (gint64) (0.5 + 1000000 / refresh_rate);
-  if (refresh_interval == 0)
-    refresh_interval = 16667; /* 1/60th second */
+  target_presentation_time = stage_cogl->last_presentation_time
+                           + stage_cogl->pending_swaps * refresh_interval
+                           + refresh_interval;
 
-  stage_cogl->update_time = stage_cogl->last_presentation_time + 1000 * sync_delay;
+  if (target_presentation_time < now)
+    {
+      /* If we missed some frames then find a more current target time that's
+       * in phase with the display hardware. This is logically equivalent to:
+       *
+       *   while (target_presentation_time < now)
+       *     target_presentation_time += refresh_interval;
+       *
+       * but with a better worst-case execution time...
+       */
+      target_presentation_time = now
+                               - now % refresh_interval
+                               + stage_cogl->last_presentation_time %
+                                 refresh_interval;
 
-  while (stage_cogl->update_time < now)
-    stage_cogl->update_time += refresh_interval;
+      if (target_presentation_time < now)
+        target_presentation_time += refresh_interval;
+    }
+
+  can_prerender_frames = MAX (1, stage_cogl->max_buffer_age - 1);
+  will_prerender_frames = MIN (want_prerender_frames, can_prerender_frames);
+
+  prerender_time = will_prerender_frames * refresh_interval
+                 - 1000 * sync_delay;
+
+  stage_cogl->update_time = target_presentation_time - prerender_time;
+
+  /* Are we repeating ourselves? If a clear and reschedule occur too close
+   * together while a swap is pending then we will often land on the same
+   * result as last time. That's not useful because it only suggests to the
+   * caller to try and render the same frame twice.
+   */
+  if (stage_cogl->update_time <= stage_cogl->last_update_time)
+    stage_cogl->update_time = stage_cogl->last_update_time + refresh_interval;
 }
 
 static gint64
 clutter_stage_cogl_get_update_time (ClutterStageWindow *stage_window)
 {
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
-
-  if (stage_cogl->pending_swaps)
-    return -1; /* in the future, indefinite */
 
   return stage_cogl->update_time;
 }
@@ -207,6 +248,7 @@ clutter_stage_cogl_clear_update_time (ClutterStageWindow *stage_window)
 {
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
 
+  stage_cogl->last_update_time = stage_cogl->update_time;
   stage_cogl->update_time = -1;
 }
 
@@ -632,6 +674,9 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
           if (valid_buffer_age (view_cogl, age))
             {
               cairo_rectangle_int_t damage_region;
+
+              if (age > stage_cogl->max_buffer_age)
+                stage_cogl->max_buffer_age = age;
 
               *current_fb_damage = fb_clip_region;
 

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -170,18 +170,7 @@ clutter_stage_cogl_schedule_update (ClutterStageWindow *stage_window,
 
   now = g_get_monotonic_time ();
 
-  /* This has been seen on Ironlake + X11 + DRI3 systems.
-   * TODO: Investigate more, but this workaround also works fine...
-   */
-  if (stage_cogl->pending_swaps > 4 && !stage_cogl->broken_driver)
-    {
-      g_warning ("BUG: Runaway pending swap count. This may be a bug in your "
-                 "graphics driver, or in mutter.");
-      stage_cogl->broken_driver = TRUE;
-    }
-
   if (sync_delay < 0 ||
-      stage_cogl->broken_driver ||
       stage_cogl->last_presentation_time <= 0 ||
       stage_cogl->refresh_rate <= 0.0)
     {

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -182,6 +182,8 @@ clutter_stage_cogl_schedule_update (ClutterStageWindow *stage_window,
       return;
     }
 
+  /* FIXME (?) - On X11 this is performing worse than swap throttling. */
+
   refresh_interval = (gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
 
   target_presentation_time = stage_cogl->last_presentation_time

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -184,7 +184,7 @@ clutter_stage_cogl_schedule_update (ClutterStageWindow *stage_window,
 
   /* FIXME (?) - On X11 this is performing worse than swap throttling. */
 
-  refresh_interval = (gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
+  refresh_interval = 0;//(gint64) (0.5 + 1000000 / stage_cogl->refresh_rate);
 
   target_presentation_time = stage_cogl->last_presentation_time
                            + stage_cogl->pending_swaps * refresh_interval

--- a/clutter/clutter/cogl/clutter-stage-cogl.h
+++ b/clutter/clutter/cogl/clutter-stage-cogl.h
@@ -50,8 +50,11 @@ struct _ClutterStageCogl
 
   float refresh_rate;
   int pending_swaps;
+  int max_buffer_age;
+  gboolean broken_driver;
 
   gint64 last_presentation_time;
+  gint64 last_update_time;
   gint64 update_time;
 
   /* We only enable clipped redraws after 2 frames, since we've seen

--- a/clutter/clutter/cogl/clutter-stage-cogl.h
+++ b/clutter/clutter/cogl/clutter-stage-cogl.h
@@ -51,10 +51,9 @@ struct _ClutterStageCogl
   float refresh_rate;
   int pending_swaps;
   int max_buffer_age;
-  gboolean broken_driver;
 
-  gint64 last_presentation_time;
   gint64 last_update_time;
+  gint64 last_presentation_time;
   gint64 update_time;
 
   /* We only enable clipped redraws after 2 frames, since we've seen


### PR DESCRIPTION
I applied a similar patch from the Ubuntu Mutter patch series in #335, but overlooked this newer, updated branch on Daniel van Vugt's fork of Mutter. These commits improve smoothness noticeably over the original patch, and fixes the dismantling of the ability to fully disable vblank. 

The FIXME commit's X11 performance comment had me curious, so I assigned `refresh_interval` a 0 value in `clutter_stage_cogl_schedule_update`. It seems to improve input latency without affecting frame sync.