### PR TITLE
 window: Expose Flatpak/Snap application IDs

### DIFF
--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -153,6 +153,7 @@ struct _MetaWindow
 
   char *startup_id;
   char *muffin_hints;
+  char *flatpak_id;
   char *gtk_theme_variant;
   char *gtk_application_id;
   char *gtk_unique_bus_name;
@@ -840,6 +841,8 @@ void meta_window_extend_by_frame (MetaWindow              *window,
 void meta_window_unextend_by_frame (MetaWindow              *window,
                                     MetaRectangle           *rect,
                                     const MetaFrameBorders  *borders);
+
+uint32_t meta_window_get_client_pid (MetaWindow *window);
 
 void meta_window_get_client_area_rect (const MetaWindow      *window,
                                        cairo_rectangle_int_t *rect);

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -153,7 +153,7 @@ struct _MetaWindow
 
   char *startup_id;
   char *muffin_hints;
-  char *flatpak_id;
+  char *sandboxed_app_id;
   char *gtk_theme_variant;
   char *gtk_application_id;
   char *gtk_unique_bus_name;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -64,6 +64,8 @@
 #include <X11/extensions/Xcomposite.h>
 #include <gdk/gdkx.h>
 
+#define SNAP_SECURITY_LABEL_PREFIX "snap."
+
 static int destroying_windows_disallowed = 0;
 
 
@@ -267,7 +269,7 @@ meta_window_finalize (GObject *object)
   g_free (window->icon_name);
   g_free (window->theme_icon_name);
   g_free (window->desc);
-  g_free (window->flatpak_id);
+  g_free (window->sandboxed_app_id);
   g_free (window->gtk_theme_variant);
   g_free (window->gtk_application_id);
   g_free (window->gtk_unique_bus_name);
@@ -761,25 +763,94 @@ sync_client_window_mapped (MetaWindow *window)
   meta_error_trap_pop (window->display);
 }
 
-static void
-meta_window_update_flatpak_id (MetaWindow *window)
+static gboolean
+meta_window_update_flatpak_id (MetaWindow *window,
+                               uint32_t    pid)
 {
-  uint32_t pid = meta_window_get_client_pid (window);
   g_autoptr(GKeyFile) key_file = NULL;
   g_autofree char *info_filename = NULL;
 
-  g_clear_pointer (&window->flatpak_id, g_free);
-
-  if (pid == 0)
-    return;
+  g_return_val_if_fail (pid != 0, FALSE);
+  g_return_val_if_fail (window->sandboxed_app_id == NULL, FALSE);
 
   key_file = g_key_file_new ();
   info_filename = g_strdup_printf ("/proc/%u/root/.flatpak-info", pid);
 
   if (!g_key_file_load_from_file (key_file, info_filename, G_KEY_FILE_NONE, NULL))
+    return FALSE;
+
+  window->sandboxed_app_id = g_key_file_get_string (key_file, "Application", "name", NULL);
+
+  return TRUE;
+}
+
+static gboolean
+meta_window_update_snap_id (MetaWindow *window,
+                            uint32_t    pid)
+{
+  g_autofree char *security_label_filename = NULL;
+  g_autofree char *security_label_contents = NULL;
+  gsize i, security_label_contents_size = 0;
+  char *contents_start;
+  char *contents_end;
+  char *sandboxed_app_id;
+
+  g_return_val_if_fail (pid != 0, FALSE);
+  g_return_val_if_fail (window->sandboxed_app_id == NULL, FALSE);
+
+  security_label_filename = g_strdup_printf ("/proc/%u/attr/current", pid);
+
+  if (!g_file_get_contents (security_label_filename,
+                            &security_label_contents,
+                            &security_label_contents_size,
+                            NULL))
+    return FALSE;
+
+  if (!g_str_has_prefix (security_label_contents, SNAP_SECURITY_LABEL_PREFIX))
+    return FALSE;
+
+  /* We need to translate the security profile into the desktop-id.
+   * The profile is in the form of 'snap.name-space.binary-name (current)'
+   * while the desktop id will be name-space_binary-name.
+   */
+  security_label_contents_size -= sizeof (SNAP_SECURITY_LABEL_PREFIX) - 1;
+  contents_start = security_label_contents + sizeof (SNAP_SECURITY_LABEL_PREFIX) - 1;
+  contents_end = strchr (contents_start, ' ');
+
+  if (contents_end)
+    security_label_contents_size = contents_end - contents_start;
+
+  for (i = 0; i < security_label_contents_size; ++i)
+    {
+      if (contents_start[i] == '.')
+        contents_start[i] = '_';
+    }
+
+  sandboxed_app_id = g_malloc0 (security_label_contents_size + 1);
+  memcpy (sandboxed_app_id, contents_start, security_label_contents_size);
+
+  window->sandboxed_app_id = sandboxed_app_id;
+
+  return TRUE;
+}
+
+static void
+meta_window_update_sandboxed_app_id (MetaWindow *window)
+{
+  uint32_t pid;
+
+  g_clear_pointer (&window->sandboxed_app_id, g_free);
+
+  pid = meta_window_get_client_pid (window);
+
+  if (pid == 0)
     return;
 
-  window->flatpak_id = g_key_file_get_string (key_file, "Application", "name", NULL);
+  if (meta_window_update_flatpak_id (window, pid))
+    return;
+
+  if (meta_window_update_snap_id (window, pid))
+    return;
 }
 
 LOCAL_SYMBOL MetaWindow*
