### PR TITLE
screen: Fetch the COW window up-front

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -237,7 +237,7 @@ get_output_window (MetaScreen *screen)
                ButtonPressMask | ButtonReleaseMask |
                KeyPressMask | KeyReleaseMask;
 
-  output = XCompositeGetOverlayWindow (xdisplay, xroot);
+  output = screen->composite_overlay_window;
 
   if (XGetWindowAttributes (xdisplay, output, &attr))
       {

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2377,7 +2377,9 @@ event_callback (XEvent   *event,
 
           screen = meta_display_screen_for_root (display,
                                                  event->xconfigure.event);
-          if (screen)
+          if (screen &&
+              event->xconfigure.event == screen->xroot &&
+              event->xconfigure.window != screen->composite_overlay_window)
             meta_stack_tracker_configure_event (screen->stack_tracker,
                                                 &event->xconfigure);
         }

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -141,6 +141,7 @@ struct _MetaScreen
    * and restack them below a guard window. When using a compositor
    * this allows us to provide live previews of unmapped windows */
   Window guard_window;
+  Window composite_overlay_window;
 };
 
 struct _MetaScreenClass

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -54,6 +54,7 @@
 #ifdef HAVE_RANDR
 #include <X11/extensions/Xrandr.h>
 #endif
+#include <X11/extensions/Xcomposite.h>
 
 #include <X11/Xatom.h>
 #include <locale.h>
@@ -988,6 +989,8 @@ meta_screen_new (MetaDisplay *display,
   screen->starting_corner = META_SCREEN_TOPLEFT;
   screen->compositor_data = NULL;
   screen->guard_window = None;
+
+  screen->composite_overlay_window = XCompositeGetOverlayWindow (xdisplay, xroot);
 
   screen->monitor_infos = NULL;
   screen->n_monitor_infos = 0;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -944,8 +944,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
 	&& attrs->width == 1 && attrs->height == 1) ||
        xwindow == screen->wm_cm_selection_window ||
        xwindow == screen->guard_window ||
-       xwindow == XCompositeGetOverlayWindow (display->xdisplay,
-                                              screen->xroot)
+       xwindow == screen->composite_overlay_window
       )
      ) {
     meta_verbose ("Not managing our own windows\n");


### PR DESCRIPTION
Based on: https://github.com/GNOME/mutter/commit/df2587a61c08735111d513b4d82b81af76cb36e5

> Fixes warning:
 mutter-WARNING **: STACK_OP_RAISE_ABOVE: window 0x65 not in stack

Ref #362 