### PR TITLE
shaped-texture: Don't redraw when setting the shape region

### DIFF
--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -808,8 +808,6 @@ meta_shaped_texture_set_shape_region (MetaShapedTexture *stex,
       cairo_region_reference (region);
       priv->shape_region = region;
     }
-
-  clutter_actor_queue_redraw (CLUTTER_ACTOR (stex));
 }
 
 /**


### PR DESCRIPTION
This isn't necessary here and causes two additional redraws any time `check_needs_reshape` is called, which is the only caller for `meta_shaped_texture_set_shape_region`. `clutter_actor_queue_redraw` is always called at the end of `check_needs_reshape` via `meta_window_actor_invalidate_shadow`. There is an is_frozen() check guarding the redraw, but `check_needs_reshape` will only be called while unfrozen.

We are currently redrawing windows when the shape region is `NULL`, a state of the window we wouldn't want to show, and right after the shape region is set, before the mask texture and corners are computed.