### PR TITLE
window-actor: Fix corners not updating on size change

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -4207,7 +4207,6 @@ meta_display_queue_retheme_all_windows (MetaDisplay *display)
       if (window->frame)
         {
           meta_frame_queue_draw (window->frame);
-          meta_window_update_corners (window);
         }
       
       tmp = tmp->next;

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -840,4 +840,8 @@ void meta_window_extend_by_frame (MetaWindow              *window,
 void meta_window_unextend_by_frame (MetaWindow              *window,
                                     MetaRectangle           *rect,
                                     const MetaFrameBorders  *borders);
+
+void meta_window_get_client_area_rect (const MetaWindow      *window,
+                                       cairo_rectangle_int_t *rect);
+
 #endif

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5948,6 +5948,37 @@ meta_window_get_outer_rect (const MetaWindow *window,
     }
 }
 
+/**
+ * meta_window_get_client_area_rect:
+ * @window: a #MetaWindow
+ * @rect: (out): pointer to a cairo rectangle
+ *
+ * Gets the rectangle for the boundaries of the client area, relative
+ * to the frame. If the window is shaded, the height of the rectangle
+ * is 0.
+ */
+void
+meta_window_get_client_area_rect (const MetaWindow      *window,
+                                  cairo_rectangle_int_t *rect)
+{
+  if (window->frame)
+    {
+      rect->x = window->frame->child_x;
+      rect->y = window->frame->child_y;
+    }
+  else
+    {
+      rect->x = 0;
+      rect->y = 0;
+    }
+
+  rect->width = window->rect.width;
+  if (window->shaded)
+    rect->height = 0;
+  else
+    rect->height = window->rect.height;
+}
+
 MetaSide
 meta_window_get_tile_side (MetaWindow *window)
 {

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -203,7 +203,6 @@ enum
   UNMANAGED,
   SIZE_CHANGED,
   POSITION_CHANGED,
-  RESIZING,
 
   LAST_SIGNAL
 };
@@ -656,15 +655,6 @@ meta_window_class_init (MetaWindowClass *klass)
                   0,
                   NULL, NULL, NULL,
                   G_TYPE_NONE, 0);
-
-  window_signals[RESIZING] =
-    g_signal_new ("resizing",
-                  G_TYPE_FROM_CLASS (object_class),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL, NULL,
-                  G_TYPE_NONE, 0);
-
 }
 
 static void
@@ -8477,10 +8467,7 @@ void
 meta_window_frame_size_changed (MetaWindow *window)
 {
   if (window->frame)
-    {
-      meta_frame_clear_cached_borders (window->frame);
-      g_signal_emit (window, window_signals[RESIZING], 0);
-    }
+    meta_frame_clear_cached_borders (window->frame);
 }
 
 static void
@@ -10076,10 +10063,7 @@ update_resize (MetaWindow *window,
   /* Store the latest resize time, if we actually resized. */
 
   if (window->rect.width != old.width || window->rect.height != old.height)
-    {
-      g_get_current_time (&window->display->grab_last_moveresize_time);
-      g_signal_emit (window, window_signals[RESIZING], 0);
-    }
+    g_get_current_time (&window->display->grab_last_moveresize_time);
 }
 
 typedef struct
@@ -12389,10 +12373,4 @@ meta_window_get_icon_name (MetaWindow *window)
     g_return_val_if_fail (META_IS_WINDOW (window), NULL);
 
     return window->theme_icon_name;
-}
-
-LOCAL_SYMBOL void
-meta_window_update_corners (MetaWindow *window)
-{
-  g_signal_emit (window, window_signals[RESIZING], 0);
 }

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -187,5 +187,4 @@ MetaWindow *meta_window_get_tile_match (MetaWindow *window);
 gboolean meta_window_can_tile (MetaWindow *window, MetaTileMode mode);
 gboolean meta_window_tile (MetaWindow *window, MetaTileMode mode, gboolean snap);
 const char *meta_window_get_icon_name (MetaWindow *window);
-void meta_window_update_corners (MetaWindow *window);
 #endif


### PR DESCRIPTION
`meta_shaped_texture_set_overlay_path` is called in `update_corners`, so it needs to be called before `meta_window_actor_reset_mask_texture` in `check_needs_reshape` because the mask generation depends on the overlay path for framed windows.

This also replaces `MetaFrameBorders` in `check_needs_reshape` with [meta_window_get_client_area_rect](https://github.com/gnome/mutter/commit/ad43cbd70b465af824a9181ee29b84807f8036be) because its an expensive function when the size changes, and the borders only need to be calculated for framed windows.

Closes https://github.com/linuxmint/mint-19.1-beta/issues/50