### PR TITLE
window-actor: Only fall back to shadows if the window has a shape

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -960,7 +960,7 @@ meta_window_actor_has_shadow (MetaWindowActor *self)
     return TRUE;
 #endif
 
-  return TRUE;
+  return priv->window->has_shape;
 }
 
 /**


### PR DESCRIPTION
This includes all of the windows I think we would want to have shadows, such as framed windows, GTK CSD windows, and chromium windows. 

This removes shadows on windows such as Steam, which has artifacts because it initially maps its menus outside of the parent window causing it to lose focus, which makes the shadow border flicker between focused and unfocused while hovering over selections.

Ref #398 