### PR TITLE
Double check whether the user time window was previously used

### DIFF
--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -477,6 +477,7 @@ reload_net_wm_user_time_window (MetaWindow    *window,
 {
   if (value->type != META_PROP_VALUE_INVALID)
     {
+      MetaWindow *prev_owner;
       /* Unregister old NET_WM_USER_TIME_WINDOW */
       if (window->user_time_window != None)
         {
@@ -489,6 +490,15 @@ reload_net_wm_user_time_window (MetaWindow    *window,
                         NoEventMask);
         }
 
+      /* Ensure the new user time window is not used on another MetaWindow,
+       * and unset its user time window if that is the case.
+       */
+      prev_owner = meta_display_lookup_x_window (window->display, value->v.xwindow);
+      if (prev_owner && prev_owner->user_time_window == value->v.xwindow)
+        {
+          meta_display_unregister_x_window (window->display, value->v.xwindow);
+          prev_owner->user_time_window = None;
+        }
 
       /* Obtain the new NET_WM_USER_TIME_WINDOW and register it */
       window->user_time_window = value->v.xwindow;


### PR DESCRIPTION
Fixes warnings such as:
```
Cinnamon warning: Window 0xca00001 (No Man's S) sets an MWM hint indicating it isn't resizable, but sets min size 1 x 1 and max size 2147483647 x 2147483647; this doesn't make much sense.
```

Based on:
https://github.com/gnome/mutter/commit/ae73e9d84d72ab55a1cae0626763039d645ce7c7