### PR TITLE
window: Implement _NET_RESTACK_WINDOW and XConfigureRequestEvent sibling

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1587,44 +1587,6 @@ meta_display_queue_autoraise_callback (MetaDisplay *display,
   display->autoraise_window = window;
 }
 
-#if 0
-static void
-handle_net_restack_window (MetaDisplay* display,
-                           XEvent *event)
-{
-  MetaWindow *window;
-
-  window = meta_display_lookup_x_window (display,
-                                         event->xclient.window);
-
-  if (window)
-    {
-      /* FIXME: The EWMH includes a sibling for the restack request, but we
-       * (stupidly) don't currently support these types of raises.
-       *
-       * Also, unconditionally following these is REALLY stupid--we should
-       * combine this code with the stuff in
-       * meta_window_configure_request() which is smart about whether to
-       * follow the request or do something else (though not smart enough
-       * and is also too stupid to handle the sibling stuff).
-       */
-      switch (event->xclient.data.l[2])
-        {
-        case Above:
-          meta_window_raise (window);
-          break;
-        case Below:
-          meta_window_lower (window);
-          break;
-        case TopIf:
-        case BottomIf:
-        case Opposite:
-          break;          
-        }
-    }
-}
-#endif
-
 /*
  * This is the most important function in the whole program. It is the heart,
  * it is the nexus, it is the Grand Central Station of Muffin's world.

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -790,6 +790,9 @@ void meta_window_frame_size_changed (MetaWindow *window);
 void meta_window_stack_just_below (MetaWindow *window,
                                    MetaWindow *below_this_one);
 
+void meta_window_stack_just_above (MetaWindow *window,
+                                   MetaWindow *above_this_one);
+
 void meta_window_set_user_time (MetaWindow *window,
                                 guint32     timestamp);
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6716,6 +6716,32 @@ meta_window_move_resize_request (MetaWindow *window,
   save_user_window_placement (window);
 }
 
+static void
+restack_window (MetaWindow *window,
+                MetaWindow *sibling,
+                int         direction)
+{
+ switch (direction)
+   {
+   case Above:
+     if (sibling)
+       meta_window_stack_just_above (window, sibling);
+     else
+       meta_window_raise (window);
+     break;
+   case Below:
+     if (sibling)
+       meta_window_stack_just_below (window, sibling);
+     else
+       meta_window_lower (window);
+     break;
+   case TopIf:
+   case BottomIf:
+   case Opposite:
+     break;
+   }
+}
+
 LOCAL_SYMBOL gboolean
 meta_window_configure_request (MetaWindow *window,
                                XEvent     *event)
@@ -6746,10 +6772,7 @@ meta_window_configure_request (MetaWindow *window,
    * the stack looks).
    *
    * I'm pretty sure no interesting client uses TopIf, BottomIf, or
-   * Opposite anyway, so the only possible missing thing is
-   * Above/Below with a sibling set. For now we just pretend there's
-   * never a sibling set and always do the full raise/lower instead of
-   * the raise-just-above/below-sibling.
+   * Opposite anyway.
    */
   if (event->xconfigurerequest.value_mask & CWStackMode)
     {
@@ -6781,19 +6804,23 @@ meta_window_configure_request (MetaWindow *window,
         }
       else
         {
-          switch (event->xconfigurerequest.detail)
+          MetaWindow *sibling = NULL;
+          /* Handle Above/Below with a sibling set */
+          if (event->xconfigurerequest.above != None)
             {
-            case Above:
-              meta_window_raise (window);
-              break;
-            case Below:
-              meta_window_lower (window);
-              break;
-            case TopIf:
-            case BottomIf:
-            case Opposite:
-              break;
+              MetaDisplay *display;
+
+              display = meta_window_get_display (window);
+              sibling = meta_display_lookup_x_window (display,
+                                                      event->xconfigurerequest.above);
+              if (sibling == NULL)
+                return TRUE;
+
+              meta_topic (META_DEBUG_STACK,
+                      "xconfigure stacking request from window %s sibling %s stackmode %d\n",
+                      window->desc, sibling->desc, event->xconfigurerequest.detail);
             }
+          restack_window (window, sibling, event->xconfigurerequest.detail);
         }
     }
 
@@ -6805,6 +6832,30 @@ meta_window_property_notify (MetaWindow *window,
                              XEvent     *event)
 {
   return process_property_notify (window, &event->xproperty);
+}
+
+static void
+handle_net_restack_window (MetaDisplay *display,
+                           XEvent      *event)
+{
+  MetaWindow *window, *sibling = NULL;
+
+  /* Ignore if this does not come from a pager, see the WM spec
+   */
+  if (event->xclient.data.l[0] != 2)
+    return;
+
+  window = meta_display_lookup_x_window (display,
+                                         event->xclient.window);
+
+  if (window)
+    {
+      if (event->xclient.data.l[1])
+        sibling = meta_display_lookup_x_window (display,
+                                                event->xclient.data.l[1]);
+
+      restack_window (window, sibling, event->xclient.data.l[2]);
+    }
 }
 
 /*
@@ -7347,6 +7398,11 @@ meta_window_client_message (MetaWindow *window,
                                  y_root, GDK_BUTTON_SECONDARY,
                                  meta_display_get_current_time_roundtrip (display));
         }
+    }
+  else if (event->xclient.message_type ==
+           display->atom__NET_RESTACK_WINDOW)
+    {
+      handle_net_restack_window (display, event);
     }
 
   return FALSE;
@@ -11083,6 +11139,30 @@ meta_window_stack_just_below (MetaWindow *window,
       meta_topic (META_DEBUG_STACK,
                   "Window %s  was already below window %s.\n",
                   window->desc, below_this_one->desc);
+    }
+}
+
+void
+meta_window_stack_just_above (MetaWindow *window,
+                              MetaWindow *above_this_one)
+{
+  g_return_if_fail (window         != NULL);
+  g_return_if_fail (above_this_one != NULL);
+
+  if (window->stack_position < above_this_one->stack_position)
+    {
+      meta_topic (META_DEBUG_STACK,
+                  "Setting stack position of window %s to %d (making it above window %s).\n",
+                  window->desc,
+                  above_this_one->stack_position,
+                  above_this_one->desc);
+      meta_window_set_stack_position (window, above_this_one->stack_position);
+    }
+  else
+    {
+      meta_topic (META_DEBUG_STACK,
+                  "Window %s  was already above window %s.\n",
+                  window->desc, above_this_one->desc);
     }
 }
 

--- a/src/meta/atomnames.h
+++ b/src/meta/atomnames.h
@@ -183,11 +183,7 @@ item(_NET_WM_BYPASS_COMPOSITOR)
 item(_NET_WM_OPAQUE_REGION)
 item(_NET_WM_FRAME_DRAWN)
 item(_NET_WM_FRAME_TIMINGS)
-
-#if 0
-/* We apparently never use: */
-/* item(_NET_RESTACK_WINDOW) */
-#endif
+item(_NET_RESTACK_WINDOW)
 
 /* eof atomnames.h */
 


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=786363
https://bugzilla.gnome.org/show_bug.cgi?id=786365

Adapted from
https://github.com/gnome/mutter/commit/e3d59832c56dbc6acb4301836bc54c467889d515
https://github.com/gnome/mutter/commit/92340fd8da1edd5b9c182f6284a791f6a17ce27c

Ref #326 