### PR TITLE
Handle GL video memory purged errors

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1424,6 +1424,8 @@ static gboolean
 meta_post_paint_func (gpointer data)
 {
   MetaCompositor *compositor = data;
+  MetaScreen *screen = (MetaScreen*) compositor->display->screens->data;
+  MetaCompScreen *info = meta_screen_get_compositor_data (screen);
   CoglGraphicsResetStatus status;
 
   if (compositor->frame_has_updated_xsurfaces)
@@ -1442,7 +1444,7 @@ meta_post_paint_func (gpointer data)
 
     case COGL_GRAPHICS_RESET_STATUS_PURGED_CONTEXT_RESET:
       g_signal_emit_by_name (compositor->display, "gl-video-memory-purged");
-      clutter_actor_queue_redraw (CLUTTER_ACTOR (compositor->stage));
+      clutter_actor_queue_redraw (CLUTTER_ACTOR (info->stage));
       break;
 
     default:

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1424,6 +1424,7 @@ static gboolean
 meta_post_paint_func (gpointer data)
 {
   MetaCompositor *compositor = data;
+  CoglGraphicsResetStatus status;
 
   if (compositor->frame_has_updated_xsurfaces)
     {
@@ -1431,6 +1432,28 @@ meta_post_paint_func (gpointer data)
         compositor->have_x11_sync_object = meta_sync_ring_after_frame ();
 
       compositor->frame_has_updated_xsurfaces = FALSE;
+    }
+
+  status = cogl_get_graphics_reset_status (compositor->context);
+  switch (status)
+    {
+    case COGL_GRAPHICS_RESET_STATUS_NO_ERROR:
+      break;
+
+    case COGL_GRAPHICS_RESET_STATUS_PURGED_CONTEXT_RESET:
+      g_signal_emit_by_name (compositor->display, "gl-video-memory-purged");
+      clutter_actor_queue_redraw (CLUTTER_ACTOR (compositor->stage));
+      break;
+
+    default:
+      /* The ARB_robustness spec says that, on error, the application
+         should destroy the old context and create a new one. Since we
+         don't have the necessary plumbing to do this we'll simply
+         restart the process. Obviously we can't do this when we are
+         a wayland compositor but in that case we shouldn't get here
+         since we don't enable robustness in that case. */
+      meta_display_restart (compositor->display);
+      break;
     }
 
   return TRUE;

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -1030,7 +1030,7 @@ fdwalk (int (*cb)(void *data, int fd), void *data)
 }
 #endif
 
-LOCAL_SYMBOL void
+void
 meta_pre_exec_close_fds(void)
 {
   fdwalk (set_cloexec, GINT_TO_POINTER(3));

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -44,7 +44,13 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include <dirent.h>
 #include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_RESOURCE_H
+#include <sys/resource.h>
+#endif
 #include <X11/Xlib.h>   /* must explicitly be included for Solaris; #326746 */
 #include <X11/Xutil.h>  /* Just for the definition of the various gravities */
 
@@ -941,3 +947,91 @@ meta_later_remove (guint later_id)
 
 /* eof util.c */
 
+/* Code to close all file descriptors before we exec; copied from gspawn.c in GLib.
+ *
+ * Authors: Padraig O'Briain, Matthias Clasen, Lennart Poettering
+ *
+ * http://bugzilla.gnome.org/show_bug.cgi?id=469231
+ * http://bugzilla.gnome.org/show_bug.cgi?id=357585
+ */
+
+static int
+set_cloexec (void *data, gint fd)
+{
+  if (fd >= GPOINTER_TO_INT (data))
+    fcntl (fd, F_SETFD, FD_CLOEXEC);
+
+  return 0;
+}
+
+#ifndef HAVE_FDWALK
+static int
+fdwalk (int (*cb)(void *data, int fd), void *data)
+{
+  gint open_max;
+  gint fd;
+  gint res = 0;
+
+#ifdef HAVE_SYS_RESOURCE_H
+  struct rlimit rl;
+#endif
+
+#ifdef __linux__
+  DIR *d;
+
+  if ((d = opendir("/proc/self/fd"))) {
+      struct dirent *de;
+
+      while ((de = readdir(d))) {
+          glong l;
+          gchar *e = NULL;
+
+          if (de->d_name[0] == '.')
+              continue;
+
+          errno = 0;
+          l = strtol(de->d_name, &e, 10);
+          if (errno != 0 || !e || *e)
+              continue;
+
+          fd = (gint) l;
+
+          if ((glong) fd != l)
+              continue;
+
+          if (fd == dirfd(d))
+              continue;
+
+          if ((res = cb (data, fd)) != 0)
+              break;
+        }
+
+      closedir(d);
+      return res;
+  }
+
+  /* If /proc is not mounted or not accessible we fall back to the old
+   * rlimit trick */
+
+#endif
+
+#ifdef HAVE_SYS_RESOURCE_H
+  if (getrlimit(RLIMIT_NOFILE, &rl) == 0 && rl.rlim_max != RLIM_INFINITY)
+      open_max = rl.rlim_max;
+  else
+#endif
+      open_max = sysconf (_SC_OPEN_MAX);
+
+  for (fd = 0; fd < open_max; fd++)
+      if ((res = cb (data, fd)) != 0)
+          break;
+
+  return res;
+}
+#endif
+
+LOCAL_SYMBOL void
+meta_pre_exec_close_fds(void)
+{
+  fdwalk (set_cloexec, GINT_TO_POINTER(3));
+}

--- a/src/meta/display.h
+++ b/src/meta/display.h
@@ -199,4 +199,6 @@ void meta_display_keybinding_action_invoke_by_code (MetaDisplay  *display,
                                                     unsigned int  keycode,
                                                     unsigned long mask);
 
+void meta_display_restart (MetaDisplay *display);
+
 #endif

--- a/src/meta/util.h
+++ b/src/meta/util.h
@@ -161,6 +161,7 @@ guint meta_later_add    (MetaLaterType  when,
                          gpointer       data,
                          GDestroyNotify notify);
 void  meta_later_remove (guint          later_id);
+void  meta_pre_exec_close_fds(void);
 
 #endif /* META_UTIL_H */
 


### PR DESCRIPTION
This prevents corruption that can occur with the proprietary Nvidia driver.

https://bugzilla.gnome.org/show_bug.cgi?id=739178