### PR TITLE
Avoid clutter_actor_queue_relayout in animations

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -11182,9 +11182,11 @@ static void
 _clutter_actor_maybe_queue_relayout (ClutterActor *self)
 {
   ClutterActorPrivate *priv = self->priv;
+  ClutterActor *stage = _clutter_actor_get_stage_internal (self);
 
   if (priv->parent &&
-      (priv->parent->flags & CLUTTER_ACTOR_NO_LAYOUT))
+      (priv->parent->flags & CLUTTER_ACTOR_NO_LAYOUT) &&
+      CLUTTER_IS_ACTOR (stage))
     {
       clutter_actor_allocate_preferred_size (self, CLUTTER_ALLOCATION_NONE);
       clutter_actor_queue_redraw (self);

--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -18398,6 +18398,10 @@ clutter_actor_set_margin_top (ClutterActor *self,
   g_return_if_fail (margin >= 0.f);
 
   info = _clutter_actor_get_layout_info_or_defaults (self);
+
+  if (info->margin.top == margin)
+    return;
+
   _clutter_actor_create_transition (self, obj_props[PROP_MARGIN_TOP],
                                     info->margin.top,
                                     margin);
@@ -18442,6 +18446,10 @@ clutter_actor_set_margin_bottom (ClutterActor *self,
   g_return_if_fail (margin >= 0.f);
 
   info = _clutter_actor_get_layout_info_or_defaults (self);
+
+  if (info->margin.bottom == margin)
+    return;
+
   _clutter_actor_create_transition (self, obj_props[PROP_MARGIN_BOTTOM],
                                     info->margin.bottom,
                                     margin);
@@ -18486,6 +18494,10 @@ clutter_actor_set_margin_left (ClutterActor *self,
   g_return_if_fail (margin >= 0.f);
 
   info = _clutter_actor_get_layout_info_or_defaults (self);
+
+  if (info->margin.left == margin)
+    return;
+
   _clutter_actor_create_transition (self, obj_props[PROP_MARGIN_LEFT],
                                     info->margin.left,
                                     margin);
@@ -18530,6 +18542,10 @@ clutter_actor_set_margin_right (ClutterActor *self,
   g_return_if_fail (margin >= 0.f);
 
   info = _clutter_actor_get_layout_info_or_defaults (self);
+
+  if (info->margin.right == margin)
+    return;
+
   _clutter_actor_create_transition (self, obj_props[PROP_MARGIN_RIGHT],
                                     info->margin.right,
                                     margin);

--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -11178,6 +11178,23 @@ clutter_actor_set_height (ClutterActor *self,
                                     height);
 }
 
+static void
+_clutter_actor_maybe_queue_relayout (ClutterActor *self)
+{
+  ClutterActorPrivate *priv = self->priv;
+
+  if (priv->parent &&
+      (priv->parent->flags & CLUTTER_ACTOR_NO_LAYOUT))
+    {
+      clutter_actor_allocate_preferred_size (self, CLUTTER_ALLOCATION_NONE);
+      clutter_actor_queue_redraw (self);
+    }
+  else
+    {
+      clutter_actor_queue_relayout (self);
+    }
+}
+
 static inline void
 clutter_actor_set_x_internal (ClutterActor *self,
                               float         x)
@@ -11198,7 +11215,7 @@ clutter_actor_set_x_internal (ClutterActor *self,
 
   clutter_actor_notify_if_geometry_changed (self, &old);
 
-  clutter_actor_queue_relayout (self);
+  _clutter_actor_maybe_queue_relayout (self);
 }
 
 static inline void
@@ -11221,7 +11238,7 @@ clutter_actor_set_y_internal (ClutterActor *self,
 
   clutter_actor_notify_if_geometry_changed (self, &old);
 
-  clutter_actor_queue_relayout (self);
+  _clutter_actor_maybe_queue_relayout (self);
 }
 
 static void
@@ -11250,7 +11267,7 @@ clutter_actor_set_position_internal (ClutterActor       *self,
 
   clutter_actor_notify_if_geometry_changed (self, &old);
 
-  clutter_actor_queue_relayout (self);
+  _clutter_actor_maybe_queue_relayout (self);
 }
 
 /**


### PR DESCRIPTION
This is intended to help prevent full-stage relayouts during animations.

Partially based on: https://gitlab.gnome.org/GNOME/mutter/merge_requests/238