### PR TITLE
 Make transitions between restarts seamless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ src/muffin-enum-types.h
 src/muffin-enum-types.lo
 src/muffin-enum-types.o
 src/muffin-plugins.pc
+src/muffin-restart-helper
 src/muffin-theme-viewer
 src/muffin.desktop
 src/org.cinnamon.muffin.gschema.valid

--- a/debian/muffin.install
+++ b/debian/muffin.install
@@ -1,3 +1,4 @@
 usr/bin
 usr/lib/*/muffin/plugins
+usr/lib/muffin/muffin-restart-helper
 usr/share/applications

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,7 @@ override_dh_autoreconf:
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	  --libexecdir="\$${prefix}/lib/muffin" \
 	  --disable-static \
 	  --enable-startup-notification=yes \
 	  --disable-silent-rules \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ libmuffin_la_SOURCES =				\
 	meta/types.h				\
 	core/session.c				\
 	core/session.h				\
+	core/restart.c				\
 	core/stack.c				\
 	core/stack.h				\
 	core/stack-tracker.c			\
@@ -228,6 +229,10 @@ bin_PROGRAMS=muffin muffin-theme-viewer
 
 muffin_SOURCES = core/muffin.c
 muffin_LDADD = $(MUFFIN_LIBS) libmuffin.la
+
+libexec_PROGRAMS = muffin-restart-helper
+muffin_restart_helper_SOURCES = core/restart-helper.c
+muffin_restart_helper_LDADD = $(MUFFIN_LIBS)
 
 if HAVE_INTROSPECTION
 include $(INTROSPECTION_MAKEFILE)

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1459,7 +1459,7 @@ meta_post_paint_func (gpointer data)
          restart the process. Obviously we can't do this when we are
          a wayland compositor but in that case we shouldn't get here
          since we don't enable robustness in that case. */
-      meta_display_restart (compositor->display);
+      meta_restart ();
       break;
     }
 

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -437,4 +437,6 @@ void meta_display_remove_autoraise_callback (MetaDisplay *display);
 /* In above-tab-keycode.c */
 guint meta_display_get_above_tab_keycode (MetaDisplay *display);
 
+void meta_display_notify_restart (MetaDisplay *display);
+
 #endif

--- a/src/core/restart-helper.c
+++ b/src/core/restart-helper.c
@@ -1,0 +1,82 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/*
+ * SECTION:restart-helper
+ * @short_description: helper program during a restart
+ *
+ * To smoothly restart Muffin, we want to keep the composite
+ * overlay window enabled during the restart. This is done by
+ * spawning this program, which keeps a reference to the the composite
+ * overlay window until Muffin picks it back up.
+ */
+
+/*
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/Xcomposite.h>
+
+int
+main (int    argc,
+      char **argv)
+{
+  Display *display = XOpenDisplay (NULL);
+  Window selection_window;
+  XSetWindowAttributes xwa;
+  unsigned long mask = 0;
+
+  xwa.override_redirect = True;
+  mask |= CWOverrideRedirect;
+
+
+  XCompositeGetOverlayWindow (display, DefaultRootWindow (display));
+
+  selection_window = XCreateWindow (display,
+				    DefaultRootWindow (display),
+				    -100, -100, 1, 1, 0,
+				    0,
+				    InputOnly,
+				    DefaultVisual (display, DefaultScreen (display)),
+				    mask, &xwa);
+
+  XSetSelectionOwner (display,
+		      XInternAtom (display, "_MUFFIN_RESTART_HELPER", False),
+		      selection_window,
+		      CurrentTime);
+
+  /* Muffin looks for an (arbitrary) line printed to stdout to know that
+   * we have started and have a reference to the COW. XSync() so that
+   * everything is set on the X server before Muffin starts restarting.
+   */
+  XSync (display, False);
+
+  printf ("STARTED\n");
+  fflush (stdout);
+
+  while (True)
+    {
+      XEvent xev;
+
+      XNextEvent (display, &xev);
+      /* Muffin restarted and unset the selection to indicate that
+       * it has a reference on the COW again */
+      if (xev.xany.type == SelectionClear)
+	return 0;
+    }
+}