@@ -1155,7 +1226,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
 
   window->screen = screen;
 
-  meta_window_update_flatpak_id (window);
+  meta_window_update_sandboxed_app_id (window);
   window->desc = g_strdup_printf ("0x%lx", window->xwindow);
 
   window->override_redirect = attrs->override_redirect;
@@ -11634,7 +11705,9 @@ meta_window_get_wm_class_instance (MetaWindow *window)
 const char *
 meta_window_get_flatpak_id (MetaWindow *window)
 {
-  return window->flatpak_id;
+  /* We're abusing this API here not to break the gnome shell assumptions
+   * or adding a new function, to be renamed to generic names in new versions */
+  return window->sandboxed_app_id;
 }
 
 /**

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -11697,13 +11697,16 @@ meta_window_get_wm_class_instance (MetaWindow *window)
 }
 
 /**
- * meta_window_get_flatpak_id:
+ * meta_window_get_sandboxed_app_id:
  * @window: a #MetaWindow
  *
- * Return value: (transfer none): the Flatpak application ID or %NULL
+ * Gets an unique id for a sandboxed app (currently flatpaks and snaps are
+ * supported).
+ *
+ * Return value: (transfer none): the sandboxed application ID or %NULL
  **/
 const char *
-meta_window_get_flatpak_id (MetaWindow *window)
+meta_window_get_sandboxed_app_id (MetaWindow *window)
 {
   /* We're abusing this API here not to break the gnome shell assumptions
    * or adding a new function, to be renamed to generic names in new versions */

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -95,6 +95,8 @@ const char * meta_window_get_wm_class (MetaWindow *window);
 const char * meta_window_get_wm_class_instance (MetaWindow *window);
 gboolean    meta_window_showing_on_its_workspace (MetaWindow *window);
 
+const char * meta_window_get_flatpak_id (MetaWindow *window);
+const char * meta_window_get_gtk_theme_variant (MetaWindow *window);
 const char * meta_window_get_gtk_application_id (MetaWindow *window);
 const char * meta_window_get_gtk_unique_bus_name (MetaWindow *window);
 const char * meta_window_get_gtk_application_object_path (MetaWindow *window);

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -95,7 +95,7 @@ const char * meta_window_get_wm_class (MetaWindow *window);
 const char * meta_window_get_wm_class_instance (MetaWindow *window);
 gboolean    meta_window_showing_on_its_workspace (MetaWindow *window);
 
-const char * meta_window_get_flatpak_id (MetaWindow *window);
+const char * meta_window_get_sandboxed_app_id (MetaWindow *window);
 const char * meta_window_get_gtk_theme_variant (MetaWindow *window);
 const char * meta_window_get_gtk_application_id (MetaWindow *window);
 const char * meta_window_get_gtk_unique_bus_name (MetaWindow *window);


### PR DESCRIPTION
This also adds `meta_window_get_client_pid` as a dependency of `meta_window_update_sandboxed_app_id`.