### PR TITLE
Fix up tile signal optimization

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1946,7 +1946,7 @@ meta_screen_tile_preview_update_timeout (gpointer data)
                                                                  snap_osd_timeout,
                                                                  screen);
     }
-    else if (screen->tile_preview_visible)
+    else
     {
         meta_compositor_hide_tile_preview (screen->display->compositor,
                                            screen);
@@ -2035,7 +2035,7 @@ meta_screen_tile_hud_update_timeout (gpointer data)
                                                                  snap_osd_timeout,
                                                                  screen);
     }
-    else if (screen->tile_hud_visible)
+    else
     {
         meta_compositor_hide_hud_preview (screen->display->compositor,
                                           screen);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9456,18 +9456,22 @@ update_move (MetaWindow  *window,
         }
     }
 
-    window->mouse_on_edge = meta_window_mouse_on_edge (window, x, y);
+  window->mouse_on_edge = meta_window_mouse_on_edge (window, x, y);
 
-    MetaRectangle min_size, max_size, target_size;
-    gboolean hminbad = FALSE;
-    gboolean vminbad = FALSE;
-    if (window->tile_mode != META_TILE_NONE) {
-      if (meta_prefs_get_edge_tiling ()) {
-        if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
+  MetaRectangle min_size, max_size, target_size;
+  gboolean hminbad = FALSE;
+  gboolean vminbad = FALSE;
+
+  if (window->tile_mode != META_TILE_NONE)
+    {
+      if (meta_prefs_get_edge_tiling ())
+        {
+          if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
             meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
-        else
+          else
             meta_screen_tile_hud_update (window->screen, TRUE, TRUE);
-      }
+        }
+
       get_size_limits (window, NULL, FALSE, &min_size, &max_size);
       meta_window_get_current_tile_area (window, &target_size);
       MetaFrameBorders borders;
@@ -9476,17 +9480,17 @@ update_move (MetaWindow  *window,
       hminbad = target_size.width < min_size.width;
       vminbad = target_size.height < min_size.height;
 
-      /* Delay showing the tile preview slightly to make it more unlikely to
-        * trigger it unwittingly, e.g. when shaking loose the window or moving
-        * it to another monitor.
-        */
+     /* Delay showing the tile preview slightly to make it more unlikely to
+      * trigger it unwittingly, e.g. when shaking loose the window or moving
+      * it to another monitor.
+      */
 
-        if (!hminbad && !vminbad)
-            meta_screen_tile_preview_update (window->screen,
-                                            window->tile_mode != META_TILE_NONE &&
-                                            !meta_screen_tile_preview_get_visible (window->screen));
-        else
-            meta_screen_tile_preview_hide (window->screen);
+      if (!hminbad && !vminbad)
+        meta_screen_tile_preview_update (window->screen,
+                                          window->tile_mode != META_TILE_NONE &&
+                                          !meta_screen_tile_preview_get_visible (window->screen));
+      else
+        meta_screen_tile_preview_hide (window->screen);
     }
 
   meta_window_get_client_root_coords (window, &old);


### PR DESCRIPTION
These checks from #354 were causing the HUD display to not disappear in some cases when tiling windows.

This also fixes some formatting issues in update_move.