### PR TITLE
Cogl, Clutter: Avoid crashing when texture allocation fails

### DIFF
--- a/clutter/clutter/clutter-offscreen-effect.c
+++ b/clutter/clutter/clutter-offscreen-effect.c
@@ -180,6 +180,12 @@ update_fbo (ClutterEffect *effect, int fbo_width, int fbo_height)
       priv->texture = NULL;
     }
 
+  if (priv->offscreen != NULL)
+    {
+      cogl_handle_unref (priv->offscreen);
+      priv->offscreen = NULL;
+    }
+
   priv->texture =
     clutter_offscreen_effect_create_texture (self, fbo_width, fbo_height);
   if (priv->texture == NULL)
@@ -189,9 +195,6 @@ update_fbo (ClutterEffect *effect, int fbo_width, int fbo_height)
 
   priv->fbo_width = fbo_width;
   priv->fbo_height = fbo_height;
-
-  if (priv->offscreen != NULL)
-    cogl_handle_unref (priv->offscreen);
 
   priv->offscreen = cogl_offscreen_new_to_texture (priv->texture);
   if (priv->offscreen == NULL)

--- a/cogl/cogl/deprecated/cogl-auto-texture.c
+++ b/cogl/cogl/deprecated/cogl-auto-texture.c
@@ -94,6 +94,7 @@ cogl_texture_new_with_size (unsigned int width,
       if (!cogl_texture_allocate (tex, &skip_error))
         {
           cogl_error_free (skip_error);
+          skip_error = NULL;
           cogl_object_unref (tex);
           tex = NULL;
         }


### PR DESCRIPTION
Based on https://gitlab.gnome.org/GNOME/mutter/merge_requests/261

https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/1790525
https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/1795774