### PR TITLE
Speed up window mapping

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -924,6 +924,16 @@ meta_window_should_attach_to_parent (MetaWindow *window)
     }
 }
 
+static gboolean
+emit_window_added (MetaWindow *window)
+{
+  if (window == NULL || window->screen == NULL || window->monitor == NULL)
+    return FALSE;
+
+  g_signal_emit_by_name (window->screen, "window-added", window, window->monitor->number);
+  return FALSE;
+}
+
 LOCAL_SYMBOL LOCAL_SYMBOL MetaWindow*
 meta_window_new_with_attrs (MetaDisplay       *display,
                             Window             xwindow,
@@ -1520,7 +1530,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
     }
 
   g_signal_emit_by_name (window->screen, "window-entered-monitor", window->monitor->number, window);
-  g_signal_emit_by_name (window->screen, "window-added", window, window->monitor->number);
+  clutter_threads_add_timeout (20, (GSourceFunc) emit_window_added, window);
 
   /* Must add window to stack before doing move/resize, since the
    * window might have fullscreen size (i.e. should have been

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -310,6 +310,16 @@ meta_workspace_remove (MetaWorkspace *workspace)
    */
 }
 
+static gboolean
+emit_window_added (MetaWindow *window)
+{
+  if (window == NULL || window->workspace == NULL)
+    return FALSE;
+
+  g_signal_emit (window->workspace, signals[WINDOW_ADDED], 0, window);
+  return FALSE;
+}
+
 LOCAL_SYMBOL void
 meta_workspace_add_window (MetaWorkspace *workspace,
                            MetaWindow    *window)
@@ -359,7 +369,7 @@ meta_workspace_add_window (MetaWorkspace *workspace,
    */
   meta_window_queue (window, META_QUEUE_CALC_SHOWING|META_QUEUE_MOVE_RESIZE);
 
-  g_signal_emit (workspace, signals[WINDOW_ADDED], 0, window);
+  clutter_threads_add_timeout (20, (GSourceFunc) emit_window_added, window);
   g_object_notify (G_OBJECT (workspace), "n-windows");
 }
 


### PR DESCRIPTION
This is [similar to one of the window mapping improvements](https://github.com/linuxmint/Cinnamon/commit/a59f64c352972ca373ad45799e553b76aea2b50f#diff-adc58d0de528049bf386ed40609b6ac9R1128) introduced to the window list applet for 3.8, but uses `clutter_threads_add_timeout` so we can acquire a lock and make Clutter more aware of the timings. The idea is to defer signal emission a bit so we're not blocking the main thread during mapping events.

I used the script from https://github.com/linuxmint/Cinnamon/pull/7251 as a general indicator, along with a stop watch app on my phone.

Before the patch:
Grouped window list - script: 5-6s, stop watch: 9s (using https://github.com/linuxmint/Cinnamon/pull/8092)
Window list - script: 0.5-1s, stop watch: 7s

After:
Grouped window list - script: 0.5s, stop watch: 6s
Window list - script: 0.5s, stop watch: 6s