### PR TITLE
clutter-stage: Don't emit "after-paint" when picking

### DIFF
--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1511,7 +1511,8 @@ _clutter_stage_do_pick_on_view (ClutterStage     *stage,
    * are drawn offscreen (as we never swap buffers)
   */
   context->pick_mode = mode;
-  _clutter_stage_paint_view (stage, view, NULL);
+  /* Paint without emitting AFTER_PAINT */
+  clutter_stage_do_paint_view (stage, view, NULL);
   context->pick_mode = CLUTTER_PICK_NONE;
 
   /* Read the color of the screen co-ords pixel. RGBA_8888_PRE is used


### PR DESCRIPTION
> The "after-paint" signal should only be emitted on real stage repaints and not fake stage repaints used in picking. The latter might occur at a much higher and inconsistent rate and is not what apps/toolkits listening for _NET_WM_FRAME_DRAWN care about.

Cherry-picked from https://github.com/GNOME/mutter/commit/93c29318b2994cb23cc88e0c63d923bb0bc92dc8