--- a/src/core/restart.c
+++ b/src/core/restart.c
@@ -1,0 +1,159 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/*
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * SECTION:restart
+ * @short_description: Smoothly restart the compositor
+ *
+ * There are some cases where we need to restart Muffin in order
+ * to deal with changes in state - the particular case inspiring
+ * this is enabling or disabling stereo output. To make this
+ * fairly smooth for the user, we need to do two things:
+ *
+ *  - Display a message to the user and make sure that it is
+ *    actually painted before we exit.
+ *  - Use a helper program so that the Composite Overlay Window
+ *    isn't unmapped and mapped.
+ *
+ * This handles both of these.
+ */
+
+#include <config.h>
+
+#include <clutter/clutter.h>
+#include <gio/gunixinputstream.h>
+
+#include <meta/main.h>
+#include "ui.h"
+#include <meta/util.h>
+#include "display-private.h"
+
+static gboolean restart_helper_started = FALSE;
+static gboolean restart_stage_shown = FALSE;
+
+static void
+restart_check_ready (void)
+{
+  if (restart_helper_started && restart_stage_shown)
+    meta_display_restart (meta_get_display ());
+}
+
+static void
+restart_helper_read_line_callback (GObject      *source_object,
+                                   GAsyncResult *res,
+                                   gpointer      user_data)
+{
+  GError *error = NULL;
+  gsize length;
+  char *line = g_data_input_stream_read_line_finish_utf8 (G_DATA_INPUT_STREAM (source_object),
+                                                          res,
+                                                          &length, &error);
+  if (line == NULL)
+    {
+      meta_warning ("Failed to read output from restart helper%s%s\n",
+                    error ? ": " : NULL,
+                    error ? error->message : NULL);
+    }
+  else
+    g_free (line); /* We don't actually care what the restart helper outputs */
+
+  g_object_unref (source_object);
+
+  restart_helper_started = TRUE;
+  restart_check_ready ();
+}
+
+static gboolean
+restart_stage_painted (gpointer data)
+{
+  restart_stage_shown = TRUE;
+  restart_check_ready ();
+
+  return FALSE;
+}
+
+/**
+ * meta_restart:
+ *
+ * Starts the process of restarting the compositor.
+ */
+void
+meta_restart (void)
+{
+  MetaDisplay *display = meta_get_display();
+  GInputStream *unix_stream;
+  GDataInputStream *data_stream;
+  GError *error = NULL;
+  int helper_out_fd;
+
+  static const char * const helper_argv[] = {
+    MUFFIN_LIBEXECDIR "/muffin-restart-helper", NULL
+  };
+
+  meta_display_notify_restart (display);
+
+  /* Wait until the stage was painted */
+  clutter_threads_add_repaint_func_full (CLUTTER_REPAINT_FLAGS_POST_PAINT,
+                                         restart_stage_painted,
+                                         NULL, NULL);
+
+  /* We also need to wait for the restart helper to get its
+   * reference to the Composite Overlay Window.
+   */
+  if (!g_spawn_async_with_pipes (NULL, /* working directory */
+                                 (char **)helper_argv,
+                                 NULL, /* envp */
+                                 G_SPAWN_DEFAULT,
+                                 NULL, NULL, /* child_setup */
+                                 NULL, /* child_pid */
+                                 NULL, /* standard_input */
+                                 &helper_out_fd,
+                                 NULL, /* standard_error */
+                                 &error))
+    {
+      meta_warning ("Failed to start restart helper: %s\n", error->message);
+      goto error;
+    }
+
+  unix_stream = g_unix_input_stream_new (helper_out_fd, TRUE);
+  data_stream = g_data_input_stream_new (unix_stream);
+  g_object_unref (unix_stream);
+
+  g_data_input_stream_read_line_async (data_stream, G_PRIORITY_DEFAULT,
+                                       NULL, restart_helper_read_line_callback,
+                                       &error);
+  if (error != NULL)
+    {
+      meta_warning ("Failed to read from restart helper: %s\n", error->message);
+      g_object_unref (data_stream);
+      goto error;
+    }
+
+  return;
+
+ error:
+  /* If starting the restart helper fails, then we just go ahead and restart
+   * immediately. We won't get a smooth transition, since the overlay window
+   * will be destroyed and recreated, but otherwise it will work fine.
+   */
+  restart_helper_started = TRUE;
+  restart_check_ready ();
+
+  return;
+}

--- a/src/meta/main.h
+++ b/src/meta/main.h
@@ -2,9 +2,9 @@
 
 /* Muffin main */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -31,6 +31,16 @@ void            meta_init               (void);
 int             meta_run                (void);
 gboolean        meta_get_replace_current_wm (void);  /* Actually defined in util.c */
 
+void            meta_set_wm_name              (const char *wm_name);
+void            meta_set_gnome_wm_keybindings (const char *wm_keybindings);
+
+void            meta_restart                (void);
+
+/**
+ * MetaExitCode:
+ * @META_EXIT_SUCCESS: Success
+ * @META_EXIT_ERROR: Error
+ */
 typedef enum
 {
   META_EXIT_SUCCESS,


### PR DESCRIPTION
This works by first notifying Cinnamon with the `restart` signal so components and xlets can wind down read/write operations on the file system. Muffin will then freeze the image and restart itself.

Adapted from GNOME/mutter@3a57f84