### PR TITLE
[Next] Avoid usage of g_getenv in frequently called functions

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -784,7 +784,7 @@ meta_window_actor_paint (ClutterActor *actor)
   MetaWindowActorPrivate *priv = self->priv;
   gboolean appears_focused = meta_window_appears_focused (priv->window);
   MetaShadow *shadow = appears_focused ? priv->focused_shadow : priv->unfocused_shadow;
-  if (g_getenv ("MUFFIN_NO_SHADOWS")) {
+  if (!priv->window->display->shadows_enabled) {
       shadow = NULL;
   }
 
@@ -1159,13 +1159,10 @@ meta_window_actor_damage_all (MetaWindowActor *self)
   MetaWindowActorPrivate *priv = self->priv;
   CoglTexture *texture;
 
-  if (!priv->needs_damage_all)
+  if (!priv->needs_damage_all || !priv->window->mapped || priv->needs_pixmap)
     return;
 
   texture = meta_shaped_texture_get_texture (META_SHAPED_TEXTURE (priv->actor));
-
-  if (!priv->window->mapped || priv->needs_pixmap)
-    return;
 
   priv->needs_damage_all = FALSE;
 
@@ -2129,7 +2126,7 @@ check_needs_pixmap (MetaWindowActor *self)
 static void
 check_needs_shadow (MetaWindowActor *self)
 {
-  if (g_getenv ("MUFFIN_NO_SHADOWS")) {
+  if (!self->priv->window->display->shadows_enabled) {
       return;
   }
 

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -299,6 +299,9 @@ struct _MetaDisplay
 #define META_DISPLAY_HAS_COMPOSITE(display) ((display)->have_composite)
 #define META_DISPLAY_HAS_DAMAGE(display) ((display)->have_damage)
 #define META_DISPLAY_HAS_XFIXES(display) ((display)->have_xfixes)
+
+  guint shadows_enabled : 1;
+  guint debug_button_grabs : 1;
 };
 
 struct _MetaDisplayClass

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -869,7 +869,9 @@ meta_display_open (void)
   the_display->last_focus_time = timestamp;
   the_display->last_user_time = timestamp;
   the_display->compositor = NULL;
-  
+  the_display->shadows_enabled = g_getenv ("MUFFIN_NO_SHADOWS") == NULL;
+  the_display->debug_button_grabs = g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS") != NULL;
+
   screens = NULL;
   
   i = 0;
@@ -1860,7 +1862,7 @@ event_callback (XEvent   *event,
           gboolean unmodified;
 
           grab_mask = display->window_grab_modifiers;
-          if (g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS"))
+          if (display->debug_button_grabs)
             grab_mask |= ControlMask;
 
           /* Two possible sources of an unmodified event; one is a
@@ -3976,10 +3978,10 @@ meta_display_grab_window_buttons (MetaDisplay *display,
    * put one big error trap around the loop and avoid a bunch of
    * XSync()
    */
+  gboolean debug = display->debug_button_grabs;
 
   if (display->window_grab_modifiers != 0)
     {
-      gboolean debug = g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS") != NULL;
       int i;
       for (i = 1; i < 4; i++)
         {
@@ -4012,7 +4014,6 @@ meta_display_grab_window_buttons (MetaDisplay *display,
 
   if (display->mouse_zoom_enabled && display->mouse_zoom_modifiers != 0)
     {
-      gboolean debug = g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS") != NULL;
       int i;
       for (i = 4; i < 6; i++)
         {
@@ -4042,8 +4043,8 @@ meta_display_ungrab_window_buttons  (MetaDisplay *display,
 
   if (display->window_grab_modifiers == 0)
     return;
-  
-  debug = g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS") != NULL;
+
+  debug = display->debug_button_grabs;
   i = 1;
   while (i < 4)
     {


### PR DESCRIPTION
After looking at the complexity of the function in GLib, it looks like this shouldn't be called inside paint functions.