### PR TITLE
[Next] Reduce usage of signals between internal components

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -423,9 +423,9 @@ texture_size_changed (MetaWindow *mw,
 
 static void
 window_position_changed (MetaWindow *mw,
-                     gpointer    data)
+                         gpointer    data)
 {
-  MetaWindowActor *self = META_WINDOW_ACTOR (data);
+  MetaWindowActor *self = META_WINDOW_ACTOR (meta_window_get_compositor_private (mw));
 
   g_signal_emit (self, signals[POSITION_CHANGED], 0); // Compatibility
 }
@@ -588,8 +588,7 @@ meta_window_actor_set_property (GObject      *object,
                                  G_CALLBACK (window_decorated_notify), self, 0);
         g_signal_connect_object (priv->window, "notify::appears-focused",
                                  G_CALLBACK (window_appears_focused_notify), self, 0);
-        g_signal_connect_object (priv->window, "position-changed",
-                                 G_CALLBACK (window_position_changed), self, 0);
+        meta_window_set_position_changed_callback (priv->window, window_position_changed);
       }
       break;
     case PROP_META_SCREEN:

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -511,6 +511,8 @@ struct _MetaWindow
 
   /* Bypass compositor hints */
   guint bypass_compositor;
+
+  MetaWindowCallback position_changed_callback;
 };
 
 struct _MetaWindowClass

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5386,7 +5386,12 @@ meta_window_move_resize_internal (MetaWindow          *window,
     save_user_window_placement (window);
 
   if (need_move_frame)
-    g_signal_emit (window, window_signals[POSITION_CHANGED], 0);
+    {
+      if (window->position_changed_callback != NULL)
+        (window->position_changed_callback) (window);
+      else
+        g_signal_emit (window, window_signals[POSITION_CHANGED], 0);
+    }
 
   if (need_resize_client)
     g_signal_emit (window, window_signals[SIZE_CHANGED], 0);
@@ -12374,3 +12379,22 @@ meta_window_get_icon_name (MetaWindow *window)
 
     return window->theme_icon_name;
 }
+
+/**
+ * meta_window_set_position_changed_callback:
+ * @window: a #MetaWindow
+ * @callback (scope notified): callback
+ * @user_data (closure): user data
+ * @data_destroy: a #GDestroyNotify
+ *
+ * Sets the callback which will be invoked on position change.
+ */
+void
+meta_window_set_position_changed_callback (MetaWindow        *window,
+                                           MetaWindowCallback callback,
+                                           gpointer           user_data,
+                                           GDestroyNotify     data_destroy)
+{
+  window->position_changed_callback = callback;
+}
+

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -68,6 +68,14 @@ typedef struct _MetaWindowClass   MetaWindowClass;
 
 GType meta_window_get_type (void);
 
+/**
+ * MetaWindowCallback:
+ * @window: (closure): a #MetaWindow
+ *
+ * Callback type for MetaWindow
+ */
+typedef void (* MetaWindowCallback) (MetaWindow *window);
+
 MetaFrame *meta_window_get_frame (MetaWindow *window);
 gboolean meta_window_has_focus (MetaWindow *window);
 gboolean meta_window_appears_focused (MetaWindow *window);


### PR DESCRIPTION
This is an extension of the idea from [Cinnamon PR #8230](https://github.com/linuxmint/Cinnamon/pull/8230). This uses a callback for MetaWindow's `position-changed` signal, which is a new addition since 4.0, and all it does is notify MetaWindowActor to emit its signal. The signal is replaced, but not removed so it doesn't conflict with #399.

I also have tested replacing `after-paint` and `presented` on ClutterStage, and that didn't work so well because it relies on the deferred behavior from `g_signal_connect_after`.