### PR TITLE
Clutter master clock improvements

### DIFF
--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -96,12 +96,6 @@ struct _ClutterMasterClockDefault
    */
   GSource *source;
 
-  /* If the master clock is idle that means it has
-   * fallen back to idle polling for timeline
-   * progressions and it may have been some time since
-   * the last real stage update.
-   */
-  guint idle : 1;
   guint ensure_next_iteration : 1;
 
   guint paused : 1;
@@ -299,21 +293,11 @@ master_clock_next_frame_time (ClutterMasterClockDefault *master_clock)
       return now;
     }
 
-  /* When we have sync-to-vblank, we count on swap-buffer requests (or
-   * swap-buffer-complete events if supported in the backend) to throttle our
+  /* We will usually have backend hardware features available to throttle our
    * frame rate so no additional delay is needed to start the next frame.
-   *
-   * If the master-clock has become idle due to no timeline progression causing
-   * redraws then we can no longer rely on vblank synchronization because the
-   * last real stage update/redraw may have happened a long time ago and so we
-   * fallback to polling for timeline progressions every 1/frame_rate seconds.
-   *
-   * (NB: if there aren't even any timelines running then the master clock will
-   * be completely stopped in master_clock_is_running())
    */
-  if (master_clock->preferred_sync_method >= SYNC_SWAP_THROTTLING &&
-      clutter_feature_available (CLUTTER_FEATURE_SYNC_TO_VBLANK) &&
-      !master_clock->idle)
+  if (master_clock->preferred_sync_method >= SYNC_SWAP_THROTTLING ||
+      clutter_feature_available (CLUTTER_FEATURE_SYNC_TO_VBLANK))
     {
       master_clock->active_sync_method = SYNC_SWAP_THROTTLING;
       return now;
@@ -543,7 +527,6 @@ clutter_clock_dispatch (GSource     *source,
 {
   ClutterClockSource *clock_source = (ClutterClockSource *) source;
   ClutterMasterClockDefault *master_clock = clock_source->master_clock;
-  gboolean stages_updated = FALSE;
   GSList *stages;
 
   CLUTTER_NOTE (SCHEDULER, "Master clock [tick]");
@@ -563,8 +546,6 @@ clutter_clock_dispatch (GSource     *source,
    */
   stages = master_clock_list_ready_stages (master_clock);
 
-  master_clock->idle = FALSE;
-
   /* Each frame is split into three separate phases: */
 
   /* 1. process all the events; each stage goes through its events queue
@@ -577,12 +558,7 @@ clutter_clock_dispatch (GSource     *source,
   master_clock_advance_timelines (master_clock);
 
   /* 3. relayout and redraw the stages */
-  stages_updated = master_clock_update_stages (master_clock, stages);
-
-  /* The master clock goes idle if no stages were updated and falls back
-   * to polling for timeline progressions... */
-  if (!stages_updated)
-    master_clock->idle = TRUE;
+  master_clock_update_stages (master_clock, stages);
 
   master_clock_reschedule_stage_updates (master_clock, stages);
 
@@ -627,7 +603,6 @@ clutter_master_clock_default_init (ClutterMasterClockDefault *self)
                                 SYNC_NONE;
   self->active_sync_method = self->preferred_sync_method;
 
-  self->idle = FALSE;
   self->ensure_next_iteration = FALSE;
   self->paused = FALSE;
 

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -386,12 +386,14 @@ clutter_stage_allocate (ClutterActor           *self,
    */
   if (!clutter_feature_available (CLUTTER_FEATURE_STAGE_STATIC))
     {
+#ifdef CLUTTER_ENABLE_DEBUG
       CLUTTER_NOTE (LAYOUT,
                     "Following allocation to %.2fx%.2f (absolute origin %s)",
                     width, height,
                     (flags & CLUTTER_ABSOLUTE_ORIGIN_CHANGED)
                       ? "changed"
                       : "not changed");
+#endif
 
       clutter_actor_set_allocation (self, box,
                                     flags | CLUTTER_DELEGATE_LAYOUT);
@@ -443,6 +445,7 @@ clutter_stage_allocate (ClutterActor           *self,
       override.x2 = window_size.width;
       override.y2 = window_size.height;
 
+#ifdef CLUTTER_ENABLE_DEBUG
       CLUTTER_NOTE (LAYOUT,
                     "Overriding original allocation of %.2fx%.2f "
                     "with %.2fx%.2f (absolute origin %s)",
@@ -451,6 +454,7 @@ clutter_stage_allocate (ClutterActor           *self,
                     (flags & CLUTTER_ABSOLUTE_ORIGIN_CHANGED)
                       ? "changed"
                       : "not changed");
+#endif
 
       /* and store the overridden allocation */
       clutter_actor_set_allocation (self, &override,
@@ -1071,7 +1075,9 @@ _clutter_stage_maybe_relayout (ClutterActor *actor)
       priv->relayout_pending = FALSE;
       priv->stage_was_relayout = TRUE;
 
+#ifdef CLUTTER_ENABLE_DEBUG
       CLUTTER_NOTE (ACTOR, "Recomputing layout");
+#endif
 
       CLUTTER_SET_PRIVATE_FLAGS (stage, CLUTTER_IN_RELAYOUT);
 
@@ -1085,9 +1091,11 @@ _clutter_stage_maybe_relayout (ClutterActor *actor)
       box.x2 = natural_width;
       box.y2 = natural_height;
 
+#ifdef CLUTTER_ENABLE_DEBUG
       CLUTTER_NOTE (ACTOR, "Allocating (0, 0 - %d, %d) for the stage",
                     (int) natural_width,
                     (int) natural_height);
+#endif
 
       clutter_actor_allocate (CLUTTER_ACTOR (stage),
                               &box, CLUTTER_ALLOCATION_NONE);
@@ -1101,6 +1109,7 @@ clutter_stage_do_redraw (ClutterStage *stage)
 {
   ClutterActor *actor = CLUTTER_ACTOR (stage);
   ClutterStagePrivate *priv = stage->priv;
+  static gboolean show_fps;
 
   if (CLUTTER_ACTOR_IN_DESTRUCTION (stage))
     return;
@@ -1108,20 +1117,21 @@ clutter_stage_do_redraw (ClutterStage *stage)
   if (priv->impl == NULL)
     return;
 
+  show_fps = _clutter_context_get_show_fps ();
+
+#ifdef CLUTTER_ENABLE_DEBUG
   CLUTTER_NOTE (PAINT, "Redraw started for stage '%s'[%p]",
                 _clutter_actor_get_debug_name (actor),
                 stage);
+#endif
 
-  if (_clutter_context_get_show_fps ())
+  if (show_fps)
     {
       if (priv->fps_timer == NULL)
         priv->fps_timer = g_timer_new ();
-    }
 
-  _clutter_stage_window_redraw (priv->impl);
+      _clutter_stage_window_redraw (priv->impl);
 
-  if (_clutter_context_get_show_fps ())
-    {
       priv->timer_n_frames += 1;
 
       if (g_timer_elapsed (priv->fps_timer, NULL) >= 1.0)
@@ -1133,11 +1143,16 @@ clutter_stage_do_redraw (ClutterStage *stage)
           priv->timer_n_frames = 0;
           g_timer_start (priv->fps_timer);
         }
+      return;
     }
 
+  _clutter_stage_window_redraw (priv->impl);
+
+#ifdef CLUTTER_ENABLE_DEBUG
   CLUTTER_NOTE (PAINT, "Redraw finished for stage '%s'[%p]",
                 _clutter_actor_get_debug_name (actor),
                 stage);
+#endif
 }
 
 static GSList *
@@ -4153,7 +4168,9 @@ _clutter_stage_queue_actor_redraw (ClutterStage *stage,
     {
       ClutterMasterClock *master_clock;
 
+#ifdef CLUTTER_ENABLE_DEBUG
       CLUTTER_NOTE (PAINT, "First redraw request");
+#endif
 
       _clutter_stage_schedule_update (stage);
       priv->redraw_pending = TRUE;


### PR DESCRIPTION
This is an improvement for higher refresh rate monitors, though seeing a noticeable reduction of input latency at 59.97-60Hz. Not seeing any change in Muffin's CPU usage. Tested on Nvidia and Mesa.

Note, the diff from upstream is a bit different because we preserve the ability to make the sync method configurable in #355.

Adapted from
https://gitlab.gnome.org/vanvugt/mutter/commit/f17de523482fe10f8a6194f32782086e39976688
https://gitlab.gnome.org/GNOME/mutter/merge_requests/346