### PR TITLE
Improve sync between the cursor and frames

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -66,6 +66,8 @@ CoglContext * meta_compositor_get_cogl_context (void);
 
 void meta_switch_workspace_completed (MetaScreen    *screen);
 
+MetaWindow * meta_compositor_get_window_for_xwindow (Window xwindow);
+
 gboolean meta_begin_modal_for_plugin (MetaScreen       *screen,
                                       MetaPlugin       *plugin,
                                       Window            grab_window,

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1553,6 +1553,20 @@ meta_compositor_hide_hud_preview (MetaCompositor *compositor,
   meta_plugin_manager_hide_hud_preview (compositor->plugin_mgr);
 }
 
+MetaWindow *
+meta_compositor_get_window_for_xwindow (Window xwindow)
+{
+  GList *l;
+
+  for (l = compositor_global->windows; l; l = l->next)
+    {
+      MetaWindow *window = meta_window_actor_get_meta_window (l->data);
+      if (window->xwindow == xwindow)
+        return window;
+    }
+  return NULL;
+}
+
 /**
  * meta_compositor_monotonic_time_to_server_time:
  * @display: a #MetaDisplay

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -742,41 +742,7 @@ meta_core_get_grab_op (Display *xdisplay)
   return display->grab_op;
 }
 
-LOCAL_SYMBOL Window
-meta_core_get_grab_frame (Display *xdisplay)
-{
-  MetaDisplay *display;
-  
-  display = meta_display_for_x_display (xdisplay);
-
-  g_assert (display != NULL);
-  g_assert (display->grab_op == META_GRAB_OP_NONE || 
-            display->grab_screen != NULL);
-  g_assert (display->grab_op == META_GRAB_OP_NONE ||
-            display->grab_screen->display->xdisplay == xdisplay);
-  
-  if (display->grab_op != META_GRAB_OP_NONE &&
-      display->grab_window &&
-      display->grab_window->frame)
-    return display->grab_window->frame->xwindow;
-  else
-    return None;
-}
-
-LOCAL_SYMBOL int
-meta_core_get_grab_button (Display  *xdisplay)
-{
-  MetaDisplay *display;
-  
-  display = meta_display_for_x_display (xdisplay);
-
-  if (display->grab_op == META_GRAB_OP_NONE)
-    return -1;
-  
-  return display->grab_button;
-}
-
-LOCAL_SYMBOL void
+void
 meta_core_grab_buttons  (Display *xdisplay,
                          Window   frame_xwindow)
 {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -197,8 +197,6 @@ gboolean   meta_core_begin_grab_op (Display    *xdisplay,
 void       meta_core_end_grab_op   (Display    *xdisplay,
                                     guint32     timestamp);
 MetaGrabOp meta_core_get_grab_op     (Display    *xdisplay);
-Window     meta_core_get_grab_frame  (Display   *xdisplay);
-int        meta_core_get_grab_button (Display  *xdisplay);
 
 
 void       meta_core_grab_buttons  (Display *xdisplay,

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -5493,6 +5493,70 @@ timestamp_too_old (MetaDisplay *display,
   return FALSE;
 }
 
+/**
+ * meta_display_get_pointer:
+ * @display: a #MetaDisplay
+ * @x: (out) (allow-none): location to store root window X coordinate, or %NULL.
+ * @y: (out) (allow-none): location to store root window Y coordinate, or %NULL.
+ * @mask: (out) (allow-none): location to store mask, or %NULL.
+ *
+ * Gets the root coordinates of the pointer.
+ **/
+void
+meta_display_get_pointer (MetaDisplay  *display,
+                          int          *x,
+                          int          *y,
+                          unsigned int *mask)
+{
+  Window root_return;
+  Window child_return;
+  int win_x;
+  int win_y;
+
+  XQueryPointer (display->xdisplay,
+                 display->active_screen->xroot,
+                 &root_return,
+                 &child_return,
+                 x,
+                 y,
+                 &win_x,
+                 &win_y,
+                 mask);
+}
+
+/**
+ * meta_display_get_window_pointer:
+ * @display: a #MetaDisplay
+ * @xwindow: an X11 #Window
+ * @x: (out) (allow-none): location to store root window X coordinate, or %NULL.
+ * @y: (out) (allow-none): location to store root window Y coordinate, or %NULL.
+ * @mask: (out) (allow-none): location to store mask, or %NULL.
+ *
+ * Gets the root coordinates of the pointer.
+ **/
+void
+meta_display_get_window_pointer (MetaDisplay  *display,
+                                 Window        xwindow,
+                                 int          *x,
+                                 int          *y,
+                                 unsigned int *mask)
+{
+  Window root_return;
+  Window child_return;
+  int root_x;
+  int root_y;
+
+  XQueryPointer (display->xdisplay,
+                 xwindow,
+                 &root_return,
+                 &child_return,
+                 &root_x,
+                 &root_y,
+                 x,
+                 y,
+                 mask);
+}
+
 void
 meta_display_set_input_focus_window (MetaDisplay *display, 
                                      MetaWindow  *window,

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3770,8 +3770,9 @@ meta_display_end_grab_op (MetaDisplay *display,
 {
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Ending grab op %u at time %u\n", display->grab_op, timestamp);
-  
-  if (display->grab_op == META_GRAB_OP_NONE)
+
+  if (display->grab_op == META_GRAB_OP_NONE ||
+      display->grab_op == META_GRAB_OP_COMPOSITOR)
     return;
 
   meta_compositor_grab_op_end (display->compositor);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -448,6 +448,12 @@ meta_frame_set_screen_cursor (MetaFrame	*frame,
     }
 }
 
+MetaCursor
+meta_frame_get_screen_cursor (MetaFrame	*frame)
+{
+  return frame->current_cursor;
+}
+
 LOCAL_SYMBOL Window
 meta_frame_get_xwindow (MetaFrame *frame)
 {

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -97,12 +97,13 @@ meta_window_ensure_frame (MetaWindow *window)
   
   frame->xwindow = meta_ui_create_frame_window (window->screen->ui,
                                                 window->display->xdisplay,
+                                                frame->window,
                                                 visual,
                                                 frame->rect.x,
                                                 frame->rect.y,
-						frame->rect.width,
-						frame->rect.height,
-						frame->window->screen->number,
+                                                frame->rect.width,
+                                                frame->rect.height,
+                                                frame->window->screen->number,
                                                 &create_serial);
   meta_stack_tracker_record_add (window->screen->stack_tracker,
                                  frame->xwindow,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -448,12 +448,6 @@ meta_frame_set_screen_cursor (MetaFrame	*frame,
     }
 }
 
-MetaCursor
-meta_frame_get_screen_cursor (MetaFrame	*frame)
-{
-  return frame->current_cursor;
-}
-
 LOCAL_SYMBOL Window
 meta_frame_get_xwindow (MetaFrame *frame)
 {

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -84,8 +84,6 @@ cairo_region_t *meta_frame_get_frame_bounds (MetaFrame *frame);
 void meta_frame_set_screen_cursor (MetaFrame	*frame,
 				   MetaCursor	cursor);
 
-MetaCursor meta_frame_get_screen_cursor (MetaFrame	*frame);
-
 #endif
 
 

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -84,6 +84,8 @@ cairo_region_t *meta_frame_get_frame_bounds (MetaFrame *frame);
 void meta_frame_set_screen_cursor (MetaFrame	*frame,
 				   MetaCursor	cursor);
 
+MetaCursor meta_frame_get_screen_cursor (MetaFrame	*frame);
+
 #endif
 
 

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -646,8 +646,7 @@ handle_preference_init_string (void)
           if (!cursor->target)
             meta_bug ("%s must have handler or target\n", cursor->base.key);
 
-          if (*(cursor->target))
-            g_free (*(cursor->target));
+          g_free (*(cursor->target));
 
           value = g_settings_get_string (SETTINGS (cursor->base.schema),
                                          cursor->base.key);
@@ -767,8 +766,7 @@ handle_preference_update_string (GSettings *settings,
 
       inform_listeners = (g_strcmp0 (value, *(cursor->target)) != 0);
 
-      if (*(cursor->target))
-        g_free(*(cursor->target));
+      g_free(*(cursor->target));
 
       *(cursor->target) = value;
     }
@@ -1360,9 +1358,7 @@ theme_name_handler (GVariant *value,
 
   if (g_strcmp0 (current_theme, string_value) != 0)
     {
-      if (current_theme)
-        g_free (current_theme);
-
+      g_free (current_theme);
       current_theme = g_strdup (string_value);
       queue_changed (META_PREF_THEME);
     }

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1124,8 +1124,7 @@ meta_screen_free (MetaScreen *screen,
   if (screen->check_fullscreen_later != 0)
     g_source_remove (screen->check_fullscreen_later);
 
-  if (screen->monitor_infos)
-    g_free (screen->monitor_infos);
+  g_free (screen->monitor_infos);
 
   if (screen->tile_preview_timeout_id) {
     g_source_remove (screen->tile_preview_timeout_id);

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -100,6 +100,31 @@ typedef void (* MetaWindowMenuFunc) (MetaWindowMenu *menu,
                                      int             workspace,
                                      gpointer        data);
 
+/**
+ * MetaGrabOp:
+ * @META_GRAB_OP_NONE: None
+ * @META_GRAB_OP_MOVING: Moving with pointer
+ * @META_GRAB_OP_RESIZING_SE: Resizing SE with pointer
+ * @META_GRAB_OP_RESIZING_S: Resizing S with pointer
+ * @META_GRAB_OP_RESIZING_SW: Resizing SW with pointer
+ * @META_GRAB_OP_RESIZING_N: Resizing N with pointer
+ * @META_GRAB_OP_RESIZING_NE: Resizing NE with pointer
+ * @META_GRAB_OP_RESIZING_NW: Resizing NW with pointer
+ * @META_GRAB_OP_RESIZING_W: Resizing W with pointer
+ * @META_GRAB_OP_RESIZING_E: Resizing E with pointer
+ * @META_GRAB_OP_KEYBOARD_MOVING: Moving with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN: Resizing with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_S: Resizing S with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_N: Resizing N with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_W: Resizing W with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_E: Resizing E with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_SE: Resizing SE with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_NE: Resizing NE with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_SW: Resizing SW with keyboard
+ * @META_GRAB_OP_KEYBOARD_RESIZING_NW: Resizing NS with keyboard
+ * @META_GRAB_OP_COMPOSITOR: Compositor asked for grab
+ */
+
 /* when changing this enum, there are various switch statements
  * you have to update
  */
@@ -145,19 +170,6 @@ typedef enum
   
   META_GRAB_OP_KEYBOARD_WORKSPACE_SWITCHING,
   
-  /* Frame button ops */
-  META_GRAB_OP_CLICKING_MINIMIZE,
-  META_GRAB_OP_CLICKING_MAXIMIZE,
-  META_GRAB_OP_CLICKING_UNMAXIMIZE,
-  META_GRAB_OP_CLICKING_DELETE,
-  META_GRAB_OP_CLICKING_MENU,
-  META_GRAB_OP_CLICKING_SHADE,
-  META_GRAB_OP_CLICKING_UNSHADE,
-  META_GRAB_OP_CLICKING_ABOVE,
-  META_GRAB_OP_CLICKING_UNABOVE,
-  META_GRAB_OP_CLICKING_STICK,
-  META_GRAB_OP_CLICKING_UNSTICK,
-
   /* Special grab op when the compositor asked for a grab */
   META_GRAB_OP_COMPOSITOR
 } MetaGrabOp;

--- a/src/meta/display.h
+++ b/src/meta/display.h
@@ -201,4 +201,15 @@ void meta_display_keybinding_action_invoke_by_code (MetaDisplay  *display,
 
 void meta_display_restart (MetaDisplay *display);
 
+void meta_display_get_pointer (MetaDisplay  *display,
+                               int          *x,
+                               int          *y,
+                               unsigned int *mask);
+
+void meta_display_get_window_pointer (MetaDisplay  *display,
+                                      Window        xwindow,
+                                      int          *x,
+                                      int          *y,
+                                      unsigned int *mask);
+
 #endif

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1688,7 +1688,8 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
       break;
     }      
 
-  if (control == frame->prelit_control)
+  if (control == frame->prelit_control &&
+      frame->button_state == META_BUTTON_STATE_PRELIGHT)
     return;
 
   /* Save the old control so we can unprelight it */

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1713,7 +1713,6 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   MetaFrames *frames;
   MetaFrameControl control;
   Window xwindow;
-  gboolean not_client_area;
   int x, y;
 
   frames = META_FRAMES (widget);
@@ -1737,18 +1736,6 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   frames->last_cursor_y = y;
 
   control = get_control (frames, frame, x, y);
-  not_client_area = control != META_FRAME_CONTROL_CLIENT_AREA;
-
-  /* While using coordinates from the x event is fast, it's not always accurate,
-     so do a round-trip and get the coordinates again IF the cursor is not inside
-     the client area (user is interacting with the application). Our concerns here
-     are only with frame operations, which are not applicable in that case.*/
-  if (not_client_area)
-    {
-      unsigned int mask;
-      meta_display_get_window_pointer (frames->display, xwindow, &x, &y, &mask);
-      control = get_control (frames, frame, x, y);
-    }
 
   if (frame->button_state == META_BUTTON_STATE_PRESSED)
     {
@@ -1760,7 +1747,7 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
           redraw_control (frames, frame, frame->prelit_control);
         }
     }
-  else if (not_client_area && control != frames->last_control)
+  else if (control != META_FRAME_CONTROL_CLIENT_AREA && control != frames->last_control)
     {
       /* Update prelit control and cursor */
       meta_frames_update_prelit_control (frames, frame, control);

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1372,9 +1372,8 @@ meta_frames_button_press_event (GtkWidget      *widget,
       return meta_frame_double_click_edge_event (frame, event, control);
     }
 
-  if (meta_core_get_grab_op (display) !=
-      META_GRAB_OP_NONE)
-    return FALSE; /* already up to something */  
+  if (meta_core_get_grab_op (display) != META_GRAB_OP_NONE)
+    return FALSE; /* already up to something */
 
   if (event->button == 1 &&
       (control == META_FRAME_CONTROL_MAXIMIZE ||
@@ -1389,63 +1388,14 @@ meta_frames_button_press_event (GtkWidget      *widget,
        control == META_FRAME_CONTROL_UNSTICK ||
        control == META_FRAME_CONTROL_MENU))
     {
-      MetaGrabOp op = META_GRAB_OP_NONE;
+      frames->grab_xwindow = frame->xwindow;
 
-      switch (control)
-        {
-        case META_FRAME_CONTROL_MINIMIZE:
-          op = META_GRAB_OP_CLICKING_MINIMIZE;
-          break;
-        case META_FRAME_CONTROL_MAXIMIZE:
-          op = META_GRAB_OP_CLICKING_MAXIMIZE;
-          break;
-        case META_FRAME_CONTROL_UNMAXIMIZE:
-          op = META_GRAB_OP_CLICKING_UNMAXIMIZE;
-          break;
-        case META_FRAME_CONTROL_DELETE:
-          op = META_GRAB_OP_CLICKING_DELETE;
-          break;
-        case META_FRAME_CONTROL_MENU:
-          op = META_GRAB_OP_CLICKING_MENU;
-          break;
-        case META_FRAME_CONTROL_SHADE:
-          op = META_GRAB_OP_CLICKING_SHADE;
-          break;
-        case META_FRAME_CONTROL_UNSHADE:
-          op = META_GRAB_OP_CLICKING_UNSHADE;
-          break;
-        case META_FRAME_CONTROL_ABOVE:
-          op = META_GRAB_OP_CLICKING_ABOVE;
-          break;
-        case META_FRAME_CONTROL_UNABOVE:
-          op = META_GRAB_OP_CLICKING_UNABOVE;
-          break;
-        case META_FRAME_CONTROL_STICK:
-          op = META_GRAB_OP_CLICKING_STICK;
-          break;
-        case META_FRAME_CONTROL_UNSTICK:
-          op = META_GRAB_OP_CLICKING_UNSTICK;
-          break;
-        default:
-          g_assert_not_reached ();
-          break;
-        }
-
-      meta_core_begin_grab_op (display,
-                               frame->xwindow,
-                               op,
-                               TRUE,
-                               TRUE,
-                               event->button,
-                               0,
-                               event->time,
-                               event->x_root,
-                               event->y_root);      
-      
+      frame->grab_button = event->button;
+      frame->button_state = META_BUTTON_STATE_PRESSED;
       frame->prelit_control = control;
       redraw_control (frames, frame, control);
 
-      if (op == META_GRAB_OP_CLICKING_MENU)
+      if (control == META_FRAME_CONTROL_MENU)
         {
           MetaFrameGeometry fgeom;
           GdkRectangle *rect;
@@ -1567,33 +1517,6 @@ meta_frames_button_press_event (GtkWidget      *widget,
   return TRUE;
 }
 
-LOCAL_SYMBOL void
-meta_frames_notify_menu_hide (MetaFrames *frames)
-{
-  Display *display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
-  if (meta_core_get_grab_op (display) ==
-      META_GRAB_OP_CLICKING_MENU)
-    {
-      Window grab_frame;
-
-      grab_frame = meta_core_get_grab_frame (display);
-
-      if (grab_frame != None)
-        {
-          MetaUIFrame *frame;
-
-          frame = meta_frames_lookup_window (frames, grab_frame);
-
-          if (frame)
-            {
-              redraw_control (frames, frame,
-                              META_FRAME_CONTROL_MENU);
-              meta_core_end_grab_op (display, CurrentTime);
-            }
-        }
-    }
-}
-
 static gboolean
 meta_frames_button_release_event    (GtkWidget           *widget,
                                      GdkEventButton      *event)
@@ -1610,103 +1533,48 @@ meta_frames_button_release_event    (GtkWidget           *widget,
   if (frame == NULL)
     return FALSE;
 
-  op = meta_core_get_grab_op (display);
-
-  if (op == META_GRAB_OP_NONE)
-    return FALSE;
-
   /* We only handle the releases we handled the presses for (things
    * involving frame controls). Window ops that don't require a
    * frame are handled in the Xlib part of the code, display.c/window.c
    */
-  if (frame->xwindow == meta_core_get_grab_frame (display) &&
-      ((int) event->button) == meta_core_get_grab_button (display))
+  if (frame->xwindow == frames->grab_xwindow &&
+      ((int) event->button) == frame->grab_button &&
+      frame->button_state == META_BUTTON_STATE_PRESSED)
     {
-      MetaFrameControl control;
-
-      control = get_control (frames, frame, event->x, event->y);
-      
-      switch (op)
+      switch (frame->prelit_control)
         {
-        case META_GRAB_OP_CLICKING_MINIMIZE:
-          if (control == META_FRAME_CONTROL_MINIMIZE)
-            meta_core_minimize (display, frame->xwindow);
-          
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_MINIMIZE:
+          meta_core_minimize (display, frame->xwindow);
           break;
-
-        case META_GRAB_OP_CLICKING_MAXIMIZE:
-          if (control == META_FRAME_CONTROL_MAXIMIZE)
-          {
-            /* Focus the window on the maximize */
-            meta_core_user_focus (display,
-                            frame->xwindow,
-                            event->time);      
-            meta_core_maximize (display, frame->xwindow);
-          }
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_MAXIMIZE:
+          /* Focus the window on the maximize */
+          meta_core_user_focus (display, frame->xwindow, event->time);
+          meta_core_maximize (display, frame->xwindow);
           break;
-
-        case META_GRAB_OP_CLICKING_UNMAXIMIZE:
-          if (control == META_FRAME_CONTROL_UNMAXIMIZE)
-            meta_core_unmaximize (display, frame->xwindow);
-          
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_UNMAXIMIZE:
+          meta_core_unmaximize (display, frame->xwindow);
           break;
-          
-        case META_GRAB_OP_CLICKING_DELETE:
-          if (control == META_FRAME_CONTROL_DELETE)
-            meta_core_delete (display, frame->xwindow, event->time);
-          
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_DELETE:
+          meta_core_delete (display, frame->xwindow, event->time);
           break;
-          
-        case META_GRAB_OP_CLICKING_MENU:
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_SHADE:
+          meta_core_shade (display, frame->xwindow, event->time);
           break;
-
-        case META_GRAB_OP_CLICKING_SHADE:
-          if (control == META_FRAME_CONTROL_SHADE)
-            meta_core_shade (display, frame->xwindow, event->time);
-          
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_UNSHADE:
+          meta_core_unshade (display, frame->xwindow, event->time);
           break;
- 
-        case META_GRAB_OP_CLICKING_UNSHADE:
-          if (control == META_FRAME_CONTROL_UNSHADE)
-            meta_core_unshade (display, frame->xwindow, event->time);
-
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_ABOVE:
+          meta_core_make_above (display, frame->xwindow);
           break;
-
-        case META_GRAB_OP_CLICKING_ABOVE:
-          if (control == META_FRAME_CONTROL_ABOVE)
-            meta_core_make_above (display, frame->xwindow);
-          
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_UNABOVE:
+          meta_core_unmake_above (display, frame->xwindow);
           break;
- 
-        case META_GRAB_OP_CLICKING_UNABOVE:
-          if (control == META_FRAME_CONTROL_UNABOVE)
-            meta_core_unmake_above (display, frame->xwindow);
-
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_STICK:
+          meta_core_stick (display, frame->xwindow);
           break;
-
-        case META_GRAB_OP_CLICKING_STICK:
-          if (control == META_FRAME_CONTROL_STICK)
-            meta_core_stick (display, frame->xwindow);
-
-          meta_core_end_grab_op (display, event->time);
+        case META_FRAME_CONTROL_UNSTICK:
+          meta_core_unstick (display, frame->xwindow);
           break;
- 
-        case META_GRAB_OP_CLICKING_UNSTICK:
-          if (control == META_FRAME_CONTROL_UNSTICK)
-            meta_core_unstick (display, frame->xwindow);
-
-          meta_core_end_grab_op (display, event->time);
-          break;
-          
         default:
           break;
         }
@@ -1716,6 +1584,7 @@ meta_frames_button_release_event    (GtkWidget           *widget,
        * prelit so to let the user know that it can now be pressed.
        * :)
        */
+      MetaFrameControl control = get_control (frames, frame, event->x, event->y);
       meta_frames_update_prelit_control (frames, frame, control);
     }
   
@@ -1824,6 +1693,7 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
   /* Save the old control so we can unprelight it */
   old_control = frame->prelit_control;
 
+  frame->button_state = META_BUTTON_STATE_PRELIGHT;
   frame->prelit_control = control;
 
   redraw_control (frames, frame, old_control);
@@ -1836,92 +1706,36 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
 {
   MetaUIFrame *frame;
   MetaFrames *frames;
-  MetaGrabOp grab_op;
-  Display *display;
-  
+  MetaFrameControl control;
+  int x, y;
+
   frames = META_FRAMES (widget);
-  display = GDK_DISPLAY_XDISPLAY (gdk_window_get_display (event->window));
-  
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
 
   frames->last_motion_frame = frame;
 
-  grab_op = meta_core_get_grab_op (display);
-  
-  switch (grab_op)
+  gdk_window_get_device_position (frame->window, event->device,
+                                  &x, &y, NULL);
+  control = get_control (frames, frame, x, y);
+
+  if (frame->button_state == META_BUTTON_STATE_PRESSED)
     {
-    case META_GRAB_OP_CLICKING_MENU:
-    case META_GRAB_OP_CLICKING_DELETE:
-    case META_GRAB_OP_CLICKING_MINIMIZE:
-    case META_GRAB_OP_CLICKING_MAXIMIZE:
-    case META_GRAB_OP_CLICKING_UNMAXIMIZE:
-    case META_GRAB_OP_CLICKING_SHADE:
-    case META_GRAB_OP_CLICKING_UNSHADE:
-    case META_GRAB_OP_CLICKING_ABOVE:
-    case META_GRAB_OP_CLICKING_UNABOVE:
-    case META_GRAB_OP_CLICKING_STICK:
-    case META_GRAB_OP_CLICKING_UNSTICK:
-      {
-        MetaFrameControl control;
-        int x, y;
-        
-        gdk_window_get_device_position (frame->window, event->device,
-                                        &x, &y, NULL);
-
-        /* Control is set to none unless it matches
-         * the current grab
-         */
-        control = get_control (frames, frame, x, y);
-        if (! ((control == META_FRAME_CONTROL_MENU &&
-                grab_op == META_GRAB_OP_CLICKING_MENU) ||
-               (control == META_FRAME_CONTROL_DELETE &&
-                grab_op == META_GRAB_OP_CLICKING_DELETE) ||
-               (control == META_FRAME_CONTROL_MINIMIZE &&
-                grab_op == META_GRAB_OP_CLICKING_MINIMIZE) ||
-               ((control == META_FRAME_CONTROL_MAXIMIZE ||
-                 control == META_FRAME_CONTROL_UNMAXIMIZE) &&
-                (grab_op == META_GRAB_OP_CLICKING_MAXIMIZE ||
-                 grab_op == META_GRAB_OP_CLICKING_UNMAXIMIZE)) ||
-               (control == META_FRAME_CONTROL_SHADE &&
-                grab_op == META_GRAB_OP_CLICKING_SHADE) ||
-               (control == META_FRAME_CONTROL_UNSHADE &&
-                grab_op == META_GRAB_OP_CLICKING_UNSHADE) ||
-               (control == META_FRAME_CONTROL_ABOVE &&
-                grab_op == META_GRAB_OP_CLICKING_ABOVE) ||
-               (control == META_FRAME_CONTROL_UNABOVE &&
-                grab_op == META_GRAB_OP_CLICKING_UNABOVE) ||
-               (control == META_FRAME_CONTROL_STICK &&
-                grab_op == META_GRAB_OP_CLICKING_STICK) ||
-               (control == META_FRAME_CONTROL_UNSTICK &&
-                grab_op == META_GRAB_OP_CLICKING_UNSTICK)))
-           control = META_FRAME_CONTROL_NONE;
-        
-        /* Update prelit control and cursor */
-        meta_frames_update_prelit_control (frames, frame, control);
-
-      }
-      break;
-    case META_GRAB_OP_NONE:
-      {
-        MetaFrameControl control;
-        int x, y;
-        
-        gdk_window_get_device_position (frame->window, event->device,
-                                        &x, &y, NULL);
-
-        control = get_control (frames, frame, x, y);
-
-        /* Update prelit control and cursor */
-        meta_frames_update_prelit_control (frames, frame, control);
-      }
-      break;
-
-    default:
-      break;
+      /* If the user leaves the frame button, set the state
+       * back to normal and redraw. */
+      if (frame->prelit_control != control)
+        {
+          frame->button_state = META_BUTTON_STATE_NORMAL;
+          redraw_control (frames, frame, frame->prelit_control);
+        }
     }
-      
+  else
+    {
+      /* Update prelit control and cursor */
+      meta_frames_update_prelit_control (frames, frame, control);
+    }
+
   return TRUE;
 }
 
@@ -2254,10 +2068,9 @@ meta_frames_paint (MetaFrames   *frames,
   MetaFrameType type;
   int w, h;
   MetaButtonState button_states[META_BUTTON_TYPE_LAST];
-  Window grab_frame;
   int i;
+  int button_type = -1;
   MetaButtonLayout button_layout;
-  MetaGrabOp grab_op;
   Display *display;
   
   widget = GTK_WIDGET (frames);
@@ -2266,84 +2079,49 @@ meta_frames_paint (MetaFrames   *frames,
   for (i = 0; i < META_BUTTON_TYPE_LAST; i++)
     button_states[i] = META_BUTTON_STATE_NORMAL;
 
-  grab_frame = meta_core_get_grab_frame (display);
-  grab_op = meta_core_get_grab_op (display);
-  if (grab_frame != frame->xwindow)
-    grab_op = META_GRAB_OP_NONE;
-  
   /* Set prelight state */
   switch (frame->prelit_control)
     {
     case META_FRAME_CONTROL_MENU:
-      if (grab_op == META_GRAB_OP_CLICKING_MENU)
-        button_states[META_BUTTON_TYPE_MENU] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_MENU] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_MENU;
       break;
     case META_FRAME_CONTROL_MINIMIZE:
-      if (grab_op == META_GRAB_OP_CLICKING_MINIMIZE)
-        button_states[META_BUTTON_TYPE_MINIMIZE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_MINIMIZE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_MINIMIZE;
       break;
     case META_FRAME_CONTROL_MAXIMIZE:
-      if (grab_op == META_GRAB_OP_CLICKING_MAXIMIZE)
-        button_states[META_BUTTON_TYPE_MAXIMIZE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_MAXIMIZE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_MAXIMIZE;
       break;
     case META_FRAME_CONTROL_UNMAXIMIZE:
-      if (grab_op == META_GRAB_OP_CLICKING_UNMAXIMIZE)
-        button_states[META_BUTTON_TYPE_MAXIMIZE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_MAXIMIZE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_MAXIMIZE;
       break;
     case META_FRAME_CONTROL_SHADE:
-      if (grab_op == META_GRAB_OP_CLICKING_SHADE)
-        button_states[META_BUTTON_TYPE_SHADE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_SHADE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_SHADE;
       break;
     case META_FRAME_CONTROL_UNSHADE:
-      if (grab_op == META_GRAB_OP_CLICKING_UNSHADE)
-        button_states[META_BUTTON_TYPE_UNSHADE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_UNSHADE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_UNSHADE;
       break;
     case META_FRAME_CONTROL_ABOVE:
-      if (grab_op == META_GRAB_OP_CLICKING_ABOVE)
-        button_states[META_BUTTON_TYPE_ABOVE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_ABOVE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_ABOVE;
       break;
     case META_FRAME_CONTROL_UNABOVE:
-      if (grab_op == META_GRAB_OP_CLICKING_UNABOVE)
-        button_states[META_BUTTON_TYPE_UNABOVE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_UNABOVE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_UNABOVE;
       break;
     case META_FRAME_CONTROL_STICK:
-      if (grab_op == META_GRAB_OP_CLICKING_STICK)
-        button_states[META_BUTTON_TYPE_STICK] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_STICK] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_STICK;
       break;
     case META_FRAME_CONTROL_UNSTICK:
-      if (grab_op == META_GRAB_OP_CLICKING_UNSTICK)
-        button_states[META_BUTTON_TYPE_UNSTICK] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_UNSTICK] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_UNSTICK;
       break;
     case META_FRAME_CONTROL_DELETE:
-      if (grab_op == META_GRAB_OP_CLICKING_DELETE)
-        button_states[META_BUTTON_TYPE_CLOSE] = META_BUTTON_STATE_PRESSED;
-      else
-        button_states[META_BUTTON_TYPE_CLOSE] = META_BUTTON_STATE_PRELIGHT;
+      button_type = META_BUTTON_TYPE_CLOSE;
       break;
     default:
       break;
     }
-  
+
+  if (button_type > -1)
+    button_states[button_type] = frame->button_state;
+
   meta_core_get (display, frame->xwindow,
                  META_CORE_GET_FRAME_FLAGS, &flags,
                  META_CORE_GET_FRAME_TYPE, &type,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -736,9 +736,8 @@ meta_frames_unmanage_window (MetaFrames *frames,
       if (frame->layout)
         g_object_unref (G_OBJECT (frame->layout));
 
-      if (frame->title)
-        g_free (frame->title);
-      
+      g_free (frame->title);
+
       g_free (frame);
     }
   else

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -260,6 +260,8 @@ meta_frames_init (MetaFrames *frames)
 
   frames->style_variants = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                   g_free, g_object_unref);
+  frames->last_window_rect_width = -1;
+  frames->last_window_rect_height = -1;
 
   update_style_contexts (frames);
 
@@ -587,10 +589,19 @@ meta_frames_calc_geometry (MetaFrames        *frames,
                            MetaUIFrame       *frame,
                            MetaFrameGeometry *fgeom)
 {
-  int width, height;
+  int width = frame->meta_window->rect.width;
+  int height = frame->meta_window->rect.height;
   MetaFrameFlags flags;
   MetaFrameType type;
   MetaButtonLayout button_layout;
+
+  /* Only calculate frame geometry if the window size has changed. */
+  if (frames->last_window_rect_width == width &&
+      frames->last_window_rect_height == height)
+    {
+      *fgeom = frames->fgeom;
+      return;
+    }
 
   flags = meta_frame_get_flags (frame->meta_window->frame);
   type = meta_window_get_frame_type (frame->meta_window);
@@ -603,10 +614,13 @@ meta_frames_calc_geometry (MetaFrames        *frames,
                             type,
                             frame->text_height,
                             flags,
-                            frame->meta_window->rect.width,
-                            frame->meta_window->rect.height,
+                            width,
+                            height,
                             &button_layout,
                             fgeom);
+  frames->fgeom = *fgeom;
+  frames->last_window_rect_width = width;
+  frames->last_window_rect_height = height;
 }
 
 LOCAL_SYMBOL MetaFrames*

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -421,7 +421,7 @@ queue_recalc_func (gpointer key, gpointer value, gpointer data)
   frame = value;
 
   invalidate_whole_window (frames, frame);
-  meta_core_queue_frame_resize (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_queue_frame_resize (meta_display_get_xdisplay (meta_get_display ()),
                                 frame->xwindow);
   if (frame->layout)
     {
@@ -510,8 +510,8 @@ meta_frames_ensure_layout (MetaFrames  *frames,
   widget = GTK_WIDGET (frames);
 
   g_return_if_fail (gtk_widget_get_realized (widget));
-      
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow,
+
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()), frame->xwindow,
                  META_CORE_GET_FRAME_FLAGS, &flags,
                  META_CORE_GET_FRAME_TYPE, &type,
                  META_CORE_GET_END);
@@ -593,8 +593,8 @@ meta_frames_calc_geometry (MetaFrames        *frames,
   MetaFrameFlags flags;
   MetaFrameType type;
   MetaButtonLayout button_layout;
-  
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow,
+
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()), frame->xwindow,
                  META_CORE_GET_CLIENT_WIDTH, &width,
                  META_CORE_GET_CLIENT_HEIGHT, &height,
                  META_CORE_GET_FRAME_FLAGS, &flags,
@@ -656,7 +656,7 @@ meta_frames_attach_style (MetaFrames  *frames,
   if (frame->style != NULL)
     g_object_unref (frame->style);
 
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()),
                  frame->xwindow,
                  META_CORE_WINDOW_HAS_FRAME, &has_frame,
                  META_CORE_GET_THEME_VARIANT, &variant,
@@ -697,8 +697,8 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->prelit_control = META_FRAME_CONTROL_NONE;
   frame->button_state = META_BUTTON_STATE_NORMAL;
 
-  meta_core_grab_buttons (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
-  
+  meta_core_grab_buttons (meta_display_get_xdisplay (meta_get_display ()), frame->xwindow);
+
   g_hash_table_replace (frames->frames, &frame->xwindow, frame);
 }
 
@@ -718,7 +718,7 @@ meta_frames_unmanage_window (MetaFrames *frames,
       invalidate_all_caches (frames);
       
       /* restore the cursor */
-      meta_core_set_screen_cursor (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+      meta_core_set_screen_cursor (meta_display_get_xdisplay (meta_get_display ()),
                                    frame->xwindow,
                                    META_CURSOR_DEFAULT);
 
@@ -768,8 +768,8 @@ meta_frames_get_borders (MetaFrames *frames,
 
   if (frame == NULL)
     meta_bug ("No such frame 0x%lx\n", xwindow);
-  
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow,
+
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()), frame->xwindow,
                  META_CORE_GET_FRAME_FLAGS, &flags,
                  META_CORE_GET_FRAME_TYPE, &type,
                  META_CORE_GET_END);
@@ -1067,8 +1067,8 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
   MetaFrameFlags flags;
   Display *display;
 
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
-  
+  display = meta_display_get_xdisplay (meta_get_display ());
+
   switch (action)
     {
     case C_DESKTOP_TITLEBAR_ACTION_TOGGLE_SHADE:
@@ -1285,7 +1285,7 @@ meta_frames_try_grab_op (MetaFrames  *frames,
   Display *display;
   gboolean ret;
 
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+  display = meta_display_get_xdisplay (meta_get_display ());
   ret = meta_core_begin_grab_op (display,
                                  frame->xwindow,
                                  op,
@@ -1318,7 +1318,7 @@ meta_frames_retry_grab_op (MetaFrames *frames,
 
   op = frames->current_grab_op;
   frames->current_grab_op = META_GRAB_OP_NONE;
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+  display = meta_display_get_xdisplay (meta_get_display ());
 
   return meta_core_begin_grab_op (display,
                                   frames->grab_frame->xwindow,
@@ -1363,7 +1363,7 @@ meta_frames_button_press_event (GtkWidget      *widget,
   Display *display;
   
   frames = META_FRAMES (widget);
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+  display = meta_display_get_xdisplay (meta_get_display ());
 
   /* Remember that the display may have already done something with this event.
    * If so there's probably a GrabOp in effect.
@@ -1559,7 +1559,7 @@ meta_frames_button_release_event    (GtkWidget           *widget,
   Display *display;
   
   frames = META_FRAMES (widget);
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+  display = meta_display_get_xdisplay (meta_get_display ());
   frames->current_grab_op = META_GRAB_OP_NONE;
 
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
@@ -1695,7 +1695,7 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
     }        
 
   /* set/unset the prelight cursor */
-  meta_core_set_screen_cursor (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_set_screen_cursor (meta_display_get_xdisplay (meta_get_display ()),
                                frame->xwindow,
                                cursor);  
 
@@ -1748,10 +1748,19 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   if (frame == NULL)
     return FALSE;
 
+  MetaDisplay *display = meta_get_display ();
+
   frames->last_motion_frame = frame;
 
-  gdk_window_get_device_position (frame->window, event->device,
-                                  &x, &y, NULL);
+  if (display->grab_op == META_GRAB_OP_MOVING)
+    gdk_window_get_device_position (frame->window, event->device,
+                                    &x, &y, NULL);
+  else
+    {
+      x = event->x;
+      y = event->y;
+    }
+
   control = get_control (frames, frame, x, y);
 
   if (frame->button_state == META_BUTTON_STATE_PRESSED)
@@ -1861,7 +1870,7 @@ populate_cache (MetaFrames *frames,
   MetaFrameFlags frame_flags;
   int i;
 
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()),
                  frame->xwindow,
                  META_CORE_GET_FRAME_WIDTH, &frame_width,
                  META_CORE_GET_FRAME_HEIGHT, &frame_height,
@@ -1956,7 +1965,7 @@ clip_to_screen (cairo_region_t *region,
    * is crucial to handle huge client windows,
    * like "xterm -geometry 1000x1000"
    */
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()),
                  frame->xwindow,
                  META_CORE_GET_FRAME_X, &frame_area.x,
                  META_CORE_GET_FRAME_Y, &frame_area.y,
@@ -1989,8 +1998,8 @@ subtract_client_area (cairo_region_t *region,
   MetaFrameBorders borders;
   cairo_region_t *tmp_region;
   Display *display;
-  
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+
+  display = meta_display_get_xdisplay (meta_get_display ());
 
   meta_core_get (display, frame->xwindow,
                  META_CORE_GET_FRAME_FLAGS, &flags,
@@ -2112,7 +2121,7 @@ meta_frames_paint (MetaFrames   *frames,
   Display *display;
   
   widget = GTK_WIDGET (frames);
-  display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
+  display = meta_display_get_xdisplay (meta_get_display ());
 
   for (i = 0; i < META_BUTTON_TYPE_LAST; i++)
     button_states[i] = META_BUTTON_STATE_NORMAL;
@@ -2306,7 +2315,7 @@ get_control (MetaFrames *frames,
   gboolean has_north_resize;
   cairo_rectangle_int_t client;
 
-  window = meta_core_get_window (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  window = meta_core_get_window (meta_display_get_xdisplay (meta_get_display ()),
                                  frame->xwindow);
 
   meta_window_get_client_area_rect (window, &client);
@@ -2325,7 +2334,7 @@ get_control (MetaFrames *frames,
   if (POINT_IN_RECT (x, y, fgeom.menu_rect.clickable))
     return META_FRAME_CONTROL_MENU;
 
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+  meta_core_get (meta_display_get_xdisplay (meta_get_display ()),
                  frame->xwindow,
                  META_CORE_GET_FRAME_FLAGS, &flags,
                  META_CORE_GET_FRAME_TYPE, &type,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -811,12 +811,7 @@ meta_frames_get_corner_radiuses (MetaFrames *frames,
                                  float      *bottom_left,
                                  float      *bottom_right)
 {
-  MetaUIFrame *frame;
-  MetaFrameGeometry fgeom;
-
-  frame = meta_frames_lookup_window (frames, xwindow);
-
-  meta_frames_calc_geometry (frames, frame, &fgeom);
+  MetaFrameGeometry fgeom = frames->fgeom;
 
   /* For compatibility with the code in get_visible_rect(), there's
    * a mysterious sqrt() added to the corner radiuses:
@@ -984,6 +979,8 @@ meta_frames_move_resize_frame (MetaFrames *frames,
 
   if (old_width != width || old_height != height)
     invalidate_whole_window (frames, frame);
+
+  frames->last_window_rect_height = -1;
 }
 
 LOCAL_SYMBOL void
@@ -1057,8 +1054,8 @@ redraw_control (MetaFrames *frames,
 {
   MetaFrameGeometry fgeom;
   GdkRectangle *rect;
-  
-  meta_frames_calc_geometry (frames, frame, &fgeom);
+
+  fgeom = frames->fgeom;
 
   rect = control_rect (control, &fgeom);
 

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -695,6 +695,7 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->title = NULL;
   frame->shape_applied = FALSE;
   frame->prelit_control = META_FRAME_CONTROL_NONE;
+  frame->button_state = META_BUTTON_STATE_NORMAL;
 
   meta_core_grab_buttons (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
   

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -598,11 +598,14 @@ meta_frames_calc_geometry (MetaFrames        *frames,
   MetaFrameType type;
   MetaButtonLayout button_layout;
 
-  /* Only calculate frame geometry if the window size has changed. */
+  /* Only calculate frame geometry if the window size has changed.
+     Tiled windows need an extra pass to not have artifacts. */
   if (frames->last_window_rect_width == width &&
-      frames->last_window_rect_height == height)
+      frames->last_window_rect_height == height &&
+      (frame->meta_window->tile_mode == META_TILE_NONE || frame->fgeom_count > 1))
     {
       *fgeom = frames->fgeom;
+      frame->fgeom_count = 0;
       return;
     }
 
@@ -621,9 +624,11 @@ meta_frames_calc_geometry (MetaFrames        *frames,
                             height,
                             &button_layout,
                             fgeom);
+
   frames->fgeom = *fgeom;
   frames->last_window_rect_width = width;
   frames->last_window_rect_height = height;
+  frame->fgeom_count++;
 }
 
 LOCAL_SYMBOL MetaFrames*
@@ -705,6 +710,7 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->shape_applied = FALSE;
   frame->prelit_control = META_FRAME_CONTROL_NONE;
   frame->button_state = META_BUTTON_STATE_NORMAL;
+  frame->fgeom_count = 0;
 
   meta_display_grab_window_buttons (meta_window->display, frame->xwindow);
 

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -728,9 +728,6 @@ meta_frames_unmanage_window (MetaFrames *frames,
 
       gdk_window_set_user_data (frame->window, NULL);
 
-      if (frames->last_motion_frame == frame)
-        frames->last_motion_frame = NULL;
-      
       g_hash_table_remove (frames->frames, &frame->xwindow);
 
       g_object_unref (frame->style);
@@ -1727,8 +1724,6 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
-
-  frames->last_motion_frame = frame;
 
   MetaCursor cursor = meta_frame_get_screen_cursor (frame->meta_window->frame);
 

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -260,6 +260,7 @@ meta_frames_init (MetaFrames *frames)
 
   frames->style_variants = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                   g_free, g_object_unref);
+  frames->entered = FALSE;
   frames->last_window_rect_width = -1;
   frames->last_window_rect_height = -1;
 
@@ -1726,6 +1727,10 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   int x, y;
 
   frames = META_FRAMES (widget);
+
+  if (!frames->entered)
+    return FALSE;
+
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
@@ -2183,6 +2188,8 @@ meta_frames_enter_notify_event      (GtkWidget           *widget,
   
   frames = META_FRAMES (widget);
 
+  frames->entered = TRUE;
+
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
@@ -2201,6 +2208,8 @@ meta_frames_leave_notify_event      (GtkWidget           *widget,
   MetaFrames *frames;
 
   frames = META_FRAMES (widget);
+
+  frames->entered = FALSE;
 
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -824,21 +824,6 @@ meta_frames_get_corner_radiuses (MetaFrames *frames,
     *bottom_right = fgeom.bottom_right_corner_rounded_radius + sqrt(fgeom.bottom_right_corner_rounded_radius);
 }
 
-/* The client rectangle surrounds client window; it subtracts both
- * the visible and invisible borders from the frame window's size.
- */
-static void
-get_client_rect (MetaFrameGeometry     *fgeom,
-                 int                    window_width,
-                 int                    window_height,
-                 cairo_rectangle_int_t *rect)
-{
-  rect->x = fgeom->borders.total.left;
-  rect->y = fgeom->borders.total.top;
-  rect->width = window_width - fgeom->borders.total.right - rect->x;
-  rect->height = window_height - fgeom->borders.total.bottom - rect->y;
-}
-
 /* The visible frame rectangle surrounds the visible portion of the
  * frame window; it subtracts only the invisible borders from the frame
  * window's size.
@@ -2324,12 +2309,13 @@ get_control (MetaFrames *frames,
   window = meta_core_get_window (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                  frame->xwindow);
 
-  meta_frames_calc_geometry (frames, frame, &fgeom);
-  get_client_rect (&fgeom, fgeom.width, fgeom.height, &client);
+  meta_window_get_client_area_rect (window, &client);
 
   if (POINT_IN_RECT (x, y, client))
     return META_FRAME_CONTROL_CLIENT_AREA;
-  
+
+  meta_frames_calc_geometry (frames, frame, &fgeom);
+
   if (POINT_IN_RECT (x, y, fgeom.close_rect.clickable))
     return META_FRAME_CONTROL_DELETE;
 

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -260,6 +260,9 @@ meta_frames_init (MetaFrames *frames)
   frames->last_cursor_x = -1;
   frames->last_cursor_y = -1;
 
+  frames->display = meta_get_display ();
+  frames->xdisplay = meta_display_get_xdisplay (frames->display);
+
   update_style_contexts (frames);
 
   gtk_widget_set_double_buffered (GTK_WIDGET (frames), FALSE);
@@ -420,8 +423,7 @@ queue_recalc_func (gpointer key, gpointer value, gpointer data)
   frame = value;
 
   invalidate_whole_window (frames, frame);
-  meta_core_queue_frame_resize (meta_display_get_xdisplay (meta_get_display ()),
-                                frame->xwindow);
+  meta_core_queue_frame_resize (frames->xdisplay, frame->xwindow);
   if (frame->layout)
     {
       /* save title to recreate layout */
@@ -720,7 +722,7 @@ meta_frames_unmanage_window (MetaFrames *frames,
       invalidate_all_caches (frames);
       
       /* restore the cursor */
-      meta_core_set_screen_cursor (meta_display_get_xdisplay (meta_get_display ()),
+      meta_core_set_screen_cursor (frames->xdisplay,
                                    frame->xwindow,
                                    META_CURSOR_DEFAULT);
 
@@ -1294,7 +1296,7 @@ meta_frames_retry_grab_op (MetaFrames *frames,
 
   op = frames->current_grab_op;
   frames->current_grab_op = META_GRAB_OP_NONE;
-  display = meta_display_get_xdisplay (meta_get_display ());
+  display = frames->xdisplay;
 
   return meta_core_begin_grab_op (display,
                                   frames->grab_frame->xwindow,
@@ -1339,7 +1341,7 @@ meta_frames_button_press_event (GtkWidget      *widget,
   Display *display;
   
   frames = META_FRAMES (widget);
-  display = meta_display_get_xdisplay (meta_get_display ());
+  display = frames->xdisplay;
 
   /* Remember that the display may have already done something with this event.
    * If so there's probably a GrabOp in effect.
@@ -1532,7 +1534,7 @@ meta_frames_button_release_event    (GtkWidget           *widget,
   Display *display;
   
   frames = META_FRAMES (widget);
-  display = meta_display_get_xdisplay (meta_get_display ());
+  display = frames->xdisplay;
   frames->current_grab_op = META_GRAB_OP_NONE;
 
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
@@ -1855,7 +1857,7 @@ populate_cache (MetaFrames *frames,
   MetaFrameFlags frame_flags;
   int i;
 
-  meta_core_get (meta_display_get_xdisplay (meta_get_display ()),
+  meta_core_get (frames->xdisplay,
                  frame->xwindow,
                  META_CORE_GET_FRAME_WIDTH, &frame_width,
                  META_CORE_GET_FRAME_HEIGHT, &frame_height,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2296,7 +2296,7 @@ get_control (MetaFrames *frames,
 
   window = frame->meta_window;
 
-  meta_window_get_client_area_rect (window, &client);
+  client = window->client_area;
 
   if (POINT_IN_RECT (x, y, client))
     return META_FRAME_CONTROL_CLIENT_AREA;

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1711,6 +1711,7 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   MetaUIFrame *frame;
   MetaFrames *frames;
   MetaFrameControl control;
+  Window xwindow;
   int x, y;
 
   frames = META_FRAMES (widget);
@@ -1718,10 +1719,11 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
   if (!frames->entered)
     return FALSE;
 
+  xwindow = GDK_WINDOW_XID (event->window);
   x = event->x;
   y = event->y;
 
-  frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
+  frame = meta_frames_lookup_window (frames, xwindow);
   if (frame == NULL)
     return FALSE;
 
@@ -1740,8 +1742,10 @@ meta_frames_motion_notify_event     (GtkWidget           *widget,
       cursor == META_CURSOR_NE_RESIZE ||
       cursor == META_CURSOR_WEST_RESIZE ||
       cursor == META_CURSOR_EAST_RESIZE)))
-    gdk_window_get_device_position (frame->window, event->device,
-                                    &x, &y, NULL);
+    {
+      unsigned int mask;
+      meta_display_get_window_pointer (frames->display, xwindow, &x, &y, &mask);
+    }
 
   control = get_control (frames, frame, x, y);
 

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -2,9 +2,9 @@
 
 /* Metacity window frame manager widget */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -83,7 +83,7 @@ struct _MetaUIFrame
   int text_height;
   char *title; /* NULL once we have a layout */
   guint shape_applied : 1;
-  
+
   /* FIXME get rid of this, it can just be in the MetaFrames struct */
   MetaFrameControl prelit_control;
   MetaButtonState button_state;
@@ -95,12 +95,10 @@ struct _MetaUIFrame
 struct _MetaFrames
 {
   GtkWindow parent_instance;
-  
+
   GHashTable *text_heights;
 
   GHashTable *frames;
-
-  MetaUIFrame *last_motion_frame;
 
   GtkStyleContext *normal_style;
   GHashTable *style_variants;

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -89,7 +89,7 @@ struct _MetaUIFrame
   MetaButtonState button_state;
   int grab_button;
 
-  int fgeom_count;
+  MetaFrameGeometry fgeom;
 };
 
 struct _MetaFrames
@@ -118,11 +118,8 @@ struct _MetaFrames
   Window grab_xwindow;
 
   guint entered : 1;
-  int last_window_rect_height;
-  int last_window_rect_width;
   int last_cursor_x;
   int last_cursor_y;
-  MetaFrameGeometry fgeom;
 };
 
 struct _MetaFramesClass
@@ -177,5 +174,8 @@ void meta_frames_queue_draw (MetaFrames *frames,
                              Window      xwindow);
 
 Window meta_frames_get_moving_frame (MetaFrames *frames);
+
+void meta_frames_calc_geometry (MetaFrames *frames,
+                                Window      xwindow);
 
 #endif

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -114,6 +114,9 @@ struct _MetaFrames
   gdouble grab_y;
 
   Window grab_xwindow;
+  int last_window_rect_height;
+  int last_window_rect_width;
+  MetaFrameGeometry fgeom;
 };
 
 struct _MetaFramesClass

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -88,6 +88,8 @@ struct _MetaUIFrame
   MetaFrameControl prelit_control;
   MetaButtonState button_state;
   int grab_button;
+
+  int fgeom_count;
 };
 
 struct _MetaFrames

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -114,6 +114,8 @@ struct _MetaFrames
   gdouble grab_y;
 
   Window grab_xwindow;
+
+  guint entered : 1;
   int last_window_rect_height;
   int last_window_rect_width;
   MetaFrameGeometry fgeom;

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -105,6 +105,12 @@ struct _MetaFrames
   GList *invalidate_frames;
   GHashTable *cache;
 
+  MetaGrabOp current_grab_op;
+  MetaUIFrame *grab_frame;
+  guint grab_button;
+  gdouble grab_x;
+  gdouble grab_y;
+
   Window grab_xwindow;
 };
 

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -115,6 +115,8 @@ struct _MetaFrames
   gdouble grab_x;
   gdouble grab_y;
 
+  MetaDisplay *display;
+  Display *xdisplay;
   Window grab_xwindow;
 
   guint entered : 1;

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -118,6 +118,8 @@ struct _MetaFrames
   guint entered : 1;
   int last_window_rect_height;
   int last_window_rect_width;
+  int last_cursor_x;
+  int last_cursor_y;
   MetaFrameGeometry fgeom;
 };
 

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -117,6 +117,8 @@ struct _MetaFrames
   Display *xdisplay;
   Window grab_xwindow;
 
+  MetaFrameControl last_control;
+
   guint entered : 1;
   int last_cursor_x;
   int last_cursor_y;

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -27,6 +27,7 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 #include <meta/common.h>
+#include <meta/types.h>
 #include "theme-private.h"
 
 typedef enum
@@ -73,6 +74,7 @@ typedef struct _MetaUIFrame         MetaUIFrame;
 
 struct _MetaUIFrame
 {
+  MetaWindow *meta_window;
   Window xwindow;
   GdkWindow *window;
   GtkStyleContext *style;
@@ -125,6 +127,7 @@ GType        meta_frames_get_type               (void) G_GNUC_CONST;
 MetaFrames *meta_frames_new (int screen_number);
 
 void meta_frames_manage_window (MetaFrames *frames,
+                                MetaWindow *meta_window,
                                 Window      xwindow,
 				GdkWindow  *window);
 void meta_frames_unmanage_window (MetaFrames *frames,

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -84,6 +84,8 @@ struct _MetaUIFrame
   
   /* FIXME get rid of this, it can just be in the MetaFrames struct */
   MetaFrameControl prelit_control;
+  MetaButtonState button_state;
+  int grab_button;
 };
 
 struct _MetaFrames
@@ -102,6 +104,8 @@ struct _MetaFrames
   int invalidate_cache_timeout_id;
   GList *invalidate_frames;
   GHashTable *cache;
+
+  Window grab_xwindow;
 };
 
 struct _MetaFramesClass
@@ -153,8 +157,6 @@ void meta_frames_move_resize_frame (MetaFrames *frames,
 				    int         height);
 void meta_frames_queue_draw (MetaFrames *frames,
                              Window      xwindow);
-
-void meta_frames_notify_menu_hide (MetaFrames *frames);
 
 Window meta_frames_get_moving_frame (MetaFrames *frames);
 

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -139,7 +139,6 @@ menu_closed (GtkMenu *widget,
   
   menu = data;
 
-  meta_frames_notify_menu_hide (menu->frames);
   (* menu->func) (menu,
                   GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                   menu->client_xwindow,
@@ -159,7 +158,6 @@ activate_cb (GtkWidget *menuitem, gpointer data)
   
   md = data;
 
-  meta_frames_notify_menu_hide (md->menu->frames);
   (* md->menu->func) (md->menu,
                       GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                       md->menu->client_xwindow,

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1165,8 +1165,7 @@ meta_color_spec_free (MetaColorSpec *spec)
       break;
 
     case META_COLOR_SPEC_GTK_CUSTOM:
-      if (spec->data.gtkcustom.color_name)
-        g_free (spec->data.gtkcustom.color_name);
+      g_free (spec->data.gtkcustom.color_name);
       if (spec->data.gtkcustom.fallback)
         meta_color_spec_free (spec->data.gtkcustom.fallback);
       DEBUG_FILL_STRUCT (&spec->data.gtkcustom);
@@ -3010,9 +3009,7 @@ meta_draw_op_free (MetaDrawOp *op)
       break;
 
     case META_DRAW_RECTANGLE:
-      if (op->data.rectangle.color_spec)
-        g_free (op->data.rectangle.color_spec);
-
+      g_free (op->data.rectangle.color_spec);
       meta_draw_spec_free (op->data.rectangle.x);
       meta_draw_spec_free (op->data.rectangle.y);
       meta_draw_spec_free (op->data.rectangle.width);
@@ -3020,9 +3017,7 @@ meta_draw_op_free (MetaDrawOp *op)
       break;
 
     case META_DRAW_ARC:
-      if (op->data.arc.color_spec)
-        g_free (op->data.arc.color_spec);
-
+      g_free (op->data.arc.color_spec);
       meta_draw_spec_free (op->data.arc.x);
       meta_draw_spec_free (op->data.arc.y);
       meta_draw_spec_free (op->data.arc.width);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -200,6 +200,12 @@ maybe_redirect_mouse_event (XEvent *xevent)
       gevent = gdk_event_new (GDK_MOTION_NOTIFY);
       gevent->motion.type = GDK_MOTION_NOTIFY;
       gevent->motion.window = g_object_ref (gdk_window);
+      gevent->motion.time = xevent->xbutton.time;
+      gevent->motion.x_root = xevent->xbutton.x_root;
+      gevent->motion.y_root = xevent->xbutton.y_root;
+
+      if (xevent->xbutton.button == 1)
+        gevent->motion.state |= GDK_BUTTON1_MASK;
       break;
     case EnterNotify:
     case LeaveNotify:

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -469,20 +469,6 @@ meta_ui_map_frame   (MetaUI *ui,
 }
 
 LOCAL_SYMBOL void
-meta_ui_unmap_frame (MetaUI *ui,
-                     Window  xwindow)
-{
-  GdkWindow *window;
-  GdkDisplay *display;
-
-  display = gdk_x11_lookup_xdisplay (ui->xdisplay);
-  window = gdk_x11_window_lookup_for_display (display, xwindow);
-
-  if (window)
-    gdk_window_hide (window);
-}
-
-LOCAL_SYMBOL void
 meta_ui_update_frame_style (MetaUI  *ui,
                             Window   xwindow)
 {

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -2,10 +2,10 @@
 
 /* Muffin interface for talking to GTK+ UI module */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
  * stock icon code Copyright (C) 2002 Jorn Baayen <jorn@nl.linux.org>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -201,6 +201,8 @@ maybe_redirect_mouse_event (XEvent *xevent)
       gevent->motion.type = GDK_MOTION_NOTIFY;
       gevent->motion.window = g_object_ref (gdk_window);
       gevent->motion.time = xevent->xbutton.time;
+      gevent->motion.x = xevent->xbutton.x;
+      gevent->motion.y = xevent->xbutton.y;
       gevent->motion.x_root = xevent->xbutton.x_root;
       gevent->motion.y_root = xevent->xbutton.y_root;
 
@@ -272,7 +274,7 @@ meta_ui_remove_event_func (Display       *xdisplay,
                            gpointer       data)
 {
   g_return_if_fail (ef != NULL);
-  
+
   gdk_window_remove_filter (NULL, filter_func, ef);
 
   g_free (ef);
@@ -370,7 +372,7 @@ meta_ui_create_frame_window (MetaUI *ui,
   gint attributes_mask;
   GdkWindow *window;
   GdkVisual *visual;
-  
+
   /* Default depth/visual handles clients with weird visuals; they can
    * always be children of the root depth/visual obviously, but
    * e.g. DRI games can't be children of a parent that has the same
@@ -420,7 +422,7 @@ meta_ui_create_frame_window (MetaUI *ui,
 
   gdk_window_resize (window, width, height);
   set_background_none (xdisplay, GDK_WINDOW_XID (window));
-  
+
   meta_frames_manage_window (ui->frames, GDK_WINDOW_XID (window), window);
 
   return GDK_WINDOW_XID (window);
@@ -622,7 +624,7 @@ meta_text_property_to_utf8 (Display             *xdisplay,
   char **list;
   int count;
   char *retval;
-  
+
   list = NULL;
 
   display = gdk_x11_lookup_xdisplay (xdisplay);
@@ -640,7 +642,7 @@ meta_text_property_to_utf8 (Display             *xdisplay,
   retval = list[0];
   list[0] = g_strdup (""); /* something to free */
     }
-  
+
   g_strfreev (list);
 
   return retval;
@@ -764,24 +766,24 @@ meta_ui_parse_accelerator (const char          *accel,
   GdkModifierType gdk_mask = 0;
   guint gdk_sym = 0;
   guint gdk_code = 0;
-  
+
   *keysym = 0;
   *keycode = 0;
   *mask = 0;
 
   if (!accel[0] || strcmp (accel, "disabled") == 0)
     return TRUE;
-  
+
   meta_ui_accelerator_parse (accel, &gdk_sym, &gdk_code, &gdk_mask);
   if (gdk_mask == 0 && gdk_sym == 0 && gdk_code == 0)
     return FALSE;
 
   if (gdk_sym == None && gdk_code == 0)
     return FALSE;
-  
+
   if (gdk_mask & GDK_RELEASE_MASK) /* we don't allow this */
     return FALSE;
-  
+
   *keysym = gdk_sym;
   *keycode = gdk_code;
 
@@ -805,7 +807,7 @@ meta_ui_parse_accelerator (const char          *accel,
     *mask |= META_VIRTUAL_HYPER_MASK;
   if (gdk_mask & GDK_META_MASK)
     *mask |= META_VIRTUAL_META_MASK;
-  
+
   return TRUE;
 }
 
@@ -815,7 +817,7 @@ meta_ui_accelerator_name  (unsigned int        keysym,
                            MetaVirtualModifier mask)
 {
   GdkModifierType mods = 0;
-        
+
   if (keysym == 0 && mask == 0)
     {
       return g_strdup ("disabled");
@@ -853,19 +855,19 @@ meta_ui_parse_modifier (const char          *accel,
   GdkModifierType gdk_mask = 0;
   guint gdk_sym = 0;
   guint gdk_code = 0;
-  
+
   *mask = 0;
 
   if (accel == NULL || !accel[0] || strcmp (accel, "disabled") == 0)
     return TRUE;
-  
+
   meta_ui_accelerator_parse (accel, &gdk_sym, &gdk_code, &gdk_mask);
   if (gdk_mask == 0 && gdk_sym == 0 && gdk_code == 0)
     return FALSE;
 
   if (gdk_sym != None || gdk_code != 0)
     return FALSE;
-  
+
   if (gdk_mask & GDK_RELEASE_MASK) /* we don't allow this */
     return FALSE;
 
@@ -889,7 +891,7 @@ meta_ui_parse_modifier (const char          *accel,
     *mask |= META_VIRTUAL_HYPER_MASK;
   if (gdk_mask & GDK_META_MASK)
     *mask |= META_VIRTUAL_META_MASK;
-  
+
   return TRUE;
 }
 
@@ -948,7 +950,7 @@ meta_stock_icons_init (void)
       icon_set = gtk_icon_set_new_from_pixbuf (pixbuf);
       gtk_icon_factory_add (factory, items[i].stock_id, icon_set);
       gtk_icon_set_unref (icon_set);
-      
+
       g_object_unref (G_OBJECT (pixbuf));
     }
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -358,12 +358,13 @@ set_background_none (Display *xdisplay,
 LOCAL_SYMBOL Window
 meta_ui_create_frame_window (MetaUI *ui,
                              Display *xdisplay,
+                             MetaWindow *meta_window,
                              Visual *xvisual,
-			     gint x,
-			     gint y,
-			     gint width,
-			     gint height,
-			     gint screen_no,
+                             gint x,
+                             gint y,
+                             gint width,
+                             gint height,
+                             gint screen_no,
                              gulong *create_serial)
 {
   GdkDisplay *display = gdk_x11_lookup_xdisplay (xdisplay);
@@ -423,7 +424,7 @@ meta_ui_create_frame_window (MetaUI *ui,
   gdk_window_resize (window, width, height);
   set_background_none (xdisplay, GDK_WINDOW_XID (window));
 
-  meta_frames_manage_window (ui->frames, GDK_WINDOW_XID (window), window);
+  meta_frames_manage_window (ui->frames, meta_window, GDK_WINDOW_XID (window), window);
 
   return GDK_WINDOW_XID (window);
 }

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -30,6 +30,7 @@
 #include "menu.h"
 #include "core.h"
 #include "theme-private.h"
+#include "window-private.h"
 
 #include "inlinepixbufs.h"
 
@@ -110,6 +111,7 @@ maybe_redirect_mouse_event (XEvent *xevent)
   GdkEvent *gevent;
   GdkWindow *gdk_window;
   Window window;
+  MetaWindow *mw;
 
   switch (xevent->type)
     {
@@ -127,6 +129,11 @@ maybe_redirect_mouse_event (XEvent *xevent)
     default:
       return FALSE;
     }
+
+  mw = meta_compositor_get_window_for_xwindow (window);
+
+  if (!mw || !mw->frame)
+    return FALSE;
 
   gdisplay = gdk_x11_lookup_xdisplay (xevent->xany.display);
   ui = g_object_get_data (G_OBJECT (gdisplay), "meta-ui");

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -26,6 +26,7 @@
 
 /* Don't include gtk.h or gdk.h here */
 #include <meta/common.h>
+#include <meta/types.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <cairo.h>
@@ -66,6 +67,7 @@ void meta_ui_get_frame_borders (MetaUI *ui,
                                 MetaFrameBorders *borders);
 Window meta_ui_create_frame_window (MetaUI *ui,
                                     Display *xdisplay,
+                                    MetaWindow *meta_window,
                                     Visual *xvisual,
 				    gint x,
 				    gint y,

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -2,9 +2,9 @@
 
 /* Muffin interface for talking to GTK+ UI module */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -86,8 +86,6 @@ void meta_ui_move_resize_frame (MetaUI *ui,
 
 /* GDK insists on tracking map/unmap */
 void meta_ui_map_frame   (MetaUI *ui,
-                          Window  xwindow);
-void meta_ui_unmap_frame (MetaUI *ui,
                           Window  xwindow);
 
 cairo_region_t *meta_ui_get_frame_bounds (MetaUI  *ui,


### PR DESCRIPTION
This PR is intended to help improve the performance of framed windows, and reduce how far out of sync window positioning is with the  cursor when dragging. 

It is a mix of select upstream commits and some new changes.

- Eliminates usage of `gdk_window_get_device_position` which causes round trips to the X server, and prevents CSD window events from being handled in MetaFrames.
- Frame geometry calculation optimization. `meta_frames_calc_geometry` was getting called often, and limiting it to when the window rect changes improves performance in my testing.
- [Adds a pointer to MetaWindow on MetaUIFrame](https://github.com/gnome/mutter/commit/12135afa5e2016e6234d24dcfecdaa293576719a), so we can replace meta_core_get* round trips with more direct calls.

Depends on #410 because of 179354a1be9c33698da9006b0fb704feb2897df5, which is a key regression fix.