### PR TITLE
Fix VLC fullscreen controller position

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -1455,9 +1455,12 @@ constrain_fully_onscreen (MetaWindow         *window,
                           ConstraintPriority  priority,
                           gboolean            check_only)
 {
+  MetaWindow *transient_for;
+
   if (priority > PRIORITY_ENTIRELY_VISIBLE_ON_WORKAREA)
     return TRUE;
 
+  transient_for = meta_window_get_transient_for(window);
   /* Exit early if we know the constraint won't apply--note that this constraint
    * is only meant for normal windows (e.g. we don't want docks to be shoved 
    * "onscreen" by their own strut).
@@ -1465,6 +1468,7 @@ constrain_fully_onscreen (MetaWindow         *window,
   if (window->type == META_WINDOW_DESKTOP ||
       window->type == META_WINDOW_DOCK    ||
       window->fullscreen                  ||
+      (transient_for && transient_for->fullscreen)           ||
       !window->require_fully_onscreen     || 
       info->is_user_action)
     return TRUE;


### PR DESCRIPTION
VLC fullscreen controller's window type was changed in commit
https://git.videolan.org/?p=vlc.git;a=commit;h=d60312d3ad4c4e27f3455b4f579999b826d3948c
Since then, it got pushed up by the height of a bottom panel, so that it was not displayed at the bottom monitor edge.
This fixes it.
This will also affect other "normal" windows that have a transient
parent in fullscreen and might need testing for those (wherever they might be)