### PR TITLE
window-actor: Fix partially visible frameless windows, some window flickering cases

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -77,6 +77,9 @@ void     meta_end_modal_for_plugin   (MetaScreen       *screen,
 gint64 meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
                                                       gint64       monotonic_time);
 
+void meta_compositor_grab_op_begin (MetaCompositor *compositor);
+void meta_compositor_grab_op_end (MetaCompositor *compositor);
+
 void meta_check_end_modal (MetaScreen *screen);
 
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1611,20 +1611,11 @@ meta_compositor_grab_op_begin (MetaCompositor *compositor)
   // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
   // but causes windows to flicker in and out of view sporadically on some configurations
   // while dragging windows. Make sure it is disabled during the grab.
-  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
-
-  if (!info)
-    return NULL;
-  clutter_actor_unset_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+  clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 void
 meta_compositor_grab_op_end (MetaCompositor *compositor)
 {
-  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
-
-  if (!info)
-    return NULL;
-
-  clutter_actor_set_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+  clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1604,3 +1604,27 @@ meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
   else
     return monotonic_time + compositor->server_time_offset;
 }
+
+void
+meta_compositor_grab_op_begin (MetaCompositor *compositor)
+{
+  // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
+  // but causes windows to flicker in and out of view sporadically on some configurations
+  // while dragging windows. Make sure it is disabled during the grab.
+  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
+
+  if (!info)
+    return NULL;
+  clutter_actor_unset_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+}
+
+void
+meta_compositor_grab_op_end (MetaCompositor *compositor)
+{
+  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
+
+  if (!info)
+    return NULL;
+
+  clutter_actor_set_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+}

--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -107,7 +107,6 @@ struct _MetaShapedTexturePrivate
   cairo_path_t *overlay_path;
 
   guint tex_width, tex_height;
-  guint mask_width, mask_height;
 
   gint64 prev_invalidation, last_invalidation;
   guint fast_updates;
@@ -332,7 +331,8 @@ install_overlay_path (MetaShapedTexture *stex,
 }
 
 LOCAL_SYMBOL void
-meta_shaped_texture_ensure_mask (MetaShapedTexture *stex)
+meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
+                                 gboolean           has_frame)
 {
   MetaShapedTexturePrivate *priv = stex->priv;
   CoglTexture *paint_tex;
@@ -348,10 +348,7 @@ meta_shaped_texture_ensure_mask (MetaShapedTexture *stex)
 
   /* If the mask texture we have was created for a different size then
      recreate it */
-  if (priv->mask_texture != NULL
-      && (priv->mask_width != tex_width
-          || priv->mask_height != tex_height
-          || priv->mask_needs_update))
+  if (priv->mask_texture != NULL && priv->mask_needs_update)
     {
       priv->mask_needs_update = FALSE;
       meta_shaped_texture_dirty_mask (stex);
@@ -410,7 +407,8 @@ meta_shaped_texture_ensure_mask (MetaShapedTexture *stex)
             memset (p, 255, x2 - x1);
         }
 
-      install_overlay_path (stex, mask_data, tex_width, tex_height, stride);
+      if (has_frame)
+        install_overlay_path (stex, mask_data, tex_width, tex_height, stride);
 
       if (meta_texture_rectangle_check (paint_tex))
         priv->mask_texture = meta_cogl_rectangle_new (tex_width, tex_height,
@@ -425,9 +423,6 @@ meta_shaped_texture_ensure_mask (MetaShapedTexture *stex)
                                                                       mask_data);
 
       g_free (mask_data);
-
-      priv->mask_width = tex_width;
-      priv->mask_height = tex_height;
     }
 }
 

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -316,8 +316,6 @@ static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
   ClutterActor *actor = CLUTTER_ACTOR (window_group);
-
-  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -316,6 +316,8 @@ static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
   ClutterActor *actor = CLUTTER_ACTOR (window_group);
+
+  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3723,6 +3723,8 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_window_refresh_resize_popup (display->grab_window);
     }
 
+  meta_compositor_grab_op_begin (display->compositor);
+
   g_signal_emit (display, display_signals[GRAB_OP_BEGIN], 0,
                  screen, display->grab_window, display->grab_op);
   
@@ -3771,6 +3773,8 @@ meta_display_end_grab_op (MetaDisplay *display,
   
   if (display->grab_op == META_GRAB_OP_NONE)
     return;
+
+  meta_compositor_grab_op_end (display->compositor);
 
   g_signal_emit (display, display_signals[GRAB_OP_END], 0,
                  display->grab_screen, display->grab_window, display->grab_op);

--- a/src/meta/meta-shaped-texture.h
+++ b/src/meta/meta-shaped-texture.h
@@ -84,7 +84,8 @@ void meta_shaped_texture_set_opaque_region (MetaShapedTexture *stex,
 cairo_surface_t * meta_shaped_texture_get_image (MetaShapedTexture     *stex,
                                                  cairo_rectangle_int_t *clip);
 
-void meta_shaped_texture_ensure_mask (MetaShapedTexture *stex);
+void meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
+                                      gboolean           has_frame);
 
 void meta_shaped_texture_dirty_mask (MetaShapedTexture *stex);
 


### PR DESCRIPTION
#390 partially fixed this, but some clients need more time after being re-mapped before the mask texture stops being set - such as Virtualbox's seamless window.

Closes #404 
Closes #398 
Closes https://github.com/linuxmint/Cinnamon/issues/8265