### PR TITLE
window: Pass the input rect to meta_compositor_tile_window

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3817,11 +3817,11 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
     {
       MetaRectangle old_rect;
       MetaRectangle new_rect;
-      meta_window_get_outer_rect (window, &old_rect);
+      meta_window_get_input_rect (window, &old_rect);
 
       meta_window_move_resize_now (window);
 
-      meta_window_get_outer_rect (window, &new_rect);
+      meta_window_get_input_rect (window, &new_rect);
       meta_compositor_tile_window (window->display->compositor,
                                    window,
                                    &old_rect,


### PR DESCRIPTION
This fixes a regression introduced in #382 that is causing the position to not be set correctly when a window is tiled.

Closes #396 