### PR TITLE
Stop caching the shape region in MetaShapedTexture

### DIFF
--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -61,8 +61,6 @@
 static void meta_shaped_texture_dispose  (GObject    *object);
 
 static void meta_shaped_texture_paint (ClutterActor       *actor);
-static void meta_shaped_texture_pick  (ClutterActor       *actor,
-				       const ClutterColor *color);
 
 static void meta_shaped_texture_get_preferred_width (ClutterActor *self,
                                                      gfloat        for_height,
@@ -100,7 +98,6 @@ struct _MetaShapedTexturePrivate
 
   cairo_region_t *clip_region;
   cairo_region_t *unobscured_region;
-  cairo_region_t *shape_region;
   cairo_region_t *opaque_region;
 
   cairo_region_t *overlay_region;
@@ -128,7 +125,6 @@ meta_shaped_texture_class_init (MetaShapedTextureClass *klass)
   actor_class->get_preferred_width = meta_shaped_texture_get_preferred_width;
   actor_class->get_preferred_height = meta_shaped_texture_get_preferred_height;
   actor_class->paint = meta_shaped_texture_paint;
-  actor_class->pick = meta_shaped_texture_pick;
   actor_class->get_paint_volume = meta_shaped_texture_get_paint_volume;
 
   signals[SIZE_CHANGED] = g_signal_new ("size-changed",
@@ -148,7 +144,6 @@ meta_shaped_texture_init (MetaShapedTexture *self)
 
   priv = self->priv = META_SHAPED_TEXTURE_GET_PRIVATE (self);
 
-  priv->shape_region = NULL;
   priv->overlay_path = NULL;
   priv->overlay_region = NULL;
   priv->paint_tower = meta_texture_tower_new ();
@@ -178,7 +173,6 @@ meta_shaped_texture_dispose (GObject *object)
   g_clear_pointer (&priv->texture, cogl_object_unref);
   g_clear_pointer (&priv->opaque_region, cairo_region_destroy);
 
-  meta_shaped_texture_set_shape_region (self, NULL);
   meta_shaped_texture_set_clip_region (self, NULL);
   meta_shaped_texture_set_overlay_path (self, NULL, NULL);
 
@@ -332,6 +326,7 @@ install_overlay_path (MetaShapedTexture *stex,
 
 LOCAL_SYMBOL void
 meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
+                                 cairo_region_t    *shape_region,
                                  gboolean           has_frame)
 {
   MetaShapedTexturePrivate *priv = stex->priv;
@@ -364,17 +359,17 @@ meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
 
       /* If we have no shape region and no (or an empty) overlay region, we
        * don't need to create a full mask texture, so quit early. */
-      if (priv->shape_region == NULL &&
+      if (shape_region == NULL &&
           (priv->overlay_region == NULL ||
            cairo_region_num_rectangles (priv->overlay_region) == 0))
         {
           return;
         }
 
-      if (priv->shape_region == NULL)
+      if (shape_region == NULL)
         return;
 
-      n_rects = cairo_region_num_rectangles (priv->shape_region);
+      n_rects = cairo_region_num_rectangles (shape_region);
 
       if (n_rects == 0)
         return;
@@ -388,7 +383,7 @@ meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
       for (i = 0; i < n_rects; i ++)
         {
           cairo_rectangle_int_t rect;
-          cairo_region_get_rectangle (priv->shape_region, i, &rect);
+          cairo_region_get_rectangle (shape_region, i, &rect);
 
           gint x1 = rect.x, x2 = x1 + rect.width;
           gint y1 = rect.y, y2 = y1 + rect.height;
@@ -664,64 +659,6 @@ meta_shaped_texture_paint (ClutterActor *actor)
 }
 
 static void
-meta_shaped_texture_pick (ClutterActor       *actor,
-			                    const ClutterColor *color)
-{
-  if (!clutter_actor_should_pick_paint (actor))
-    return;
-
-  MetaShapedTexture *stex = (MetaShapedTexture *) actor;
-  MetaShapedTexturePrivate *priv = stex->priv;
-  ClutterActorIter iter;
-  ClutterActor *child;
-
-  /* If there is no region then use the regular pick */
-  if (priv->shape_region == NULL)
-    CLUTTER_ACTOR_CLASS (meta_shaped_texture_parent_class)->pick (actor, color);
-  else
-    {
-      int n_rects;
-      float *rectangles;
-      int i;
-      CoglPipeline *pipeline;
-      CoglContext *ctx;
-      CoglFramebuffer *fb;
-      CoglColor cogl_color;
-
-      n_rects = cairo_region_num_rectangles (priv->shape_region);
-      rectangles = g_alloca (sizeof (float) * 4 * n_rects);
-
-      for (i = 0; i < n_rects; i++)
-        {
-          cairo_rectangle_int_t rect;
-          int pos = i * 4;
-
-          cairo_region_get_rectangle (priv->shape_region, i, &rect);
-
-          rectangles[pos + 0] = rect.x;
-          rectangles[pos + 1] = rect.y;
-          rectangles[pos + 2] = rect.x + rect.width;
-          rectangles[pos + 3] = rect.y + rect.height;
-        }
-
-      ctx = clutter_backend_get_cogl_context (clutter_get_default_backend ());
-      fb = cogl_get_draw_framebuffer ();
-
-      cogl_color_init_from_4ub (&cogl_color, color->red, color->green, color->blue, color->alpha);
-
-      pipeline = cogl_pipeline_new (ctx);
-      cogl_pipeline_set_color (pipeline, &cogl_color);
-      cogl_framebuffer_draw_rectangles (fb, pipeline, rectangles, n_rects);
-      cogl_object_unref (pipeline);
-    }
-
-  clutter_actor_iter_init (&iter, actor);
-
-  while (clutter_actor_iter_next (&iter, &child))
-    clutter_actor_paint (child);
-}
-
-static void
 meta_shaped_texture_get_preferred_width (ClutterActor *self,
                                          gfloat        for_height,
                                          gfloat       *min_width_p,
@@ -785,29 +722,6 @@ meta_shaped_texture_set_create_mipmaps (MetaShapedTexture *stex,
       base_texture = create_mipmaps ? priv->texture : NULL;
 
       meta_texture_tower_set_base_texture (priv->paint_tower, base_texture);
-    }
-}
-
-void
-meta_shaped_texture_set_shape_region (MetaShapedTexture *stex,
-                                      cairo_region_t    *region)
-{
-  MetaShapedTexturePrivate *priv;
-
-  g_return_if_fail (META_IS_SHAPED_TEXTURE (stex));
-
-  priv = stex->priv;
-
-  if (priv->shape_region != NULL)
-    {
-      cairo_region_destroy (priv->shape_region);
-      priv->shape_region = NULL;
-    }
-
-  if (region != NULL)
-    {
-      cairo_region_reference (region);
-      priv->shape_region = region;
     }
 }
 

--- a/src/meta/meta-shaped-texture.h
+++ b/src/meta/meta-shaped-texture.h
@@ -68,9 +68,6 @@ gboolean meta_shaped_texture_update_area (MetaShapedTexture *stex,
 
 CoglTexture *meta_shaped_texture_get_texture (MetaShapedTexture *stex);
 
-void meta_shaped_texture_set_shape_region (MetaShapedTexture *stex,
-                                           cairo_region_t    *region);
-
 void meta_shaped_texture_set_overlay_path (MetaShapedTexture *stex,
                                            cairo_region_t    *overlay_region,
                                            cairo_path_t      *overlay_path);
@@ -85,6 +82,7 @@ cairo_surface_t * meta_shaped_texture_get_image (MetaShapedTexture     *stex,
                                                  cairo_rectangle_int_t *clip);
 
 void meta_shaped_texture_ensure_mask (MetaShapedTexture *stex,
+                                      cairo_region_t    *shape_region,
                                       gboolean           has_frame);
 
 void meta_shaped_texture_dirty_mask (MetaShapedTexture *stex);


### PR DESCRIPTION
Seeing Cinnamon start with slightly lower memory usage with this patch applied, and improved responsiveness.

Depends on #405