### PR TITLE
Replace some GLib wrappers

### DIFF
--- a/clutter/clutter/cally/cally-actor.c
+++ b/clutter/clutter/cally/cally-actor.c
@@ -947,7 +947,7 @@ cally_actor_action_set_description (AtkAction   *action,
   if (info == NULL)
       return FALSE;
 
-  g_free (info->description);
+  free (info->description);
   info->description = g_strdup (desc);
 
   return TRUE;
@@ -1236,9 +1236,9 @@ _cally_actor_destroy_action_info (gpointer action_info,
 
   g_assert (info != NULL);
 
-  g_free (info->name);
-  g_free (info->description);
-  g_free (info->keybinding);
+  free (info->name);
+  free (info->description);
+  free (info->keybinding);
 
   if (info->notify)
     info->notify (info->user_data);

--- a/clutter/clutter/cally/cally-factory.h
+++ b/clutter/clutter/cally/cally-factory.h
@@ -93,7 +93,7 @@ type_as_function ## _factory_get_type (void)					\
     name = g_strconcat (g_type_name (type), "Factory", NULL);			\
     t = g_type_register_static (						\
 	    ATK_TYPE_OBJECT_FACTORY, name, &tinfo, 0);				\
-    g_free (name);								\
+    free (name);								\
   }										\
 										\
   return t;									\

--- a/clutter/clutter/cally/cally-text.c
+++ b/clutter/clutter/cally/cally-text.c
@@ -750,7 +750,7 @@ pango_layout_get_line_after (PangoLayout     *layout,
  * atk_text_get_text_after_offset().
  *
  * Returns: a newly allocated string containing a slice of text
- *     from layout. Free with g_free().
+ *     from layout. Free with free().
  */
 static gchar *
 _gtk_pango_get_text_at (PangoLayout     *layout,
@@ -849,7 +849,7 @@ _gtk_pango_get_text_at (PangoLayout     *layout,
  * atk_text_get_text_before_offset().
  *
  * Returns: a newly allocated string containing a slice of text
- *     from layout. Free with g_free().
+ *     from layout. Free with free().
  */
 static gchar *
 _gtk_pango_get_text_before (PangoLayout     *layout,
@@ -950,7 +950,7 @@ _gtk_pango_get_text_before (PangoLayout     *layout,
  * atk_text_get_text_after_offset().
  *
  * Returns: a newly allocated string containing a slice of text
- *     from layout. Free with g_free().
+ *     from layout. Free with free().
  */
 static gchar *
 _gtk_pango_get_text_after (PangoLayout     *layout,

--- a/clutter/clutter/cally/cally-text.c
+++ b/clutter/clutter/cally/cally-text.c
@@ -1860,7 +1860,7 @@ _cally_misc_add_attribute (AtkAttributeSet *attrib_set,
                            gchar           *value)
 {
   AtkAttributeSet *return_set;
-  AtkAttribute *at = g_malloc (sizeof (AtkAttribute));
+  AtkAttribute *at = malloc (sizeof (AtkAttribute));
   at->name = g_strdup (atk_text_attribute_get_name (attr));
   at->value = value;
   return_set = g_slist_prepend(attrib_set, at);

--- a/clutter/clutter/cally/cally-util.c
+++ b/clutter/clutter/cally/cally-util.c
@@ -156,7 +156,7 @@ cally_util_add_key_event_listener (AtkKeySnoopFunc  listener,
 
   if (!key_listener_list)
   {
-    key_listener_list = g_hash_table_new_full (NULL, NULL, NULL, g_free);
+    key_listener_list = g_hash_table_new_full (NULL, NULL, NULL, free);
 
     cally_util_simulate_snooper_install ();
   }
@@ -414,8 +414,8 @@ cally_key_snooper (ClutterActor *actor,
       consumed = g_hash_table_foreach_steal (new_hash, notify_hf, key_event);
       g_hash_table_destroy (new_hash);
 
-      g_free (key_event->string);
-      g_free (key_event);
+      free (key_event->string);
+      free (key_event);
     }
 
   return (consumed ? 1 : 0);

--- a/clutter/clutter/clutter-actor-meta.c
+++ b/clutter/clutter/clutter-actor-meta.c
@@ -167,7 +167,7 @@ clutter_actor_meta_finalize (GObject *gobject)
   if (priv->destroy_id != 0 && priv->actor != NULL)
     g_signal_handler_disconnect (priv->actor, priv->destroy_id);
 
-  g_free (priv->name);
+  free (priv->name);
 
   G_OBJECT_CLASS (clutter_actor_meta_parent_class)->finalize (gobject);
 }
@@ -257,7 +257,7 @@ clutter_actor_meta_set_name (ClutterActorMeta *meta,
   if (g_strcmp0 (meta->priv->name, name) == 0)
     return;
 
-  g_free (meta->priv->name);
+  free (meta->priv->name);
   meta->priv->name = g_strdup (name);
 
   g_object_notify_by_pspec (G_OBJECT (meta), obj_props[PROP_NAME]);

--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -24,7 +24,7 @@
 
 /**
  * SECTION:clutter-actor
- * @short_description: The basic element of the scene graph 
+ * @short_description: The basic element of the scene graph
  *
  * The ClutterActor class is the basic element of the scene graph in Clutter,
  * and it encapsulates the position, size, and transformations of a node in
@@ -3414,7 +3414,7 @@ _clutter_actor_paint_cull_result (ClutterActor *self,
                                 0,
                                 &color,
                                 0);
-      g_free (label);
+      free (label);
       g_object_unref (layout);
     }
 }
@@ -4733,7 +4733,7 @@ clutter_actor_set_rotation_center_internal (ClutterActor        *self,
                                             ClutterRotateAxis    axis,
                                             const ClutterVertex *center)
 {
-  ClutterVertex v = CLUTTER_VERTEX_INIT_ZERO; 
+  ClutterVertex v = CLUTTER_VERTEX_INIT_ZERO;
   GObject *obj = G_OBJECT (self);
   ClutterTransformInfo *info;
 
@@ -5998,10 +5998,10 @@ clutter_actor_finalize (GObject *object)
                 _clutter_actor_get_debug_name ((ClutterActor *) object),
                 g_type_name (G_OBJECT_TYPE (object)));
 
-  g_free (priv->name);
+  free (priv->name);
 
 #ifdef CLUTTER_ENABLE_DEBUG
-  g_free (priv->debug_name);
+  free (priv->debug_name);
 #endif
 
   G_OBJECT_CLASS (clutter_actor_parent_class)->finalize (object);
@@ -11919,7 +11919,7 @@ clutter_actor_set_name (ClutterActor *self,
 {
   g_return_if_fail (CLUTTER_IS_ACTOR (self));
 
-  g_free (self->priv->name);
+  free (self->priv->name);
   self->priv->name = g_strdup (name);
 
   g_object_notify_by_pspec (G_OBJECT (self), obj_props[PROP_NAME]);
@@ -14138,7 +14138,7 @@ clutter_actor_get_anchor_point_gravity (ClutterActor *self)
  *
  * Since: 0.6
  *
- * Deprecated: 1.12: Use #ClutterActor:pivot-point and 
+ * Deprecated: 1.12: Use #ClutterActor:pivot-point and
  * clutter_actor_set_translation() instead.
  */
 void
@@ -14186,7 +14186,7 @@ clutter_actor_move_anchor_point (ClutterActor *self,
  *
  * Since: 0.6
  *
- * Deprecated: 1.12: Use #ClutterActor:pivot-point and 
+ * Deprecated: 1.12: Use #ClutterActor:pivot-point and
  * clutter_actor_set_translation() instead.
  */
 void
@@ -14238,7 +14238,7 @@ clutter_actor_move_anchor_point_from_gravity (ClutterActor   *self,
  *
  * Since: 0.6
  *
- * Deprecated: 1.12: Use #ClutterActor:pivot-point and 
+ * Deprecated: 1.12: Use #ClutterActor:pivot-point and
  * clutter_actor_set_translation() instead. E.g. For %CLUTTER_GRAVITY_CENTER set
  * pivot_point to (0.5,0.5) and the translation to (width/2,height/2).
  */
@@ -14763,7 +14763,7 @@ clutter_actor_set_custom_property (ClutterScriptable *scriptable,
                     name,
                     tmp);
 
-      g_free (tmp);
+      free (tmp);
     }
 #endif /* CLUTTER_ENABLE_DEBUG */
 
@@ -14933,7 +14933,7 @@ clutter_actor_find_property (ClutterAnimatable *animatable,
       pspec = g_object_class_find_property (klass, property_name);
     }
 
-  g_free (p_name);
+  free (p_name);
 
   return pspec;
 }
@@ -14955,7 +14955,7 @@ clutter_actor_get_initial_state (ClutterAnimatable *animatable,
   else
     g_object_get_property (G_OBJECT (animatable), property_name, initial);
 
-  g_free (p_name);
+  free (p_name);
 }
 
 /*
@@ -15129,7 +15129,7 @@ clutter_actor_set_final_state (ClutterAnimatable *animatable,
         }
     }
 
-  g_free (p_name);
+  free (p_name);
 }
 
 static void
@@ -15795,7 +15795,7 @@ update_pango_context (ClutterBackend *backend,
   pango_cairo_context_set_resolution (context, resolution);
 
   pango_font_description_free (font_desc);
-  g_free (font_name);
+  free (font_name);
 }
 
 /**
@@ -19080,7 +19080,7 @@ transition_closure_free (gpointer data)
       /* remove the reference added in add_transition_internal() */
       g_object_unref (clos->transition);
 
-      g_free (clos->name);
+      free (clos->name);
 
       g_slice_free (TransitionClosure, clos);
     }
@@ -19136,7 +19136,7 @@ on_transition_stopped (ClutterTransition *transition,
                  t_name,
                  is_finished);
 
-  g_free (t_name);
+  free (t_name);
 
   /* if it's the last transition then we clean up */
   if (g_hash_table_size (info->transitions) == 0)
@@ -19301,7 +19301,7 @@ _clutter_actor_create_transition (ClutterActor *actor,
   if (error != NULL)
     {
       g_critical ("%s: %s", G_STRLOC, error);
-      g_free (error);
+      free (error);
       goto out;
     }
 
@@ -19312,7 +19312,7 @@ _clutter_actor_create_transition (ClutterActor *actor,
     {
       g_critical ("%s: %s", G_STRLOC, error);
       g_value_unset (&initial);
-      g_free (error);
+      free (error);
       goto out;
     }
 
@@ -19371,8 +19371,8 @@ _clutter_actor_create_transition (ClutterActor *actor,
                         info->cur_state->easing_delay,
                         initial_v, final_v);
 
-          g_free (initial_v);
-          g_free (final_v);
+          free (initial_v);
+          free (final_v);
         }
 #endif /* CLUTTER_ENABLE_DEBUG */
 
@@ -19518,7 +19518,7 @@ clutter_actor_remove_transition (ClutterActor *self,
                      FALSE);
     }
 
-  g_free (t_name);
+  free (t_name);
 }
 
 /**

--- a/clutter/clutter/clutter-backend.c
+++ b/clutter/clutter/clutter-backend.c
@@ -125,7 +125,7 @@ clutter_backend_finalize (GObject *gobject)
 
   g_source_destroy (backend->cogl_source);
 
-  g_free (backend->font_name);
+  free (backend->font_name);
   clutter_backend_set_font_options (backend, NULL);
   g_clear_object (&backend->input_method);
 
@@ -155,7 +155,7 @@ get_units_per_em (ClutterBackend       *backend,
           font_desc = pango_font_description_from_string (font_name);
           free_font_desc = TRUE;
 
-          g_free (font_name);
+          free (font_name);
         }
     }
 
@@ -1170,7 +1170,7 @@ clutter_backend_get_font_name (ClutterBackend *backend)
   /* XXX yuck. but we return a const pointer, so we need to
    * store it in the backend
    */
-  g_free (backend->font_name);
+  free (backend->font_name);
   g_object_get (settings, "font-name", &backend->font_name, NULL);
 
   return backend->font_name;

--- a/clutter/clutter/clutter-container.c
+++ b/clutter/clutter/clutter-container.c
@@ -1222,7 +1222,7 @@ clutter_container_child_set (ClutterContainer *container,
   GObjectClass *klass;
   const gchar *name;
   va_list var_args;
-  
+
   g_return_if_fail (CLUTTER_IS_CONTAINER (container));
   g_return_if_fail (CLUTTER_IS_ACTOR (actor));
 
@@ -1236,7 +1236,7 @@ clutter_container_child_set (ClutterContainer *container,
       GValue value = G_VALUE_INIT;
       gchar *error = NULL;
       GParamSpec *pspec;
-    
+
       pspec = clutter_container_class_find_child_property (klass, name);
       if (!pspec)
         {
@@ -1265,7 +1265,7 @@ clutter_container_child_set (ClutterContainer *container,
            * on it might crash
            */
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 
@@ -1357,7 +1357,7 @@ clutter_container_child_get_property (ClutterContainer *container,
  *
  * In general, a copy is made of the property contents and the caller is
  * responsible for freeing the memory in the appropriate manner for the type, for
- * instance by calling g_free() or g_object_unref(). 
+ * instance by calling free() or g_object_unref().
  *
  * Since: 0.8
  */
@@ -1370,7 +1370,7 @@ clutter_container_child_get (ClutterContainer *container,
   GObjectClass *klass;
   const gchar *name;
   va_list var_args;
-  
+
   g_return_if_fail (CLUTTER_IS_CONTAINER (container));
   g_return_if_fail (CLUTTER_IS_ACTOR (actor));
 
@@ -1384,7 +1384,7 @@ clutter_container_child_get (ClutterContainer *container,
       GValue value = G_VALUE_INIT;
       gchar *error = NULL;
       GParamSpec *pspec;
-    
+
       pspec = clutter_container_class_find_child_property (klass, name);
       if (!pspec)
         {
@@ -1408,7 +1408,7 @@ clutter_container_child_get (ClutterContainer *container,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           g_value_unset (&value);
           break;
         }

--- a/clutter/clutter/clutter-debug.h
+++ b/clutter/clutter/clutter-debug.h
@@ -63,7 +63,7 @@ typedef enum {
         if (G_UNLIKELY (CLUTTER_HAS_DEBUG (type))) {                     \
           gchar *_fmt = g_strdup_printf (__VA_ARGS__);                   \
           _clutter_debug_message ("[" #type "]:" G_STRLOC ": %s", _fmt); \
-          g_free (_fmt);                                                 \
+          free (_fmt);                                                 \
         }                                               } G_STMT_END
 #endif
 

--- a/clutter/clutter/clutter-deform-effect.c
+++ b/clutter/clutter/clutter-deform-effect.c
@@ -272,7 +272,7 @@ clutter_deform_effect_paint_target (ClutterOffscreenEffect *effect)
                                 0, /* offset */
                                 verts,
                                 sizeof (*verts) * priv->n_vertices);
-          g_free (verts);
+          free (verts);
         }
 
       priv->is_dirty = FALSE;
@@ -425,7 +425,7 @@ clutter_deform_effect_init_arrays (ClutterDeformEffect *self)
                               static_indices,
                               n_indices);
 
-  g_free (static_indices);
+  free (static_indices);
 
   priv->n_vertices = (priv->x_tiles + 1) * (priv->y_tiles + 1);
 

--- a/clutter/clutter/clutter-deform-effect.c
+++ b/clutter/clutter/clutter-deform-effect.c
@@ -215,7 +215,7 @@ clutter_deform_effect_paint_target (ClutterOffscreenEffect *effect)
       if (verts == NULL)
         {
           mapped_buffer = FALSE;
-          verts = g_malloc (sizeof (*verts) * priv->n_vertices);
+          verts = malloc (sizeof (*verts) * priv->n_vertices);
         }
       else
         mapped_buffer = TRUE;

--- a/clutter/clutter/clutter-drop-action.c
+++ b/clutter/clutter/clutter-drop-action.c
@@ -111,7 +111,7 @@ drop_target_free (gpointer _data)
 
   g_signal_handler_disconnect (data->stage, data->capture_id);
   g_hash_table_destroy (data->actions);
-  g_free (data);
+  free (data);
 }
 
 static gboolean

--- a/clutter/clutter/clutter-event.c
+++ b/clutter/clutter/clutter-event.c
@@ -1029,7 +1029,7 @@ clutter_event_get_event_sequence (const ClutterEvent *event)
 
 /**
  * clutter_event_get_device_id:
- * @event: a clutter event 
+ * @event: a clutter event
  *
  * Retrieves the events device id if set.
  *
@@ -1439,22 +1439,22 @@ clutter_event_free (ClutterEvent *event)
         {
         case CLUTTER_BUTTON_PRESS:
         case CLUTTER_BUTTON_RELEASE:
-          g_free (event->button.axes);
+          free (event->button.axes);
           break;
 
         case CLUTTER_MOTION:
-          g_free (event->motion.axes);
+          free (event->motion.axes);
           break;
 
         case CLUTTER_SCROLL:
-          g_free (event->scroll.axes);
+          free (event->scroll.axes);
           break;
 
         case CLUTTER_TOUCH_BEGIN:
         case CLUTTER_TOUCH_UPDATE:
         case CLUTTER_TOUCH_END:
         case CLUTTER_TOUCH_CANCEL:
-          g_free (event->touch.axes);
+          free (event->touch.axes);
           break;
 
         default:
@@ -1469,7 +1469,7 @@ clutter_event_free (ClutterEvent *event)
 /**
  * clutter_event_get:
  *
- * Pops an event off the event queue. Applications should not need to call 
+ * Pops an event off the event queue. Applications should not need to call
  * this.
  *
  * Return value: A #ClutterEvent or NULL if queue empty
@@ -1492,9 +1492,9 @@ clutter_event_get (void)
 
 /**
  * clutter_event_peek:
- * 
- * Returns a pointer to the first event from the event queue but 
- * does not remove it. 
+ *
+ * Returns a pointer to the first event from the event queue but
+ * does not remove it.
  *
  * Return value: (transfer none): A #ClutterEvent or NULL if queue empty.
  *
@@ -1506,7 +1506,7 @@ clutter_event_peek (void)
   ClutterMainContext *context = _clutter_context_get_default ();
 
   g_return_val_if_fail (context != NULL, NULL);
-  
+
   if (context->events_queue == NULL)
     return NULL;
 

--- a/clutter/clutter/clutter-input-device.c
+++ b/clutter/clutter/clutter-input-device.c
@@ -95,9 +95,9 @@ clutter_input_device_dispose (GObject *gobject)
 {
   ClutterInputDevice *device = CLUTTER_INPUT_DEVICE (gobject);
 
-  g_clear_pointer (&device->device_name, g_free);
-  g_clear_pointer (&device->vendor_id, g_free);
-  g_clear_pointer (&device->product_id, g_free);
+  g_clear_pointer (&device->device_name, free);
+  g_clear_pointer (&device->vendor_id, free);
+  g_clear_pointer (&device->product_id, free);
 
   if (device->associated != NULL)
     {

--- a/clutter/clutter/clutter-interval.c
+++ b/clutter/clutter/clutter-interval.c
@@ -578,7 +578,7 @@ clutter_interval_init (ClutterInterval *self)
   self->priv = clutter_interval_get_instance_private (self);
 
   self->priv->value_type = G_TYPE_INVALID;
-  self->priv->values = g_malloc0 (sizeof (GValue) * N_VALUES);
+  self->priv->values = calloc (1, sizeof (GValue) * N_VALUES);
 }
 
 static inline void

--- a/clutter/clutter/clutter-interval.c
+++ b/clutter/clutter/clutter-interval.c
@@ -398,7 +398,7 @@ clutter_interval_finalize (GObject *gobject)
   if (G_IS_VALUE (&priv->values[RESULT]))
     g_value_unset (&priv->values[RESULT]);
 
-  g_free (priv->values);
+  free (priv->values);
 
   G_OBJECT_CLASS (clutter_interval_parent_class)->finalize (gobject);
 }
@@ -445,7 +445,7 @@ clutter_interval_get_property (GObject    *gobject,
                                GParamSpec *pspec)
 {
   ClutterIntervalPrivate *priv;
-  
+
   priv = clutter_interval_get_instance_private (CLUTTER_INTERVAL (gobject));
 
   switch (prop_id)
@@ -661,7 +661,7 @@ clutter_interval_set_initial_internal (ClutterInterval *interval,
        * given the error and calling g_value_unset() might lead to
        * undefined behaviour
        */
-      g_free (error);
+      free (error);
       return FALSE;
     }
 
@@ -690,7 +690,7 @@ clutter_interval_set_final_internal (ClutterInterval *interval,
        * given the error and calling g_value_unset() might lead to
        * undefined behaviour
        */
-      g_free (error);
+      free (error);
       return FALSE;
     }
 
@@ -715,7 +715,7 @@ clutter_interval_get_interval_valist (ClutterInterval *interval,
   if (error)
     {
       g_warning ("%s: %s", G_STRLOC, error);
-      g_free (error);
+      free (error);
       g_value_unset (&value);
       return;
     }
@@ -729,7 +729,7 @@ clutter_interval_get_interval_valist (ClutterInterval *interval,
   if (error)
     {
       g_warning ("%s: %s", G_STRLOC, error);
-      g_free (error);
+      free (error);
       g_value_unset (&value);
       return;
     }

--- a/clutter/clutter/clutter-keyframe-transition.c
+++ b/clutter/clutter/clutter-keyframe-transition.c
@@ -321,8 +321,8 @@ clutter_keyframe_transition_compute_value (ClutterTransition *transition,
                     to,
                     p, real_progress);
 
-      g_free (from);
-      g_free (to);
+      free (from);
+      free (to);
     }
 #endif /* CLUTTER_ENABLE_DEBUG */
 
@@ -593,7 +593,7 @@ clutter_keyframe_transition_set (ClutterKeyframeTransition *transition,
       if (error != NULL)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 

--- a/clutter/clutter/clutter-layout-manager.c
+++ b/clutter/clutter/clutter-layout-manager.c
@@ -817,7 +817,7 @@ clutter_layout_manager_child_set (ClutterLayoutManager *manager,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 
@@ -965,7 +965,7 @@ clutter_layout_manager_child_get (ClutterLayoutManager *manager,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           g_value_unset (&value);
           break;
         }
@@ -1083,7 +1083,7 @@ clutter_layout_manager_find_child_property (ClutterLayoutManager *manager,
  * stored inside the #ClutterLayoutMeta sub-class used by @manager
  *
  * Return value: (transfer full) (array length=n_pspecs): the newly-allocated,
- *   %NULL-terminated array of #GParamSpec<!-- -->s. Use g_free() to free the
+ *   %NULL-terminated array of #GParamSpec<!-- -->s. Use free() to free the
  *   resources allocated for the array
  *
  * Since: 1.2

--- a/clutter/clutter/clutter-main.c
+++ b/clutter/clutter/clutter-main.c
@@ -208,7 +208,7 @@ clutter_config_read_from_key_file (GKeyFile *keyfile)
   else
     clutter_try_set_windowing_backend (str_value);
 
-  g_free (str_value);
+  free (str_value);
 
   str_value =
     g_key_file_get_string (keyfile, ENVIRONMENT_GROUP,
@@ -219,7 +219,7 @@ clutter_config_read_from_key_file (GKeyFile *keyfile)
   else
     clutter_set_allowed_drivers (str_value);
 
-  g_free (str_value);
+  free (str_value);
 
   bool_value =
     g_key_file_get_boolean (keyfile, ENVIRONMENT_GROUP,
@@ -296,7 +296,7 @@ clutter_config_read_from_key_file (GKeyFile *keyfile)
         clutter_text_direction = CLUTTER_TEXT_DIRECTION_LTR;
     }
 
-  g_free (str_value);
+  free (str_value);
 }
 
 #ifdef CLUTTER_ENABLE_DEBUG
@@ -322,7 +322,7 @@ clutter_debug_read_from_key_file (GKeyFile *keyfile)
   else
     g_clear_error (&key_error);
 
-  g_free (value);
+  free (value);
 
   value = g_key_file_get_value (keyfile, DEBUG_GROUP,
                                 "PaintDebug",
@@ -337,7 +337,7 @@ clutter_debug_read_from_key_file (GKeyFile *keyfile)
   else
     g_clear_error (&key_error);
 
-  g_free (value);
+  free (value);
 
   value = g_key_file_get_value (keyfile, DEBUG_GROUP,
                                 "PickDebug",
@@ -352,7 +352,7 @@ clutter_debug_read_from_key_file (GKeyFile *keyfile)
   else
     g_clear_error (&key_error);
 
-  g_free (value);
+  free (value);
 }
 #endif
 
@@ -397,7 +397,7 @@ clutter_config_read (void)
   if (g_file_test (config_path, G_FILE_TEST_EXISTS))
     clutter_config_read_from_file (config_path);
 
-  g_free (config_path);
+  free (config_path);
 
   config_path = g_build_filename (g_get_user_config_dir (),
                                   "clutter-1.0",
@@ -406,7 +406,7 @@ clutter_config_read (void)
   if (g_file_test (config_path, G_FILE_TEST_EXISTS))
     clutter_config_read_from_file (config_path);
 
-  g_free (config_path);
+  free (config_path);
 }
 
 /**
@@ -954,7 +954,7 @@ _clutter_threads_dispatch_free (gpointer data)
  *   return g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
  *                           idle_safe_callback,
  *                           closure,
- *                           g_free)
+ *                           free)
  * }
  *]|
  *
@@ -978,7 +978,7 @@ _clutter_threads_dispatch_free (gpointer data)
  *                           closure->text);
  *
  *   g_object_unref (closure->label);
- *   g_free (closure);
+ *   free (closure);
  *
  *   return FALSE;
  * }
@@ -3701,11 +3701,11 @@ _clutter_debug_messagev (const char *format,
     }
 
   fmt = g_strconcat (stamp, ":", format, NULL);
-  g_free (stamp);
+  free (stamp);
 
   g_logv (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, fmt, var_args);
 
-  g_free (fmt);
+  free (fmt);
 }
 
 void
@@ -3746,5 +3746,5 @@ _clutter_diagnostic_message (const char *format, ...)
   g_logv (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, fmt, args);
   va_end (args);
 
-  g_free (fmt);
+  free (fmt);
 }

--- a/clutter/clutter/clutter-paint-node.c
+++ b/clutter/clutter/clutter-paint-node.c
@@ -173,7 +173,7 @@ clutter_paint_node_real_finalize (ClutterPaintNode *node)
 {
   ClutterPaintNode *iter;
 
-  g_free (node->name);
+  free (node->name);
 
   if (node->operations != NULL)
     {
@@ -306,7 +306,7 @@ clutter_paint_node_set_name (ClutterPaintNode *node,
 {
   g_return_if_fail (CLUTTER_IS_PAINT_NODE (node));
 
-  g_free (node->name);
+  free (node->name);
   node->name = g_strdup (name);
 }
 
@@ -1095,7 +1095,7 @@ _clutter_paint_node_dump_tree (ClutterPaintNode *node)
 
   g_print ("Render tree starting from %p:\n%s\n", node, str);
 
-  g_free (str);
+  free (str);
 #endif /* CLUTTER_ENABLE_DEBUG */
 }
 

--- a/clutter/clutter/clutter-paint-nodes.c
+++ b/clutter/clutter/clutter-paint-nodes.c
@@ -857,7 +857,7 @@ clutter_text_node_serialize (ClutterPaintNode *node)
 
       str = g_strndup (text, 12);
       json_builder_add_string_value (builder, str);
-      g_free (str);
+      free (str);
     }
   else
     json_builder_add_string_value (builder, pango_layout_get_text (tnode->layout));

--- a/clutter/clutter/clutter-path.c
+++ b/clutter/clutter/clutter-path.c
@@ -1135,7 +1135,7 @@ clutter_path_set_description (ClutterPath *path,
  * Returns a newly allocated string describing the path in the same
  * format as used by clutter_path_add_string().
  *
- * Return value: a string description of the path. Free with g_free().
+ * Return value: a string description of the path. Free with free().
  *
  * Since: 1.0
  */

--- a/clutter/clutter/clutter-property-transition.c
+++ b/clutter/clutter/clutter-property-transition.c
@@ -125,7 +125,7 @@ clutter_property_transition_detached (ClutterTransition *transition,
   ClutterPropertyTransition *self = CLUTTER_PROPERTY_TRANSITION (transition);
   ClutterPropertyTransitionPrivate *priv = self->priv;
 
-  priv->pspec = NULL; 
+  priv->pspec = NULL;
 }
 
 static void
@@ -238,7 +238,7 @@ clutter_property_transition_finalize (GObject *gobject)
 
   priv = CLUTTER_PROPERTY_TRANSITION (gobject)->priv;
 
-  g_free (priv->property_name);
+  free (priv->property_name);
 
   G_OBJECT_CLASS (clutter_property_transition_parent_class)->finalize (gobject);
 }
@@ -322,7 +322,7 @@ clutter_property_transition_set_property_name (ClutterPropertyTransition *transi
   if (g_strcmp0 (priv->property_name, property_name) == 0)
     return;
 
-  g_free (priv->property_name);
+  free (priv->property_name);
   priv->property_name = g_strdup (property_name);
   priv->pspec = NULL;
 

--- a/clutter/clutter/clutter-script-parser.c
+++ b/clutter/clutter/clutter-script-parser.c
@@ -81,10 +81,10 @@ _clutter_script_get_type_from_symbol (const gchar *symbol)
 
   if (!module)
     module = g_module_open (NULL, 0);
-  
+
   if (g_module_symbol (module, symbol, (gpointer)&func))
     gtype = func ();
-  
+
   return gtype;
 }
 
@@ -100,7 +100,7 @@ _clutter_script_get_type_from_class (const gchar *name)
 
   if (G_UNLIKELY (!module))
     module = g_module_open (NULL, 0);
-  
+
   for (i = 0; name[i] != '\0'; i++)
     {
       gchar c = name[i];
@@ -138,7 +138,7 @@ _clutter_script_get_type_from_class (const gchar *name)
     }
 
   g_string_append (symbol_name, "_get_type");
-  
+
   symbol = g_string_free (symbol_name, FALSE);
 
   if (g_module_symbol (module, symbol, (gpointer)&func))
@@ -146,8 +146,8 @@ _clutter_script_get_type_from_class (const gchar *name)
       CLUTTER_NOTE (SCRIPT, "Type function: %s", symbol);
       gtype = func ();
     }
-  
-  g_free (symbol);
+
+  free (symbol);
 
   return gtype;
 }
@@ -176,10 +176,10 @@ _clutter_script_enum_from_string (GType        type,
   gchar *endptr;
   gint value;
   gboolean retval = TRUE;
-  
+
   g_return_val_if_fail (G_TYPE_IS_ENUM (type), 0);
   g_return_val_if_fail (string != NULL, 0);
-  
+
   value = strtoul (string, &endptr, 0);
   if (endptr != string) /* parsed a number */
     *enum_value = value;
@@ -194,7 +194,7 @@ _clutter_script_enum_from_string (GType        type,
 	*enum_value = ev->value;
       else
         retval = FALSE;
-      
+
       g_type_class_unref (eclass);
     }
 
@@ -216,7 +216,7 @@ _clutter_script_flags_from_string (GType        type,
   g_return_val_if_fail (string != NULL, 0);
 
   ret = TRUE;
-  
+
   value = strtoul (string, &endptr, 0);
   if (endptr != string) /* parsed a number */
     *flags_value = value;
@@ -230,19 +230,19 @@ _clutter_script_flags_from_string (GType        type,
       for (value = i = j = 0; ; i++)
 	{
           gboolean eos = (flagstr[i] == '\0') ? TRUE : FALSE;
-	  
+
 	  if (!eos && flagstr[i] != '|')
 	    continue;
-	  
+
 	  flag = &flagstr[j];
 	  endptr = &flagstr[i];
-	  
+
 	  if (!eos)
 	    {
 	      flagstr[i++] = '\0';
 	      j = i;
 	    }
-	  
+
 	  /* trim spaces */
 	  for (;;)
 	    {
@@ -252,7 +252,7 @@ _clutter_script_flags_from_string (GType        type,
 
 	      flag = g_utf8_next_char (flag);
 	    }
-	  
+
 	  while (endptr > flag)
 	    {
               gunichar ch;
@@ -265,16 +265,16 @@ _clutter_script_flags_from_string (GType        type,
 
 	      endptr = prevptr;
 	    }
-	  
+
 	  if (endptr > flag)
 	    {
 	      *endptr = '\0';
 
 	      fv = g_flags_get_value_by_name (fclass, flag);
-	      
+
 	      if (!fv)
 		fv = g_flags_get_value_by_nick (fclass, flag);
-	      
+
 	      if (fv)
 		value |= fv->value;
 	      else
@@ -283,16 +283,16 @@ _clutter_script_flags_from_string (GType        type,
 		  break;
 		}
 	    }
-	  
+
 	  if (eos)
 	    {
 	      *flags_value = value;
 	      break;
 	    }
 	}
-      
-      g_free (flagstr);
-      
+
+      free (flagstr);
+
       g_type_class_unref (fclass);
     }
 
@@ -1059,7 +1059,7 @@ clutter_script_parser_object_end (JsonParser *json_parser,
                     json_object_get_string_member (object, "id"),
                     json_object_get_string_member (object, "type"));
 
-      g_free (fake);
+      free (fake);
     }
 
   if (!json_object_has_member (object, "type"))
@@ -1953,7 +1953,7 @@ apply_child_properties (ClutterScript    *script,
           continue;
         }
 
-      
+
       CLUTTER_NOTE (SCRIPT,
                     "Setting %s child property '%s' (type:%s) to "
                     "object '%s' (id:%s)",
@@ -2023,7 +2023,7 @@ add_children (ClutterScript *script,
       clutter_container_add_actor (container, CLUTTER_ACTOR (object));
     }
 
-  g_list_foreach (oinfo->children, (GFunc) g_free, NULL);
+  g_list_foreach (oinfo->children, (GFunc) free, NULL);
   g_list_free (oinfo->children);
 
   oinfo->children = unresolved;
@@ -2136,7 +2136,7 @@ _clutter_script_apply_properties (ClutterScript *script,
       else
         g_object_set_property (object, param->name, &param->value);
 
-      g_free ((gchar *) param->name);
+      free ((gchar *) param->name);
       g_value_unset (&param->value);
     }
 
@@ -2202,7 +2202,7 @@ _clutter_script_construct_object (ClutterScript *script,
         {
           GParameter *param = &g_array_index (params, GParameter, i);
 
-          g_free ((gchar *) param->name);
+          free ((gchar *) param->name);
           g_value_unset (&param->value);
         }
 
@@ -2236,7 +2236,7 @@ _clutter_script_construct_object (ClutterScript *script,
         {
           GParameter *param = &g_array_index (params, GParameter, i);
 
-          g_free ((gchar *) param->name);
+          free ((gchar *) param->name);
           g_value_unset (&param->value);
         }
 
@@ -2250,7 +2250,7 @@ _clutter_script_construct_object (ClutterScript *script,
   else
     g_object_set_data_full (oinfo->object, "clutter-script-id",
                             g_strdup (oinfo->id),
-                            g_free);
+                            free);
 
   _clutter_script_check_unresolved (script, oinfo);
 }

--- a/clutter/clutter/clutter-script.c
+++ b/clutter/clutter/clutter-script.c
@@ -314,7 +314,7 @@ property_info_free (gpointer data)
       if (pinfo->pspec)
         g_param_spec_unref (pinfo->pspec);
 
-      g_free (pinfo->name);
+      free (pinfo->name);
 
       g_slice_free (PropertyInfo, pinfo);
     }
@@ -327,11 +327,11 @@ signal_info_free (gpointer data)
     {
       SignalInfo *sinfo = data;
 
-      g_free (sinfo->name);
-      g_free (sinfo->handler);
-      g_free (sinfo->object);
-      g_free (sinfo->state);
-      g_free (sinfo->target);
+      free (sinfo->name);
+      free (sinfo->handler);
+      free (sinfo->object);
+      free (sinfo->state);
+      free (sinfo->target);
 
       g_slice_free (SignalInfo, sinfo);
     }
@@ -344,9 +344,9 @@ object_info_free (gpointer data)
     {
       ObjectInfo *oinfo = data;
 
-      g_free (oinfo->id);
-      g_free (oinfo->class_name);
-      g_free (oinfo->type_func);
+      free (oinfo->id);
+      free (oinfo->class_name);
+      free (oinfo->type_func);
 
       g_list_foreach (oinfo->properties, (GFunc) property_info_free, NULL);
       g_list_free (oinfo->properties);
@@ -355,7 +355,7 @@ object_info_free (gpointer data)
       g_list_free (oinfo->signals);
 
       /* these are ids */
-      g_list_foreach (oinfo->children, (GFunc) g_free, NULL);
+      g_list_foreach (oinfo->children, (GFunc) free, NULL);
       g_list_free (oinfo->children);
 
       /* we unref top-level objects and leave the actors alone,
@@ -387,9 +387,9 @@ clutter_script_finalize (GObject *gobject)
   g_object_unref (priv->parser);
   g_hash_table_destroy (priv->objects);
   g_strfreev (priv->search_paths);
-  g_free (priv->filename);
+  free (priv->filename);
   g_hash_table_destroy (priv->states);
-  g_free (priv->translation_domain);
+  free (priv->translation_domain);
 
   G_OBJECT_CLASS (clutter_script_parent_class)->finalize (gobject);
 }
@@ -524,7 +524,7 @@ clutter_script_init (ClutterScript *script)
                                          NULL,
                                          object_info_free);
   priv->states = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                        g_free,
+                                        free,
                                         (GDestroyNotify) g_object_unref);
 }
 
@@ -576,7 +576,7 @@ clutter_script_load_from_file (ClutterScript  *script,
 
   priv = script->priv;
 
-  g_free (priv->filename);
+  free (priv->filename);
   priv->filename = g_strdup (filename);
   priv->is_filename = TRUE;
   priv->last_merge_id += 1;
@@ -629,7 +629,7 @@ clutter_script_load_from_data (ClutterScript  *script,
 
   priv = script->priv;
 
-  g_free (priv->filename);
+  free (priv->filename);
   priv->filename = NULL;
   priv->is_filename = FALSE;
   priv->last_merge_id += 1;
@@ -731,7 +731,7 @@ clutter_script_get_objects_valist (ClutterScript *script,
   while (name)
     {
       GObject **obj = NULL;
-      
+
       obj = va_arg (args, GObject**);
 
       *obj = clutter_script_get_object (script, name);
@@ -848,7 +848,7 @@ clutter_script_unmerge_objects (ClutterScript *script,
   for (l = data.ids; l != NULL; l = l->next)
     g_hash_table_remove (priv->objects, l->data);
 
-  g_slist_foreach (data.ids, (GFunc) g_free, NULL);
+  g_slist_foreach (data.ids, (GFunc) free, NULL);
   g_slist_free (data.ids);
 
   clutter_script_ensure_objects (script);
@@ -903,7 +903,7 @@ clutter_script_ensure_objects (ClutterScript *script)
  * @script: a #ClutterScript
  * @type_name: name of the type to look up
  *
- * Looks up a type by name, using the virtual function that 
+ * Looks up a type by name, using the virtual function that
  * #ClutterScript has for that purpose. This function should
  * rarely be used.
  *
@@ -1011,7 +1011,7 @@ clutter_script_default_connect (ClutterScript *script,
  * This method invokes clutter_script_connect_signals_full() internally
  * and uses  #GModule's introspective features (by opening the current
  * module's scope) to look at the application's symbol table.
- * 
+ *
  * Note that this function will not work if #GModule is not supported by
  * the platform Clutter is running on.
  *
@@ -1042,7 +1042,7 @@ clutter_script_connect_signals (ClutterScript *script,
 
   g_module_close (cd->module);
 
-  g_free (cd);
+  free (cd);
 }
 
 typedef struct {
@@ -1067,7 +1067,7 @@ hook_data_free (gpointer data)
     {
       HookData *hook_data = data;
 
-      g_free (hook_data->target);
+      free (hook_data->target);
       g_slice_free (HookData, hook_data);
     }
 }
@@ -1358,7 +1358,7 @@ clutter_script_lookup_filename (ClutterScript *script,
             return retval;
           else
             {
-              g_free (retval);
+              free (retval);
               retval = NULL;
             }
         }
@@ -1369,15 +1369,15 @@ clutter_script_lookup_filename (ClutterScript *script,
     dirname = g_path_get_dirname (script->priv->filename);
   else
     dirname = g_get_current_dir ();
-  
+
   retval = g_build_filename (dirname, filename, NULL);
   if (!g_file_test (retval, G_FILE_TEST_EXISTS))
     {
-      g_free (retval);
+      free (retval);
       retval = NULL;
     }
-  
-  g_free (dirname);
+
+  free (dirname);
 
   return retval;
 }
@@ -1509,7 +1509,7 @@ clutter_script_set_translation_domain (ClutterScript *script,
   if (g_strcmp0 (domain, script->priv->translation_domain) == 0)
     return;
 
-  g_free (script->priv->translation_domain);
+  free (script->priv->translation_domain);
   script->priv->translation_domain = g_strdup (domain);
 
   g_object_notify_by_pspec (G_OBJECT (script), obj_props[PROP_TRANSLATION_DOMAIN]);
@@ -1543,7 +1543,7 @@ clutter_script_get_translation_domain (ClutterScript *script)
  * an "id" member
  *
  * Return value: a newly-allocated string containing the fake
- *   id. Use g_free() to free the resources allocated by the
+ *   id. Use free() to free the resources allocated by the
  *   returned value
  *
  */

--- a/clutter/clutter/clutter-scriptable.c
+++ b/clutter/clutter/clutter-scriptable.c
@@ -90,7 +90,7 @@ clutter_scriptable_set_id (ClutterScriptable *scriptable,
     g_object_set_data_full (G_OBJECT (scriptable),
                             "clutter-script-id",
                             g_strdup (id_),
-                            g_free);
+                            free);
 }
 
 /**

--- a/clutter/clutter/clutter-settings.c
+++ b/clutter/clutter/clutter-settings.c
@@ -274,9 +274,9 @@ clutter_settings_finalize (GObject *gobject)
 {
   ClutterSettings *self = CLUTTER_SETTINGS (gobject);
 
-  g_free (self->font_name);
-  g_free (self->xft_hint_style);
-  g_free (self->xft_rgba);
+  free (self->font_name);
+  free (self->xft_hint_style);
+  free (self->xft_rgba);
 
   G_OBJECT_CLASS (clutter_settings_parent_class)->finalize (gobject);
 }
@@ -308,7 +308,7 @@ clutter_settings_set_property (GObject      *gobject,
       break;
 
     case PROP_FONT_NAME:
-      g_free (self->font_name);
+      free (self->font_name);
       self->font_name = g_value_dup_string (value);
       settings_update_font_name (self);
       break;
@@ -329,13 +329,13 @@ clutter_settings_set_property (GObject      *gobject,
       break;
 
     case PROP_FONT_HINT_STYLE:
-      g_free (self->xft_hint_style);
+      free (self->xft_hint_style);
       self->xft_hint_style = g_value_dup_string (value);
       settings_update_font_options (self);
       break;
 
     case PROP_FONT_RGBA:
-      g_free (self->xft_rgba);
+      free (self->xft_rgba);
       self->xft_rgba = g_value_dup_string (value);
       settings_update_font_options (self);
       break;
@@ -844,5 +844,5 @@ _clutter_settings_read_from_key_file (ClutterSettings *settings,
       g_value_unset (&value);
     }
 
-  g_free (pspecs);
+  free (pspecs);
 }

--- a/clutter/clutter/clutter-shader-effect.c
+++ b/clutter/clutter/clutter-shader-effect.c
@@ -364,7 +364,7 @@ clutter_shader_effect_try_static_source (ClutterShaderEffect *self)
 
           cogl_shader_source (class_priv->shader, source);
 
-          g_free (source);
+          free (source);
 
           CLUTTER_NOTE (SHADER, "Compiling shader effect");
 
@@ -384,7 +384,7 @@ clutter_shader_effect_try_static_source (ClutterShaderEffect *self)
               gchar *log_buf = cogl_shader_get_info_log (class_priv->shader);
 
               g_warning (G_STRLOC ": Unable to compile the GLSL shader: %s", log_buf);
-              g_free (log_buf);
+              free (log_buf);
             }
         }
 
@@ -575,7 +575,7 @@ shader_uniform_free (gpointer data)
       ShaderUniform *uniform = data;
 
       g_value_unset (&uniform->value);
-      g_free (uniform->name);
+      free (uniform->name);
 
       g_slice_free (ShaderUniform, uniform);
     }
@@ -732,7 +732,7 @@ clutter_shader_effect_set_uniform_valist (ClutterShaderEffect *effect,
           g_value_init (&value, CLUTTER_TYPE_SHADER_INT);
           clutter_value_set_shader_int (&value, n_values, int_values);
 
-          g_free (int_values);
+          free (int_values);
         }
 
       goto add_uniform;
@@ -764,7 +764,7 @@ clutter_shader_effect_set_uniform_valist (ClutterShaderEffect *effect,
           g_value_init (&value, CLUTTER_TYPE_SHADER_FLOAT);
           clutter_value_set_shader_float (&value, n_values, float_values);
 
-          g_free (float_values);
+          free (float_values);
         }
 
       goto add_uniform;
@@ -916,7 +916,7 @@ clutter_shader_effect_set_shader_source (ClutterShaderEffect *effect,
       gchar *log_buf = cogl_shader_get_info_log (priv->shader);
 
       g_warning (G_STRLOC ": Unable to compile the GLSL shader: %s", log_buf);
-      g_free (log_buf);
+      free (log_buf);
     }
 
   return TRUE;

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1433,8 +1433,8 @@ read_pixels_to_file (char *filename_stem,
   cairo_surface_write_to_png (surface, filename);
   cairo_surface_destroy (surface);
 
-  g_free (data);
-  g_free (filename);
+  free (data);
+  free (filename);
 
   read_count++;
 }
@@ -1551,7 +1551,7 @@ _clutter_stage_do_pick_on_view (ClutterStage     *stage,
 
       read_pixels_to_file (file_name, 0, 0, fb_width, fb_height);
 
-      g_free (file_name);
+      free (file_name);
     }
 
   /* Restore whether GL_DITHER was enabled */
@@ -1888,7 +1888,7 @@ clutter_stage_finalize (GObject *object)
   g_queue_foreach (priv->event_queue, (GFunc) clutter_event_free, NULL);
   g_queue_free (priv->event_queue);
 
-  g_free (priv->title);
+  free (priv->title);
 
   g_array_free (priv->paint_volume_stack, TRUE);
 
@@ -2933,7 +2933,7 @@ clutter_stage_hide_cursor (ClutterStage *stage)
  * and not guaranteed to hold any sensible value.
  *
  * Return value: (transfer full) (array): a pointer to newly allocated memory with the buffer
- *   or %NULL if the read failed. Use g_free() on the returned data
+ *   or %NULL if the read failed. Use free() on the returned data
  *   to release the resources it has allocated.
  */
 guchar *
@@ -3124,7 +3124,7 @@ clutter_stage_set_title (ClutterStage       *stage,
 
   priv = stage->priv;
 
-  g_free (priv->title);
+  free (priv->title);
   priv->title = g_strdup (title);
 
   impl = CLUTTER_STAGE_WINDOW (priv->impl);

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -2992,7 +2992,7 @@ clutter_stage_read_pixels (ClutterStage *stage,
   cogl_push_framebuffer (framebuffer);
   clutter_stage_do_paint_view (stage, view, &clip_rect);
 
-  pixels = g_malloc0 (clip_rect.width * clip_rect.height * 4);
+  pixels = calloc (1, clip_rect.width * clip_rect.height * 4);
   cogl_framebuffer_read_pixels (framebuffer,
                                 clip_rect.x, clip_rect.y,
                                 clip_rect.width, clip_rect.height,

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1420,7 +1420,7 @@ read_pixels_to_file (char *filename_stem,
                                     filename_stem,
                                     read_count);
 
-  data = g_malloc (4 * width * height);
+  data = malloc (4 * width * height);
   cogl_read_pixels (x, y, width, height,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     CLUTTER_CAIRO_FORMAT_ARGB32,

--- a/clutter/clutter/clutter-test-utils.c
+++ b/clutter/clutter/clutter-test-utils.c
@@ -220,7 +220,7 @@ clutter_test_add_data_full (const char     *test_path,
 
   g_test_add_data_func_full (test_path, data,
                              clutter_test_func_wrapper,
-                             g_free);
+                             free);
 }
 
 /**
@@ -262,10 +262,10 @@ clutter_test_run (void)
   int res;
 
   g_assert (test_environ != NULL);
-  
+
   res = g_test_run ();
 
-  g_free (test_environ);
+  free (test_environ);
 
   return res;
 }
@@ -389,7 +389,7 @@ clutter_test_check_actor_at_point (ClutterActor        *stage,
   if (press_id != 0)
     g_signal_handler_disconnect (stage, press_id);
 
-  g_free (data);
+  free (data);
 
   return *result == actor;
 }
@@ -460,8 +460,8 @@ clutter_test_check_color_at_point (ClutterActor       *stage,
            buffer[1] == color->green &&
            buffer[2] == color->blue;
 
-  g_free (data->result);
-  g_free (data);
+  free (data->result);
+  free (data);
 
   return retval;
 }

--- a/clutter/clutter/clutter-test-utils.h
+++ b/clutter/clutter/clutter-test-utils.h
@@ -126,7 +126,7 @@ G_STMT_START { \
     char *__msg = g_strdup_printf ("assertion failed (actor %s at %.2f,%.2f): found actor %s", \
                                    __str1, __p->x, __p->y, __str2); \
     g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, __msg); \
-    g_free (__msg); \
+    free (__msg); \
   } \
 } G_STMT_END
 
@@ -142,9 +142,9 @@ G_STMT_START { \
     char *__msg = g_strdup_printf ("assertion failed (color %s at %.2f,%.2f): found color %s", \
                                    __str1, __p->x, __p->y, __str2); \
     g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, __msg); \
-    g_free (__msg); \
-    g_free (__str1); \
-    g_free (__str2); \
+    free (__msg); \
+    free (__str1); \
+    free (__str2); \
   } \
 } G_STMT_END
 

--- a/clutter/clutter/clutter-text-buffer.c
+++ b/clutter/clutter/clutter-text-buffer.c
@@ -165,7 +165,7 @@ clutter_text_buffer_normal_insert_text (ClutterTextBuffer *buffer,
       et_new = g_malloc (pv->normal_text_size);
       memcpy (et_new, pv->normal_text, MIN (prev_size, pv->normal_text_size));
       trash_area (pv->normal_text, prev_size);
-      g_free (pv->normal_text);
+      free (pv->normal_text);
       pv->normal_text = et_new;
     }
 
@@ -265,7 +265,7 @@ clutter_text_buffer_finalize (GObject *obj)
   if (pv->normal_text)
     {
       trash_area (pv->normal_text, pv->normal_text_size);
-      g_free (pv->normal_text);
+      free (pv->normal_text);
       pv->normal_text = NULL;
       pv->normal_text_bytes = pv->normal_text_size = 0;
       pv->normal_text_chars = 0;

--- a/clutter/clutter/clutter-text-buffer.c
+++ b/clutter/clutter/clutter-text-buffer.c
@@ -162,7 +162,7 @@ clutter_text_buffer_normal_insert_text (ClutterTextBuffer *buffer,
         }
 
       /* Could be a password, so can't leave stuff in memory. */
-      et_new = g_malloc (pv->normal_text_size);
+      et_new = malloc (pv->normal_text_size);
       memcpy (et_new, pv->normal_text, MIN (prev_size, pv->normal_text_size));
       trash_area (pv->normal_text, prev_size);
       free (pv->normal_text);

--- a/clutter/clutter/clutter-text.c
+++ b/clutter/clutter/clutter-text.c
@@ -699,7 +699,7 @@ clutter_text_create_layout_no_cache (ClutterText       *text,
   pango_layout_set_width (layout, width);
   pango_layout_set_height (layout, height);
 
-  g_free (contents);
+  free (contents);
 
   return layout;
 }
@@ -754,7 +754,7 @@ clutter_text_set_font_description_internal (ClutterText          *self,
   priv->font_desc = pango_font_description_copy (desc);
 
   /* update the font name string we use */
-  g_free (priv->font_name);
+  free (priv->font_name);
   priv->font_name = pango_font_description_to_string (priv->font_desc);
 
   clutter_text_dirty_cache (self);
@@ -794,7 +794,7 @@ clutter_text_settings_changed_cb (ClutterText *text)
       clutter_text_set_font_description_internal (text, font_desc, TRUE);
 
       pango_font_description_free (font_desc);
-      g_free (font_name);
+      free (font_name);
     }
 
   clutter_text_dirty_cache (text);
@@ -1102,7 +1102,7 @@ clutter_text_position_to_coords (ClutterText *self,
       else
         index_ = position * password_char_bytes;
 
-      g_free (text);
+      free (text);
       g_string_free (tmp, TRUE);
     }
 
@@ -1317,7 +1317,7 @@ clutter_text_set_markup_internal (ClutterText *self,
   if (text)
     {
       clutter_text_buffer_set_text (get_buffer (self), text, -1);
-      g_free (text);
+      free (text);
     }
 
   /* Store the new markup attributes */
@@ -1640,7 +1640,7 @@ clutter_text_finalize (GObject *gobject)
   clutter_text_dirty_paint_volume (self);
 
   clutter_text_set_buffer (self, NULL);
-  g_free (priv->font_name);
+  free (priv->font_name);
 
   g_clear_object (&priv->input_focus);
 
@@ -1732,10 +1732,10 @@ clutter_text_foreach_selection_rectangle (ClutterText              *self,
           func (self, &box, user_data);
         }
 
-      g_free (ranges);
+      free (ranges);
     }
 
-  g_free (utf8);
+  free (utf8);
 }
 
 static void
@@ -1846,7 +1846,7 @@ clutter_text_move_word_backward (ClutterText *self,
       while (retval > 0 && !log_attrs[retval].is_word_start)
         retval -= 1;
 
-      g_free (log_attrs);
+      free (log_attrs);
     }
 
   return retval;
@@ -1872,7 +1872,7 @@ clutter_text_move_word_forward (ClutterText *self,
       while (retval < n_chars && !log_attrs[retval].is_word_end)
         retval += 1;
 
-      g_free (log_attrs);
+      free (log_attrs);
     }
 
   return retval;
@@ -5007,7 +5007,7 @@ clutter_text_set_selection (ClutterText *self,
  * Retrieves the currently selected text.
  *
  * Return value: a newly allocated string containing the currently
- *   selected text, or %NULL. Use g_free() to free the returned
+ *   selected text, or %NULL. Use free() to free the returned
  *   string.
  *
  * Since: 1.0
@@ -5338,7 +5338,7 @@ clutter_text_set_font_name (ClutterText *self,
 
 out:
   if (is_default_font)
-    g_free ((gchar *) font_name);
+    free ((gchar *) font_name);
 }
 
 /**
@@ -6305,7 +6305,7 @@ clutter_text_delete_chars (ClutterText *self,
  * The positions are specified in characters, not in bytes.
  *
  * Return value: a newly allocated string with the contents of
- *   the text actor between the specified positions. Use g_free()
+ *   the text actor between the specified positions. Use free()
  *   to free the resources when done
  *
  * Since: 1.0
@@ -6438,7 +6438,7 @@ clutter_text_set_preedit_string (ClutterText   *self,
 
   priv = self->priv;
 
-  g_free (priv->preedit_str);
+  free (priv->preedit_str);
   priv->preedit_str = NULL;
 
   if (priv->preedit_attrs != NULL)

--- a/clutter/clutter/clutter-text.c
+++ b/clutter/clutter/clutter-text.c
@@ -5045,7 +5045,7 @@ clutter_text_get_selection (ClutterText *self)
   end_offset = offset_to_bytes (text, end_index);
   len = end_offset - start_offset;
 
-  str = g_malloc (len + 1);
+  str = malloc (len + 1);
   g_utf8_strncpy (str, text + start_offset, end_index - start_index);
 
   return str;

--- a/clutter/clutter/clutter-timeline.c
+++ b/clutter/clutter/clutter-timeline.c
@@ -244,7 +244,7 @@ timeline_marker_free (gpointer data)
     {
       TimelineMarker *marker = data;
 
-      g_free (marker->name);
+      free (marker->name);
       g_slice_free (TimelineMarker, marker);
     }
 }

--- a/clutter/clutter/clutter-transition.c
+++ b/clutter/clutter/clutter-transition.c
@@ -618,7 +618,7 @@ clutter_transition_set_from (ClutterTransition *transition,
   if (error != NULL)
     {
       g_warning ("%s: %s", G_STRLOC, error);
-      g_free (error);
+      free (error);
       return;
     }
 
@@ -671,7 +671,7 @@ clutter_transition_set_to (ClutterTransition *transition,
   if (error != NULL)
     {
       g_warning ("%s: %s", G_STRLOC, error);
-      g_free (error);
+      free (error);
       return;
     }
 

--- a/clutter/clutter/clutter-types.h
+++ b/clutter/clutter/clutter-types.h
@@ -28,6 +28,7 @@
 #error "Only <clutter/clutter.h> can be included directly."
 #endif
 
+#include <stdlib.h>
 #include <cairo.h>
 #include <cogl/cogl.h>
 #include <clutter/clutter-macros.h>

--- a/clutter/clutter/clutter-units.c
+++ b/clutter/clutter/clutter-units.c
@@ -600,7 +600,7 @@ clutter_unit_type_name (ClutterUnitType unit_type)
  * typographic points. Pixels are integers.
  *
  * Return value: a newly allocated string containing the encoded
- *   #ClutterUnits value. Use g_free() to free the string
+ *   #ClutterUnits value. Use free() to free the string
  *
  * Since: 1.0
  */
@@ -826,7 +826,7 @@ param_units_validate (GParamSpec *pspec,
                  str,
                  clutter_unit_type_name (uspec->default_type));
 
-      g_free (str);
+      free (str);
 
       return FALSE;
     }

--- a/clutter/clutter/deprecated/clutter-actor-deprecated.c
+++ b/clutter/clutter/deprecated/clutter-actor-deprecated.c
@@ -131,7 +131,7 @@ clutter_actor_set_shader (ClutterActor  *self,
       shader_data->shader = NULL;
       shader_data->value_hash =
         g_hash_table_new_full (g_str_hash, g_str_equal,
-                               g_free,
+                               free,
                                shader_value_free);
 
       g_object_set_data_full (G_OBJECT (self), "-clutter-actor-shader-data",

--- a/clutter/clutter/deprecated/clutter-animation.c
+++ b/clutter/clutter/deprecated/clutter-animation.c
@@ -603,7 +603,7 @@ clutter_animation_init (ClutterAnimation *self)
 
   self->priv->properties =
     g_hash_table_new_full (g_str_hash, g_str_equal,
-                           (GDestroyNotify) g_free,
+                           (GDestroyNotify) free,
                            (GDestroyNotify) g_object_unref);
 }
 
@@ -2013,7 +2013,7 @@ clutter_animation_setup_valist (ClutterAnimation *animation,
           if (error)
             {
               g_warning ("%s: %s", G_STRLOC, error);
-              g_free (error);
+              free (error);
               break;
             }
 

--- a/clutter/clutter/deprecated/clutter-animator.c
+++ b/clutter/clutter/deprecated/clutter-animator.c
@@ -1232,7 +1232,7 @@ clutter_animator_set (ClutterAnimator *animator,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 
@@ -1490,7 +1490,7 @@ clutter_animator_remove_key (ClutterAnimator *animator,
                              const gchar     *property_name,
                              gdouble          progress)
 {
-  clutter_animator_remove_key_internal (animator, object, property_name, 
+  clutter_animator_remove_key_internal (animator, object, property_name,
                                         progress, FALSE);
 }
 

--- a/clutter/clutter/deprecated/clutter-box.c
+++ b/clutter/clutter/deprecated/clutter-box.c
@@ -500,7 +500,7 @@ clutter_box_set_property_valist (ClutterBox   *box,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 

--- a/clutter/clutter/deprecated/clutter-list-model.c
+++ b/clutter/clutter/deprecated/clutter-list-model.c
@@ -127,9 +127,9 @@ clutter_list_model_iter_get_value (ClutterModelIter *iter,
 
   if (!g_type_is_a (G_VALUE_TYPE (value), G_VALUE_TYPE (iter_value)))
     {
-      if (!g_value_type_compatible (G_VALUE_TYPE (value), 
+      if (!g_value_type_compatible (G_VALUE_TYPE (value),
                                     G_VALUE_TYPE (iter_value)) &&
-          !g_value_type_compatible (G_VALUE_TYPE (iter_value), 
+          !g_value_type_compatible (G_VALUE_TYPE (iter_value),
                                     G_VALUE_TYPE (value)))
         {
           g_warning ("%s: Unable to convert from %s to %s",
@@ -142,7 +142,7 @@ clutter_list_model_iter_get_value (ClutterModelIter *iter,
       if (!g_value_transform (iter_value, &real_value))
         {
           g_warning ("%s: Unable to make conversion from %s to %s",
-                     G_STRLOC, 
+                     G_STRLOC,
                      g_type_name (G_VALUE_TYPE (value)),
                      g_type_name (G_VALUE_TYPE (iter_value)));
           g_value_unset (&real_value);
@@ -150,7 +150,7 @@ clutter_list_model_iter_get_value (ClutterModelIter *iter,
 
       converted = TRUE;
     }
-  
+
   if (converted)
     {
       g_value_copy (&real_value, value);
@@ -180,9 +180,9 @@ clutter_list_model_iter_set_value (ClutterModelIter *iter,
 
   if (!g_type_is_a (G_VALUE_TYPE (value), G_VALUE_TYPE (iter_value)))
     {
-      if (!g_value_type_compatible (G_VALUE_TYPE (value), 
+      if (!g_value_type_compatible (G_VALUE_TYPE (value),
                                     G_VALUE_TYPE (iter_value)) &&
-          !g_value_type_compatible (G_VALUE_TYPE (iter_value), 
+          !g_value_type_compatible (G_VALUE_TYPE (iter_value),
                                     G_VALUE_TYPE (value)))
         {
           g_warning ("%s: Unable to convert from %s to %s\n",
@@ -195,7 +195,7 @@ clutter_list_model_iter_set_value (ClutterModelIter *iter,
       if (!g_value_transform (value, &real_value))
         {
           g_warning ("%s: Unable to make conversion from %s to %s\n",
-                     G_STRLOC, 
+                     G_STRLOC,
                      g_type_name (G_VALUE_TYPE (value)),
                      g_type_name (G_VALUE_TYPE (iter_value)));
           g_value_unset (&real_value);
@@ -203,7 +203,7 @@ clutter_list_model_iter_set_value (ClutterModelIter *iter,
 
       converted = TRUE;
     }
- 
+
   if (converted)
     {
       g_value_copy (&real_value, iter_value);
@@ -248,7 +248,7 @@ clutter_list_model_iter_is_first (ClutterModelIter *iter)
     }
 
   /* This is because the 'begin_iter' is always *before* the last valid
-   * iter, otherwise we'd have endless loops 
+   * iter, otherwise we'd have endless loops
    */
   end = g_sequence_iter_prev (end);
 
@@ -294,7 +294,7 @@ clutter_list_model_iter_is_last (ClutterModelIter *iter)
     }
 
   /* This is because the 'end_iter' is always *after* the last valid iter.
-   * Otherwise we'd have endless loops 
+   * Otherwise we'd have endless loops
    */
   end = g_sequence_iter_next (end);
 
@@ -394,7 +394,7 @@ clutter_list_model_iter_copy (ClutterModelIter *iter)
   ClutterListModelIter *iter_copy;
   ClutterModel *model;
   guint row;
- 
+
   iter_default = CLUTTER_LIST_MODEL_ITER (iter);
 
   model = clutter_model_iter_get_model (iter);
@@ -550,7 +550,7 @@ clutter_list_model_remove_row (ClutterModel *model,
       if (clutter_model_filter_row (model, pos))
         {
           if (pos == row)
-            {  
+            {
               ClutterModelIter *iter;
 
               iter = g_object_new (CLUTTER_TYPE_LIST_MODEL_ITER,
@@ -648,7 +648,7 @@ clutter_list_model_row_removed (ClutterModel     *model,
   for (i = 0; i < n_columns; i++)
     g_value_unset (&values[i]);
 
-  g_free (values);
+  free (values);
 
   g_sequence_remove (iter_default->seq_iter);
   iter_default->seq_iter = NULL;
@@ -672,7 +672,7 @@ clutter_list_model_finalize (GObject *gobject)
       for (i = 0; i < n_columns; i++)
         g_value_unset (&values[i]);
 
-      g_free (values);
+      free (values);
 
       iter = g_sequence_iter_next (iter);
     }
@@ -729,11 +729,11 @@ clutter_list_model_init (ClutterListModel *model)
  * @n_columns: number of columns in the model
  * @...: @n_columns number of #GType and string pairs
  *
- * Creates a new default model with @n_columns columns with the types 
+ * Creates a new default model with @n_columns columns with the types
  * and names passed in.
  *
  * For example:
- * 
+ *
  * <informalexample><programlisting>
  * model = clutter_list_model_new (3,
  *                                 G_TYPE_INT,      "Score",
@@ -770,7 +770,7 @@ clutter_list_model_new (guint n_columns,
   va_start (args, n_columns);
 
   for (i = 0; i < n_columns; i++)
-    { 
+    {
       GType type = va_arg (args, GType);
       const gchar *name = va_arg (args, gchar*);
 

--- a/clutter/clutter/deprecated/clutter-media.c
+++ b/clutter/clutter/deprecated/clutter-media.c
@@ -295,7 +295,7 @@ clutter_media_set_uri (ClutterMedia *media,
  *
  * Retrieves the URI from @media.
  *
- * Return value: the URI of the media stream. Use g_free()
+ * Return value: the URI of the media stream. Use free()
  *   to free the returned string
  *
  * Since: 0.2
@@ -319,8 +319,8 @@ clutter_media_get_uri (ClutterMedia *media)
  * @media: a #ClutterMedia
  * @playing: %TRUE to start playing
  *
- * Starts or stops playing of @media. 
- 
+ * Starts or stops playing of @media.
+
  * The implementation might be asynchronous, so the way to know whether
  * the actual playing state of the @media is to use the #GObject::notify
  * signal on the #ClutterMedia:playing property and then retrieve the
@@ -435,7 +435,7 @@ clutter_media_set_subtitle_uri (ClutterMedia *media,
  *
  * Retrieves the URI of the subtitle file in use.
  *
- * Return value: the URI of the subtitle file. Use g_free()
+ * Return value: the URI of the subtitle file. Use free()
  *   to free the returned string
  *
  * Since: 1.2
@@ -487,7 +487,7 @@ clutter_media_set_subtitle_font_name (ClutterMedia *media,
  *
  * Retrieves the font name currently used.
  *
- * Return value: a string containing the font name. Use g_free()
+ * Return value: a string containing the font name. Use free()
  *   to free the returned string
  *
  * Since: 1.2
@@ -648,7 +648,7 @@ clutter_media_set_filename (ClutterMedia *media,
 
       abs_path = g_build_filename (g_get_current_dir (), filename, NULL);
       uri = g_filename_to_uri (abs_path, NULL, &uri_error);
-      g_free (abs_path);
+      free (abs_path);
     }
   else
     uri = g_filename_to_uri (filename, NULL, &uri_error);
@@ -662,5 +662,5 @@ clutter_media_set_filename (ClutterMedia *media,
 
   clutter_media_set_uri (media, uri);
 
-  g_free (uri);
+  free (uri);
 }

--- a/clutter/clutter/deprecated/clutter-model.c
+++ b/clutter/clutter/deprecated/clutter-model.c
@@ -32,9 +32,9 @@
  * #ClutterModel is a generic list model API which can be used to implement
  * the model-view-controller architectural pattern in Clutter.
  *
- * The #ClutterModel class is a list model which can accept most GObject 
+ * The #ClutterModel class is a list model which can accept most GObject
  * types as a column type.
- * 
+ *
  * ## Creating a simple ClutterModel
  *
  * The example below shows how to create a simple list model.
@@ -47,7 +47,7 @@
  *
  *   N_COLUMNS
  * };
- * 
+ *
  * {
  *   ClutterModel *model;
  *   gint i;
@@ -63,10 +63,10 @@
  *                             COLUMN_INT, i,
  *                             COLUMN_STRING, string,
  *                             -1);
- *       g_free (string);
+ *       free (string);
  *     }
  *
- *   
+ *
  * }
  * ]|
  *
@@ -77,7 +77,7 @@
  * clutter_model_iter_prev() to move forward or backwards, repectively.
  *
  * A valid #ClutterModelIter represents the position between two rows in the
- * model. For example, the "first" iterator represents the gap immediately 
+ * model. For example, the "first" iterator represents the gap immediately
  * before the first row, and the "last" iterator represents the gap immediately
  * after the last row. In an empty sequence, the first and last iterators are
  * the same.
@@ -90,7 +90,7 @@
  *
  *   N_COLUMNS
  * };
- * 
+ *
  * {
  *   ClutterModel *model;
  *   ClutterModelIter *iter = NULL;
@@ -103,7 +103,7 @@
  *   while (!clutter_model_iter_is_last (iter))
  *     {
  *       print_row (iter);
- *       
+ *
  *       iter = clutter_model_iter_next (iter);
  *     }
  *
@@ -187,7 +187,7 @@ enum
 
   SORT_CHANGED,
   FILTER_CHANGED,
-  
+
   LAST_SIGNAL
 };
 
@@ -206,7 +206,7 @@ struct _ClutterModelPrivate
    *
    * for a reference.
    */
-  gint                    n_columns; 
+  gint                    n_columns;
 
   ClutterModelFilterFunc  filter_func;
   gpointer                filter_data;
@@ -289,7 +289,7 @@ clutter_model_real_get_n_rows (ClutterModel *model)
   return row_count;
 }
 
-static void 
+static void
 clutter_model_finalize (GObject *object)
 {
   ClutterModelPrivate *priv = CLUTTER_MODEL (object)->priv;
@@ -297,11 +297,11 @@ clutter_model_finalize (GObject *object)
 
   if (priv->sort_notify)
     priv->sort_notify (priv->sort_data);
-  
+
   if (priv->filter_notify)
     priv->filter_notify (priv->filter_data);
 
-  g_free (priv->column_types);
+  free (priv->column_types);
 
   if (priv->column_names != NULL)
     {
@@ -309,9 +309,9 @@ clutter_model_finalize (GObject *object)
        * to use the columns number to clear up everything
        */
       for (i = 0; i < priv->n_columns; i++)
-        g_free (priv->column_names[i]);
+        free (priv->column_names[i]);
 
-      g_free (priv->column_names);
+      free (priv->column_names);
     }
 
   G_OBJECT_CLASS (clutter_model_parent_class)->finalize (object);
@@ -439,7 +439,7 @@ clutter_model_class_init (ClutterModelClass *klass)
   /**
    * ClutterModel::sort-changed:
    * @model: the #ClutterModel on which the signal is emitted
-   * 
+   *
    * The ::sort-changed signal is emitted after the model has been sorted
    *
    * Since: 0.6
@@ -456,7 +456,7 @@ clutter_model_class_init (ClutterModelClass *klass)
                   G_TYPE_NONE, 0);
    /**
    * ClutterModel::filter-changed:
-   * @model: the #ClutterModel on which the signal is emitted   
+   * @model: the #ClutterModel on which the signal is emitted
    *
    * The ::filter-changed signal is emitted when a new filter has been applied
    *
@@ -478,7 +478,7 @@ static void
 clutter_model_init (ClutterModel *self)
 {
   ClutterModelPrivate *priv;
-  
+
   self->priv = priv = clutter_model_get_instance_private (self);
 
   priv->n_columns = -1;
@@ -643,7 +643,7 @@ clutter_model_set_custom_property (ClutterScriptable *scriptable,
           _clutter_model_set_column_name (model, i, cinfo->name);
           _clutter_model_set_column_type (model, i, cinfo->type);
 
-          g_free (cinfo->name);
+          free (cinfo->name);
           g_slice_free (ColumnInfo, cinfo);
         }
 
@@ -752,8 +752,8 @@ clutter_model_set_custom_property (ClutterScriptable *scriptable,
 
           clutter_model_insertv (model, row, n_values, columns, values);
 
-          g_free (values);
-          g_free (columns);
+          free (values);
+          free (columns);
           json_node_free (node);
 
           row += 1;
@@ -900,7 +900,7 @@ _clutter_model_set_n_columns (ClutterModel *model,
     return;
 
   priv->n_columns = n_columns;
-  
+
   if (set_types && !priv->column_types)
     priv->column_types = g_new0 (GType,  n_columns);
 
@@ -1348,7 +1348,7 @@ clutter_model_insertv (ClutterModel *model,
  * @column: column to modify
  * @value: new value for the cell
  *
- * Sets the data in the cell specified by @iter and @column. The type of 
+ * Sets the data in the cell specified by @iter and @column. The type of
  * @value must be convertable to the type of the column. If the row does
  * not exist then it is created.
  *
@@ -1366,7 +1366,7 @@ clutter_model_insert_value (ClutterModel *model,
   ClutterModelClass *klass;
   ClutterModelIter *iter;
   gboolean added = FALSE;
-  
+
   g_return_if_fail (CLUTTER_IS_MODEL (model));
 
   priv = model->priv;
@@ -1504,7 +1504,7 @@ clutter_model_get_column_type (ClutterModel *model,
  *
  * Deprecated: 1.24: Use #GListModel instead
  */
-ClutterModelIter * 
+ClutterModelIter *
 clutter_model_get_iter_at_row (ClutterModel *model,
                                guint         row)
 {
@@ -1615,7 +1615,7 @@ clutter_model_get_n_rows (ClutterModel *model)
  *
  * Deprecated: 1.24: Use #GListModel instead
  */
-void               
+void
 clutter_model_set_sorting_column (ClutterModel *model,
                                   gint          column)
 {
@@ -1666,7 +1666,7 @@ clutter_model_get_sorting_column (ClutterModel *model)
  * @func: (scope call): a #ClutterModelForeachFunc
  * @user_data: user data to pass to @func
  *
- * Calls @func for each row in the model. 
+ * Calls @func for each row in the model.
  *
  * Since: 0.6
  *
@@ -1678,7 +1678,7 @@ clutter_model_foreach (ClutterModel            *model,
                        gpointer                 user_data)
 {
   ClutterModelIter *iter;
-  
+
   g_return_if_fail (CLUTTER_IS_MODEL (model));
 
   iter = clutter_model_get_first_iter (model);
@@ -1721,7 +1721,7 @@ clutter_model_set_sort (ClutterModel         *model,
                         GDestroyNotify        notify)
 {
   ClutterModelPrivate *priv;
-    
+
   g_return_if_fail (CLUTTER_IS_MODEL (model));
   g_return_if_fail ((func != NULL && column >= 0) ||
                     (func == NULL && column == -1));
@@ -1734,7 +1734,7 @@ clutter_model_set_sort (ClutterModel         *model,
   priv->sort_func = func;
   priv->sort_data = user_data;
   priv->sort_notify = notify;
-  
+
   /* This takes care of calling _model_sort & emitting the signal*/
   clutter_model_set_sorting_column (model, column);
 }
@@ -1759,7 +1759,7 @@ clutter_model_set_filter (ClutterModel           *model,
                           GDestroyNotify          notify)
 {
   ClutterModelPrivate *priv;
-    
+
   g_return_if_fail (CLUTTER_IS_MODEL (model));
   priv = model->priv;
 
@@ -1796,7 +1796,7 @@ clutter_model_get_filter_set (ClutterModel *model)
 }
 
 /*
- * ClutterModelIter Object 
+ * ClutterModelIter Object
  */
 
 /**
@@ -2057,11 +2057,11 @@ clutter_model_iter_set_internal_valist (ClutterModelIter *iter,
   ClutterModel *model = priv->model;
   guint column = 0;
   gboolean sort = FALSE;
-  
+
   g_assert (CLUTTER_IS_MODEL (model));
 
   column = va_arg (args, gint);
-  
+
   while (column != -1)
     {
       GValue value = G_VALUE_INIT;
@@ -2069,7 +2069,7 @@ clutter_model_iter_set_internal_valist (ClutterModelIter *iter,
       GType col_type;
 
       if (column >= clutter_model_get_n_columns (model))
-        { 
+        {
           g_warning ("%s: Invalid column number %d added to iter "
                      "(remember to end you list of columns with a -1)",
                      G_STRLOC, column);
@@ -2082,19 +2082,19 @@ clutter_model_iter_set_internal_valist (ClutterModelIter *iter,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
 
           /* Leak value as it might not be in a sane state */
           break;
         }
 
       clutter_model_iter_set_value_internal (iter, column, &value);
-      
+
       g_value_unset (&value);
-      
+
       if (column == clutter_model_get_sorting_column (model))
         sort = TRUE;
-      
+
       column = va_arg (args, gint);
     }
 
@@ -2125,7 +2125,7 @@ clutter_model_iter_emit_row_changed (ClutterModelIter *iter)
  *
  * Deprecated: 1.24: Use #GListModel instead
  */
-void 
+void
 clutter_model_iter_set_valist (ClutterModelIter *iter,
                                va_list           args)
 {
@@ -2149,7 +2149,7 @@ clutter_model_iter_set_valist (ClutterModelIter *iter,
  * <informalexample><programlisting>
  *   clutter_model_iter_get (iter, 0, &place_string_here, -1);
  * </programlisting></informalexample>
- * 
+ *
  * where place_string_here is a gchar* to be filled with the string. If
  * appropriate, the returned values have to be freed or unreferenced.
  *
@@ -2184,7 +2184,7 @@ clutter_model_iter_get_value_internal (ClutterModelIter *iter,
  * @column: column number to retrieve the value from
  * @value: (out): an empty #GValue to set
  *
- * Sets an initializes @value to that at @column. When done with @value, 
+ * Sets an initializes @value to that at @column. When done with @value,
  * g_value_unset() needs to be called to free any allocated memory.
  *
  * Since: 0.6
@@ -2199,7 +2199,7 @@ clutter_model_iter_get_value (ClutterModelIter *iter,
   ClutterModel *model;
 
   g_return_if_fail (CLUTTER_IS_MODEL_ITER (iter));
-  
+
   model = iter->priv->model;
 
   if (G_VALUE_TYPE (value) == G_TYPE_INVALID)
@@ -2220,14 +2220,14 @@ clutter_model_iter_get_value (ClutterModelIter *iter,
  *
  * Deprecated: 1.24: Use #GListModel instead
  */
-void 
+void
 clutter_model_iter_get_valist (ClutterModelIter *iter,
                                va_list           args)
 {
   ClutterModelIterPrivate *priv;
   ClutterModel *model;
   guint column = 0;
-  
+
   g_return_if_fail (CLUTTER_IS_MODEL_ITER (iter));
 
   priv = iter->priv;
@@ -2243,7 +2243,7 @@ clutter_model_iter_get_valist (ClutterModelIter *iter,
       GType col_type;
 
       if (column >= clutter_model_get_n_columns (model))
-        { 
+        {
           g_warning ("%s: Invalid column number %d added to iter "
                      "(remember to end you list of columns with a -1)",
                      G_STRLOC, column);
@@ -2259,14 +2259,14 @@ clutter_model_iter_get_valist (ClutterModelIter *iter,
       if (error)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
 
           /* Leak value as it might not be in a sane state */
           break;
         }
-     
+
       g_value_unset (&value);
-      
+
       column = va_arg (args, gint);
     }
 }
@@ -2345,14 +2345,14 @@ gboolean
 clutter_model_iter_is_first (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), FALSE);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->is_first (iter);
 }
 
 /**
  * clutter_model_iter_is_last:
  * @iter: a #ClutterModelIter
- * 
+ *
  * Gets whether the iterator is at the end of the model to which it
  * belongs.
  *
@@ -2366,14 +2366,14 @@ gboolean
 clutter_model_iter_is_last (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), FALSE);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->is_last (iter);
 }
 
 /**
  * clutter_model_iter_next:
  * @iter: a #ClutterModelIter
- * 
+ *
  * Updates the @iter to point at the next position in the model.
  * The model implementation should take into account the presence of
  * a filter function.
@@ -2389,14 +2389,14 @@ ClutterModelIter *
 clutter_model_iter_next (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), NULL);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->next (iter);
 }
 
 /**
  * clutter_model_iter_prev:
  * @iter: a #ClutterModelIter
- * 
+ *
  * Sets the @iter to point at the previous position in the model.
  * The model implementation should take into account the presence of
  * a filter function.
@@ -2412,14 +2412,14 @@ ClutterModelIter *
 clutter_model_iter_prev (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), NULL);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->prev (iter);
 }
 
 /**
  * clutter_model_iter_get_model:
  * @iter: a #ClutterModelIter
- * 
+ *
  * Retrieves a pointer to the #ClutterModel that this iter is part of.
  *
  * Return value: (transfer none): a pointer to a #ClutterModel.
@@ -2432,14 +2432,14 @@ ClutterModel *
 clutter_model_iter_get_model (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), NULL);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->get_model (iter);
 }
 
 /**
  * clutter_model_iter_get_row:
  * @iter: a #ClutterModelIter
- * 
+ *
  * Retrieves the position of the row that the @iter points to.
  *
  * Return value: the position of the @iter in the model
@@ -2452,7 +2452,7 @@ guint
 clutter_model_iter_get_row (ClutterModelIter *iter)
 {
   g_return_val_if_fail (CLUTTER_IS_MODEL_ITER (iter), 0);
-  
+
   return CLUTTER_MODEL_ITER_GET_CLASS (iter)->get_row (iter);
 }
 

--- a/clutter/clutter/deprecated/clutter-score.c
+++ b/clutter/clutter/deprecated/clutter-score.c
@@ -149,7 +149,7 @@ static inline void clutter_score_clear (ClutterScore *score);
 
 G_DEFINE_TYPE_WITH_PRIVATE (ClutterScore, clutter_score, G_TYPE_OBJECT)
 
-static int score_signals[LAST_SIGNAL] = { 0 }; 
+static int score_signals[LAST_SIGNAL] = { 0 };
 
 /* Object */
 
@@ -160,7 +160,7 @@ clutter_score_set_property (GObject      *gobject,
 			    GParamSpec   *pspec)
 {
   ClutterScorePrivate *priv;
-  
+
   priv = clutter_score_get_instance_private (CLUTTER_SCORE (gobject));
 
   switch (prop_id)
@@ -454,7 +454,7 @@ destroy_entry (GNode                  *node,
         }
 
       g_object_unref (entry->timeline);
-      g_free (entry->marker);
+      free (entry->marker);
       g_slice_free (ClutterScoreEntry, entry);
 
       node->data = NULL;
@@ -646,7 +646,7 @@ on_timeline_completed (ClutterTimeline   *timeline,
   g_signal_handler_disconnect (timeline, entry->complete_id);
   entry->complete_id = 0;
 
-  CLUTTER_NOTE (SCHEDULER, "timeline [%p] ('%lu') completed", 
+  CLUTTER_NOTE (SCHEDULER, "timeline [%p] ('%lu') completed",
 		entry->timeline,
                 entry->id);
 
@@ -666,11 +666,11 @@ on_timeline_completed (ClutterTimeline   *timeline,
   if (g_hash_table_size (priv->running_timelines) == 0)
     {
       CLUTTER_NOTE (SCHEDULER, "looks like we finished");
-      
+
       g_signal_emit (entry->score, score_signals[COMPLETED], 0);
 
       clutter_score_stop (entry->score);
-      
+
       if (priv->loop)
         clutter_score_start (entry->score);
     }
@@ -827,7 +827,7 @@ clutter_score_pause (ClutterScore *score)
 
   priv = score->priv;
 
-  if (!clutter_score_is_playing (score)) 
+  if (!clutter_score_is_playing (score))
     return;
 
   g_hash_table_foreach (priv->running_timelines,
@@ -1021,7 +1021,7 @@ clutter_score_append_at_marker (ClutterScore    *score,
 
   entry->node = g_node_append_data (node, entry);
 
-  g_free (marker_reached_signal);
+  free (marker_reached_signal);
 
   priv->last_id += 1;
 

--- a/clutter/clutter/deprecated/clutter-shader.c
+++ b/clutter/clutter/deprecated/clutter-shader.c
@@ -134,8 +134,8 @@ clutter_shader_finalize (GObject *object)
 
   clutter_shaders_list = g_list_remove (clutter_shaders_list, object);
 
-  g_free (priv->fragment_source);
-  g_free (priv->vertex_source);
+  free (priv->fragment_source);
+  free (priv->vertex_source);
 
   G_OBJECT_CLASS (clutter_shader_parent_class)->finalize (object);
 }
@@ -374,7 +374,7 @@ clutter_shader_set_source (ClutterShader     *shader,
   switch (shader_type)
     {
     case CLUTTER_FRAGMENT_SHADER:
-      g_free (priv->fragment_source);
+      free (priv->fragment_source);
 
       priv->fragment_source = g_strndup (data, length);
       priv->fragment_is_glsl = is_glsl;
@@ -382,7 +382,7 @@ clutter_shader_set_source (ClutterShader     *shader,
       break;
 
     case CLUTTER_VERTEX_SHADER:
-      g_free (priv->vertex_source);
+      free (priv->vertex_source);
 
       priv->vertex_source = g_strndup (data, length);
       priv->vertex_is_glsl = is_glsl;
@@ -518,7 +518,7 @@ clutter_shader_glsl_bind (ClutterShader      *self,
                                                         : _("Fragment shader"),
                    log_buf);
 
-      g_free (log_buf);
+      free (log_buf);
 
       return FALSE;
     }

--- a/clutter/clutter/deprecated/clutter-state.c
+++ b/clutter/clutter/deprecated/clutter-state.c
@@ -205,7 +205,7 @@ typedef struct StateAnimator {
 } StateAnimator;
 
 typedef struct State
-{ 
+{
   const gchar  *name;          /* interned string for this state name */
   GHashTable   *durations;     /* durations for transitions from various state
                                   names */
@@ -242,7 +242,7 @@ struct _ClutterStatePrivate
  *
  */
 typedef struct _ClutterStateKey
-{ 
+{
   GObject         *object;       /* an Gobject */
   const gchar     *property_name;/* the name of a property */
   gulong           mode;         /* alpha to use */
@@ -500,7 +500,7 @@ state_free (gpointer data)
 
   g_array_free (state->animators, TRUE);
   g_hash_table_destroy (state->durations);
-  g_free (state);
+  free (state);
 }
 
 static State *
@@ -518,7 +518,7 @@ state_new (ClutterState *clutter_state,
   return state;
 }
 
-static void 
+static void
 clutter_state_finalize (GObject *object)
 {
   ClutterStatePrivate *priv = CLUTTER_STATE (object)->priv;
@@ -580,7 +580,7 @@ clutter_state_new_frame (ClutterTimeline *timeline,
         {
           if (key->source_state != NULL &&
               key->source_state->name != NULL &&
-              priv->source_state_name != NULL && 
+              priv->source_state_name != NULL &&
               g_str_equal (priv->source_state_name, key->source_state->name))
             {
               found_specific = TRUE;
@@ -1018,7 +1018,7 @@ clutter_state_set (ClutterState *state,
       if (error != NULL)
         {
           g_warning ("%s: %s", G_STRLOC, error);
-          g_free (error);
+          free (error);
           break;
         }
 
@@ -1638,7 +1638,7 @@ clutter_state_set_animator (ClutterState    *state,
   target_state = clutter_state_fetch_state (state, target_state_name, TRUE);
   if (target_state == NULL)
     return;
-  
+
   for (i = 0; target_state->animators->len; i++)
     {
       StateAnimator *a;
@@ -1996,7 +1996,7 @@ clutter_state_set_duration (ClutterState *state,
  *
  * The semantics for the query are the same as the semantics used for
  * setting the duration with clutter_state_set_duration()
- * 
+ *
  * Return value: the duration, in milliseconds
  *
  * Since: 1.4
@@ -2056,7 +2056,7 @@ clutter_state_get_duration (ClutterState *state,
  *
  * This function is useful when called from handlers of the
  * #ClutterState::completed signal.
- * 
+ *
  * Return value: a string containing the target state. The returned string
  *   is owned by the #ClutterState and should not be modified or freed
  *

--- a/clutter/clutter/deprecated/clutter-texture.c
+++ b/clutter/clutter/deprecated/clutter-texture.c
@@ -716,7 +716,7 @@ clutter_texture_async_data_free (ClutterTextureAsyncData *data)
      once it is known that the load thread has completed or from the
      load thread/upload function itself if the abort flag is true (in
      which case the main thread has disowned the data) */
-  g_free (data->load_filename);
+  free (data->load_filename);
 
   if (data->load_bitmap != NULL)
     cogl_object_unref (data->load_bitmap);
@@ -797,7 +797,7 @@ clutter_texture_finalize (GObject *object)
 {
   ClutterTexturePrivate *priv = CLUTTER_TEXTURE (object)->priv;
 
-  g_free (priv->filename);
+  free (priv->filename);
 
   G_OBJECT_CLASS (clutter_texture_parent_class)->finalize (object);
 }
@@ -1244,7 +1244,7 @@ clutter_texture_set_custom_property (ClutterScriptable *scriptable,
           g_error_free (error);
         }
 
-      g_free (path);
+      free (path);
     }
   else
     {
@@ -1595,7 +1595,7 @@ clutter_texture_set_from_data (ClutterTexture     *texture,
       return FALSE;
     }
 
-  g_free (priv->filename);
+  free (priv->filename);
   priv->filename = NULL;
 
   clutter_texture_set_cogl_texture (texture, new_texture);
@@ -2088,7 +2088,7 @@ clutter_texture_set_from_file (ClutterTexture *texture,
       return FALSE;
     }
 
-  g_free (priv->filename);
+  free (priv->filename);
   priv->filename = g_strdup (filename);
 
   clutter_texture_set_cogl_texture (texture, new_texture);
@@ -2381,7 +2381,7 @@ clutter_texture_set_area_from_rgb_data (ClutterTexture     *texture,
       return FALSE;
     }
 
-  g_free (texture->priv->filename);
+  free (texture->priv->filename);
   texture->priv->filename = NULL;
 
   /* rename signal */

--- a/clutter/clutter/evdev/clutter-device-manager-evdev.c
+++ b/clutter/clutter/evdev/clutter-device-manager-evdev.c
@@ -2694,7 +2694,7 @@ clutter_evdev_remove_filter (ClutterEvdevFilterFunc func,
         {
           if (filter->destroy_notify)
             filter->destroy_notify (filter->data);
-          g_free (filter);
+          free (filter);
           manager_evdev->priv->event_filters =
             g_slist_delete_link (manager_evdev->priv->event_filters, tmp_list);
           return;
@@ -2742,6 +2742,6 @@ clutter_evdev_warp_pointer (ClutterInputDevice   *pointer_device,
 void
 clutter_evdev_set_seat_id (const gchar *seat_id)
 {
-  g_free (evdev_seat_id);
+  free (evdev_seat_id);
   evdev_seat_id = g_strdup (seat_id);
 }

--- a/clutter/clutter/evdev/clutter-input-device-evdev.c
+++ b/clutter/clutter/evdev/clutter-input-device-evdev.c
@@ -250,7 +250,7 @@ clutter_input_device_evdev_free_pending_slow_key (gpointer data)
   clutter_event_free (slow_keys_event->event);
   if (slow_keys_event->timer)
     g_source_remove (slow_keys_event->timer);
-  g_free (slow_keys_event);
+  free (slow_keys_event);
 }
 
 static void
@@ -1368,9 +1368,9 @@ _clutter_input_device_evdev_new (ClutterDeviceManager *manager,
 
   libinput_device_set_user_data (libinput_device, device);
   libinput_device_ref (libinput_device);
-  g_free (vendor);
-  g_free (product);
-  g_free (node_path);
+  free (vendor);
+  free (product);
+  free (node_path);
 
   if (libinput_device_get_size (libinput_device, &width, &height) == 0)
     device->device_aspect_ratio = width / height;

--- a/clutter/clutter/evdev/clutter-seat-evdev.c
+++ b/clutter/clutter/evdev/clutter-seat-evdev.c
@@ -846,7 +846,7 @@ clutter_seat_evdev_free (ClutterSeatEvdev *seat)
       g_object_unref (device);
     }
   g_slist_free (seat->devices);
-  g_free (seat->touch_states);
+  free (seat->touch_states);
 
   xkb_state_unref (seat->xkb);
 
@@ -855,7 +855,7 @@ clutter_seat_evdev_free (ClutterSeatEvdev *seat)
   if (seat->libinput_seat)
     libinput_seat_unref (seat->libinput_seat);
 
-  g_free (seat);
+  free (seat);
 }
 
 ClutterInputDevice *

--- a/clutter/clutter/evdev/clutter-seat-evdev.c
+++ b/clutter/clutter/evdev/clutter-seat-evdev.c
@@ -102,9 +102,8 @@ ensure_seat_slot_allocated (ClutterSeatEvdev *seat,
       int i;
 
       seat->n_alloc_touch_states += size_increase;
-      seat->touch_states = g_realloc_n (seat->touch_states,
-                                        seat->n_alloc_touch_states,
-                                        sizeof (ClutterTouchState *));
+      seat->touch_states = realloc (seat->touch_states,
+                                    seat->n_alloc_touch_states * sizeof (ClutterTouchState *));
       for (i = 0; i < size_increase; i++)
         seat->touch_states[seat->n_alloc_touch_states - (i + 1)] = NULL;
     }

--- a/clutter/clutter/x11/clutter-backend-x11.c
+++ b/clutter/clutter/x11/clutter-backend-x11.c
@@ -445,7 +445,7 @@ clutter_backend_x11_post_parse (ClutterBackend  *backend,
   backend_x11->atom_NET_WM_NAME = atoms[9];
   backend_x11->atom_UTF8_STRING = atoms[10];
 
-  g_free (clutter_display_name);
+  free (clutter_display_name);
 
   CLUTTER_NOTE (BACKEND,
                 "X Display '%s'[%p] opened (screen:%d, root:%u, dpi:%f)",
@@ -542,7 +542,7 @@ clutter_backend_x11_finalize (GObject *gobject)
 {
   ClutterBackendX11 *backend_x11 = CLUTTER_BACKEND_X11 (gobject);
 
-  g_free (backend_x11->display_name);
+  free (backend_x11->display_name);
 
   clutter_x11_remove_filter (cogl_xlib_filter, gobject);
 
@@ -1175,7 +1175,7 @@ clutter_x11_remove_filter (ClutterX11FilterFunc func,
             g_slist_remove_link (backend_x11->event_filters, this);
 
           g_slist_free_1 (this);
-          g_free (filter);
+          free (filter);
 
           return;
         }
@@ -1437,7 +1437,7 @@ _clutter_x11_input_device_translate_screen_coord (ClutterInputDevice *device,
   ClutterAxisInfo *info;
   ClutterBackendX11 *backend_x11;
   gdouble width, scale, offset;
-  
+
   backend_x11 = CLUTTER_BACKEND_X11 (device->backend);
 
   if (device->axes == NULL || index_ >= device->axes->len)

--- a/clutter/clutter/x11/clutter-device-manager-xi2.c
+++ b/clutter/clutter/x11/clutter-device-manager-xi2.c
@@ -444,7 +444,7 @@ create_device (ClutterDeviceManagerXI2 *manager_xi2,
       else
         source = CLUTTER_POINTER_DEVICE;
 
-      g_free (name);
+      free (name);
     }
 
   switch (info->use)
@@ -507,9 +507,9 @@ create_device (ClutterDeviceManagerXI2 *manager_xi2,
     clutter_input_device_xi2_ensure_wacom_info (retval, manager_xi2->wacom_db);
 #endif
 
-  g_free (vendor_id);
-  g_free (product_id);
-  g_free (node_path);
+  free (vendor_id);
+  free (product_id);
+  free (node_path);
 
   CLUTTER_NOTE (BACKEND, "Created device '%s' (id: %d, has-cursor: %s)",
                 info->name,
@@ -556,7 +556,7 @@ pad_passive_button_grab (ClutterInputDevice *device)
 
   clutter_x11_untrap_x_errors ();
 
-  g_free (xi_event_mask.mask);
+  free (xi_event_mask.mask);
 }
 
 static ClutterInputDevice *
@@ -738,7 +738,7 @@ translate_hierarchy_event (ClutterBackendX11       *backend_x11,
             {
               ClutterStage *stage = _clutter_input_device_get_stage (master);
               if (stage != NULL)
-                _clutter_stage_x11_events_device_changed (CLUTTER_STAGE_X11 (_clutter_stage_get_window (stage)), 
+                _clutter_stage_x11_events_device_changed (CLUTTER_STAGE_X11 (_clutter_stage_get_window (stage)),
                                                           master,
                                                           CLUTTER_DEVICE_MANAGER (manager_xi2));
             }
@@ -1053,7 +1053,7 @@ clutter_device_manager_xi2_select_stage_events (ClutterDeviceManager *manager,
 
   XISelectEvents (backend_x11->xdpy, stage_x11->xwin, &xi_event_mask, 1);
 
-  g_free (mask);
+  free (mask);
 }
 
 static guint
@@ -2071,7 +2071,7 @@ clutter_device_manager_xi2_class_init (ClutterDeviceManagerXI2Class *klass)
   gobject_class->set_property = clutter_device_manager_xi2_set_property;
 
   g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
-  
+
   manager_class = CLUTTER_DEVICE_MANAGER_CLASS (klass);
   manager_class->add_device = clutter_device_manager_xi2_add_device;
   manager_class->remove_device = clutter_device_manager_xi2_remove_device;

--- a/clutter/clutter/x11/clutter-event-x11.c
+++ b/clutter/clutter/x11/clutter-event-x11.c
@@ -127,7 +127,7 @@ _clutter_x11_event_source_new (ClutterBackendX11 *backend_x11)
   name = g_strdup_printf ("Clutter X11 Event (connection: %d)",
                           connection_number);
   g_source_set_name (source, name);
-  g_free (name);
+  free (name);
 
   event_source->backend = backend_x11;
   event_source->event_poll_fd.fd = connection_number;

--- a/clutter/clutter/x11/clutter-stage-x11.c
+++ b/clutter/clutter/x11/clutter-stage-x11.c
@@ -773,7 +773,7 @@ clutter_stage_x11_set_title (ClutterStageWindow *stage_window,
 {
   ClutterStageX11 *stage_x11 = CLUTTER_STAGE_X11 (stage_window);
 
-  g_free (stage_x11->title);
+  free (stage_x11->title);
   stage_x11->title = g_strdup (title);
   set_wm_title (stage_x11);
 }
@@ -954,7 +954,7 @@ clutter_stage_x11_finalize (GObject *gobject)
 {
   ClutterStageX11 *stage_x11 = CLUTTER_STAGE_X11 (gobject);
 
-  g_free (stage_x11->title);
+  free (stage_x11->title);
 
   G_OBJECT_CLASS (clutter_stage_x11_parent_class)->finalize (gobject);
 }

--- a/clutter/examples/actor-model.c
+++ b/clutter/examples/actor-model.c
@@ -42,7 +42,7 @@ example_menu_item_model_finalize (GObject *gobject)
 {
   ExampleMenuItemModel *self = (ExampleMenuItemModel *) gobject;
 
-  g_free (self->label);
+  free (self->label);
 
   G_OBJECT_CLASS (example_menu_item_model_parent_class)->finalize (gobject);
 }
@@ -58,7 +58,7 @@ example_menu_item_model_set_property (GObject      *gobject,
   switch (prop_id)
     {
     case MENU_ITEM_MODEL_PROP_LABEL:
-      g_free (self->label);
+      free (self->label);
       self->label = g_value_dup_string (value);
       break;
 
@@ -426,7 +426,7 @@ on_model_item_selection (GObject    *model_item,
   if (is_selected)
     g_print ("Item '%s' selected!\n", label);
 
-  g_free (label);
+  free (label);
 }
 
 static ClutterActor *
@@ -453,7 +453,7 @@ create_menu_actor (void)
                         NULL);
 
       g_object_unref (item);
-      g_free (label);
+      free (label);
     }
 
   /* Bind the list of menu item models to the menu actor; this will

--- a/clutter/examples/box-layout.c
+++ b/clutter/examples/box-layout.c
@@ -128,7 +128,7 @@ changed_cb (ClutterActor *actor,
                            get_align_name (x_align),
                            get_align_name (y_align));
   clutter_text_set_text (CLUTTER_TEXT (text), label);
-  g_free (label);
+  free (label);
 }
 
 static void

--- a/clutter/examples/easing-modes.c
+++ b/clutter/examples/easing-modes.c
@@ -79,7 +79,7 @@ on_button_press (ClutterActor       *actor,
                               n_easing_modes);
 
       clutter_text_set_markup (CLUTTER_TEXT (easing_mode_label), text);
-      g_free (text);
+      free (text);
     }
   else if (event->button == CLUTTER_BUTTON_MIDDLE)
     {
@@ -227,7 +227,7 @@ main (int argc, char *argv[])
   clutter_actor_add_constraint (label, clutter_align_constraint_new (stage, CLUTTER_ALIGN_Y_AXIS, 0.95));
   easing_mode_label = label;
 
-  g_free (text);
+  free (text);
 
   g_signal_connect (stage,
                     "button-press-event", G_CALLBACK (on_button_press),

--- a/clutter/examples/flow-layout.c
+++ b/clutter/examples/flow-layout.c
@@ -153,7 +153,7 @@ main (int argc, char *argv[])
 
       clutter_actor_add_child (box, rect);
 
-      g_free (name);
+      free (name);
     }
 
   clutter_actor_show (stage);

--- a/clutter/examples/grid-layout.c
+++ b/clutter/examples/grid-layout.c
@@ -189,7 +189,7 @@ changed_cb (ClutterActor *actor,
                            get_align_name (x_align),
                            get_align_name (y_align));
   clutter_text_set_text (CLUTTER_TEXT (text), label);
-  g_free (label);
+  free (label);
 }
 
 static void

--- a/clutter/examples/image-content.c
+++ b/clutter/examples/image-content.c
@@ -38,7 +38,7 @@ on_tap (ClutterTapAction *action,
 
   str = g_strconcat ("Content gravity: ", gravities[cur_gravity].name, NULL);
   clutter_text_set_text (label, str);
-  g_free (str);
+  free (str);
 
   cur_gravity += 1;
 
@@ -98,7 +98,7 @@ main (int argc, char *argv[])
   clutter_actor_add_constraint (text, clutter_align_constraint_new (stage, CLUTTER_ALIGN_BOTH, 0.5));
   clutter_actor_add_child (stage, text);
 
-  g_free (str);
+  free (str);
 
   action = clutter_tap_action_new ();
   g_signal_connect (action, "tap", G_CALLBACK (on_tap), text);

--- a/clutter/examples/threads.c
+++ b/clutter/examples/threads.c
@@ -41,7 +41,7 @@ test_thread_data_free (gpointer _data)
   g_clear_object (&data->flip);
   g_clear_object (&data->bounce);
 
-  g_free (data);
+  free (data);
 }
 
 static gboolean
@@ -114,8 +114,8 @@ update_label_idle (gpointer data)
   clutter_actor_set_width (update->thread_data->progress, width);
   clutter_actor_restore_easing_state (update->thread_data->progress);
 
-  g_free (text);
-  g_free (update);
+  free (text);
+  free (update);
 
   return G_SOURCE_REMOVE;
 }
@@ -235,7 +235,7 @@ main (int argc, char *argv[])
   clutter_actor_set_background_color (stage, CLUTTER_COLOR_Aluminium3);
   clutter_actor_set_size (stage, 600, 300);
   g_signal_connect (stage, "destroy", G_CALLBACK (clutter_main_quit), NULL);
-  
+
   count_label = clutter_text_new_with_text ("Mono 12", "Counter");
   clutter_actor_set_position (count_label, 350, 50);
   clutter_actor_add_child (stage, count_label);

--- a/clutter/tests/accessibility/cally-atktext-example.c
+++ b/clutter/tests/accessibility/cally-atktext-example.c
@@ -63,29 +63,29 @@ test_atk_text (ClutterActor *actor)
   unichar = atk_text_get_character_at_offset (cally_text, 5);
   buf = g_ucs4_to_utf8 (&unichar, 1, NULL, NULL, NULL);
   g_print ("atk_text_get_character_at_offset(5): '%s' vs '%c'\n", buf, text[5]);
-  g_free (text); text = NULL;
-  g_free (buf); buf = NULL;
+  free (text); text = NULL;
+  free (buf); buf = NULL;
 
   text = atk_text_get_text_before_offset (cally_text,
                                           5, ATK_TEXT_BOUNDARY_WORD_END,
                                           &start, &end);
   g_print ("atk_text_get_text_before_offset: %s, %i, %i\n",
            text, start, end);
-  g_free (text); text = NULL;
+  free (text); text = NULL;
 
   text = atk_text_get_text_at_offset (cally_text,
                                       5, ATK_TEXT_BOUNDARY_WORD_END,
                                       &start, &end);
   g_print ("atk_text_get_text_at_offset: %s, %i, %i\n",
            text, start, end);
-  g_free (text); text = NULL;
+  free (text); text = NULL;
 
   text = atk_text_get_text_after_offset (cally_text,
                                          5, ATK_TEXT_BOUNDARY_WORD_END,
                                          &start, &end);
   g_print ("atk_text_get_text_after_offset: %s, %i, %i\n",
            text, start, end);
-  g_free (text); text = NULL;
+  free (text); text = NULL;
 
   pos = atk_text_get_caret_offset (cally_text);
   g_print ("atk_text_get_caret_offset: %i\n", pos);
@@ -100,7 +100,7 @@ test_atk_text (ClutterActor *actor)
 
   text = atk_text_get_selection (cally_text, 0, &start, &end);
   g_print ("atk_text_get_selection: %s, %i, %i\n", text, start, end);
-  g_free(text); text = NULL;
+  free(text); text = NULL;
 
   bool = atk_text_remove_selection (cally_text, 0);
   g_print ("atk_text_remove_selection (0): %i\n", bool);

--- a/clutter/tests/accessibility/cally-examples-util.c
+++ b/clutter/tests/accessibility/cally-examples-util.c
@@ -139,8 +139,8 @@ cally_util_a11y_init (int *argc, char ***argv)
 
   result = _a11y_invoke_module (bridge_path, TRUE);
 
-  g_free (bridge_dir);
-  g_free (bridge_path);
+  free (bridge_dir);
+  free (bridge_path);
 
   return result;
 }

--- a/clutter/tests/conform/actor-iter.c
+++ b/clutter/tests/conform/actor-iter.c
@@ -24,7 +24,7 @@ actor_iter_traverse_children (void)
 
       clutter_actor_add_child (actor, child);
 
-      g_free (name);
+      free (name);
     }
 
   g_assert_cmpint (clutter_actor_get_n_children (actor), ==, n_actors);
@@ -99,7 +99,7 @@ actor_iter_traverse_remove (void)
 
       clutter_actor_add_child (actor, child);
 
-      g_free (name);
+      free (name);
     }
 
   g_assert_cmpint (clutter_actor_get_n_children (actor), ==, n_actors);
@@ -155,7 +155,7 @@ actor_iter_assignment (void)
 
       clutter_actor_add_child (actor, child);
 
-      g_free (name);
+      free (name);
     }
 
   g_assert_cmpint (clutter_actor_get_n_children (actor), ==, n_actors);

--- a/clutter/tests/conform/actor-offscreen-redirect.c
+++ b/clutter/tests/conform/actor-offscreen-redirect.c
@@ -147,7 +147,7 @@ verify_results (Data *data,
   g_assert_cmpint (ABS ((int) expected_color_green - (int) pixel[1]), <=, 2);
   g_assert_cmpint (ABS ((int) expected_color_blue - (int) pixel[2]), <=, 2);
 
-  g_free (pixel);
+  free (pixel);
 }
 
 static void

--- a/clutter/tests/conform/animator.c
+++ b/clutter/tests/conform/animator.c
@@ -99,7 +99,7 @@ animator_multi_properties (void)
   g_list_free (keys);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -160,7 +160,7 @@ animator_properties (void)
 
   g_list_free (keys);
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -189,7 +189,7 @@ animator_base (void)
   g_assert_cmpint (duration, ==, 1000);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 CLUTTER_TEST_SUITE (

--- a/clutter/tests/conform/behaviours.c
+++ b/clutter/tests/conform/behaviours.c
@@ -73,7 +73,7 @@ main (int argc, char *argv[])
 
       clutter_test_add (path, behaviour_tests[i].func);
 
-      g_free (path);
+      free (path);
     }
 
   return clutter_test_run ();

--- a/clutter/tests/conform/cally-text.c
+++ b/clutter/tests/conform/cally-text.c
@@ -235,7 +235,7 @@ build_attribute_set (const gchar* first_attribute, ...)
     {
         if ((i> 0) && (i % 2 != 0))
           {
-            AtkAttribute *at = g_malloc (sizeof (AtkAttribute));
+            AtkAttribute *at = malloc (sizeof (AtkAttribute));
             at->name = g_strdup (name);
             at->value = g_strdup (value);
             return_set = g_slist_prepend (return_set, at);

--- a/clutter/tests/conform/cally-text.c
+++ b/clutter/tests/conform/cally-text.c
@@ -189,7 +189,7 @@ check_result (CallbackData *data)
       dump_attribute_set (attrs);
     }
 
-  g_free (text);
+  free (text);
   text = NULL;
 
   if (fail)

--- a/clutter/tests/conform/color.c
+++ b/clutter/tests/conform/color.c
@@ -251,7 +251,7 @@ color_to_string (void)
   str = clutter_color_to_string (&color);
   g_assert_cmpstr (str, ==, "#cccccc22");
 
-  g_free (str);
+  free (str);
 }
 
 static void

--- a/clutter/tests/conform/interval.c
+++ b/clutter/tests/conform/interval.c
@@ -107,7 +107,7 @@ interval_from_script (void)
   g_assert (G_VALUE_HOLDS (final, CLUTTER_TYPE_COLOR));
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 CLUTTER_TEST_SUITE (

--- a/clutter/tests/conform/model.c
+++ b/clutter/tests/conform/model.c
@@ -122,7 +122,7 @@ compare_iter (ClutterModelIter *iter,
   g_assert_cmpstr (foo, ==, expected_foo);
   g_assert_cmpint (bar, ==, expected_bar);
 
-  g_free (foo);
+  free (foo);
 }
 
 static void
@@ -191,7 +191,7 @@ list_model_filter (void)
                             COLUMN_BAR, i,
                             -1);
 
-      g_free (foo);
+      free (foo);
     }
 
   if (g_test_verbose ())
@@ -282,7 +282,7 @@ list_model_iterate (void)
                             COLUMN_BAR, i,
                             -1);
 
-      g_free (foo);
+      free (foo);
     }
 
   if (g_test_verbose ())
@@ -355,7 +355,7 @@ list_model_populate (void)
                             COLUMN_BAR, i,
                             -1);
 
-      g_free (foo);
+      free (foo);
     }
 
   g_object_unref (test_data.model);
@@ -474,7 +474,7 @@ list_model_row_changed (void)
                             COLUMN_BAR, i,
                             -1);
 
-      g_free (foo);
+      free (foo);
     }
 
   g_signal_connect (test_data.model, "row-changed",

--- a/clutter/tests/conform/path.c
+++ b/clutter/tests/conform/path.c
@@ -389,8 +389,8 @@ path_test_get_description (CallbackData *data)
   if (strcmp (desc1, desc2))
     ret = FALSE;
 
-  g_free (desc1);
-  g_free (desc2);
+  free (desc1);
+  free (desc2);
 
   return ret;
 }

--- a/clutter/tests/conform/score.c
+++ b/clutter/tests/conform/score.c
@@ -60,28 +60,28 @@ score_base (TestConformSimpleFixture *fixture,
   timeline_1 = clutter_timeline_new (100);
   g_object_set_data_full (G_OBJECT (timeline_1),
                           "timeline-name", g_strdup ("Timeline 1"),
-                          g_free);
+                          free);
 
   timeline_2 = clutter_timeline_new (100);
   clutter_timeline_add_marker_at_time (timeline_2, "foo", 50);
   g_object_set_data_full (G_OBJECT (timeline_2),
                           "timeline-name", g_strdup ("Timeline 2"),
-                          g_free);
+                          free);
 
   timeline_3 = clutter_timeline_new (100);
   g_object_set_data_full (G_OBJECT (timeline_3),
                           "timeline-name", g_strdup ("Timeline 3"),
-                          g_free);
+                          free);
 
   timeline_4 = clutter_timeline_new (100);
   g_object_set_data_full (G_OBJECT (timeline_4),
                           "timeline-name", g_strdup ("Timeline 4"),
-                          g_free);
+                          free);
 
   timeline_5 = clutter_timeline_new (100);
   g_object_set_data_full (G_OBJECT (timeline_5),
                           "timeline-name", g_strdup ("Timeline 5"),
-                          g_free);
+                          free);
 
   score = clutter_score_new();
   g_signal_connect (score, "started",

--- a/clutter/tests/conform/script-parser.c
+++ b/clutter/tests/conform/script-parser.c
@@ -160,7 +160,7 @@ script_child (void)
   g_assert (!focus_ret);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -193,7 +193,7 @@ script_single (void)
   g_assert_cmpint (color.alpha, ==, 0xff);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -231,7 +231,7 @@ script_implicit_alpha (void)
   g_assert_cmpint (clutter_timeline_get_duration (timeline), ==, 500);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -257,7 +257,7 @@ script_object_property (void)
   g_assert (CLUTTER_IS_BIN_LAYOUT (manager));
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -284,7 +284,7 @@ script_named_object (void)
   g_assert (clutter_box_layout_get_vertical (CLUTTER_BOX_LAYOUT (manager)));
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -306,7 +306,7 @@ script_animation (void)
   g_assert (CLUTTER_IS_ANIMATION (animation));
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 static void
@@ -412,7 +412,7 @@ script_margin (void)
   g_assert_cmpfloat (clutter_actor_get_margin_left (actor), ==, 40.0f);
 
   g_object_unref (script);
-  g_free (test_file);
+  free (test_file);
 }
 
 CLUTTER_TEST_SUITE (

--- a/clutter/tests/conform/state.c
+++ b/clutter/tests/conform/state.c
@@ -19,7 +19,7 @@ state_base (TestConformSimpleFixture *fixture G_GNUC_UNUSED,
   if (g_test_verbose () && error)
     g_print ("Error: %s\n", error->message);
 
-  g_free (test_file);
+  free (test_file);
 
 #if GLIB_CHECK_VERSION (2, 20, 0)
   g_assert_no_error (error);
@@ -45,7 +45,7 @@ state_base (TestConformSimpleFixture *fixture G_GNUC_UNUSED,
   keys = clutter_state_get_keys (CLUTTER_STATE (state), "base", "clicked",
                                  clutter_script_get_object (script, "rect"),
                                  "opacity");
-  
+
   g_assert (keys != NULL);
   g_assert_cmpint (g_list_length (keys), ==, 1);
 
@@ -65,7 +65,7 @@ state_base (TestConformSimpleFixture *fixture G_GNUC_UNUSED,
 
   keys = clutter_state_get_keys (CLUTTER_STATE (state), "base", "clicked",
                                  NULL, NULL);
-  
+
   g_assert (keys != NULL);
   g_assert_cmpint (g_list_length (keys), ==, 2);
   g_list_free (keys);

--- a/clutter/tests/conform/text.c
+++ b/clutter/tests/conform/text.c
@@ -256,19 +256,19 @@ text_get_chars (void)
 
   chars = clutter_text_get_chars (text, 2, -1);
   g_assert_cmpstr (chars, ==, "abcdef11");
-  g_free (chars);
+  free (chars);
 
   chars = clutter_text_get_chars (text, 0, 8);
   g_assert_cmpstr (chars, ==, "00abcdef");
-  g_free (chars);
+  free (chars);
 
   chars = clutter_text_get_chars (text, 2, 8);
   g_assert_cmpstr (chars, ==, "abcdef");
-  g_free (chars);
+  free (chars);
 
   chars = clutter_text_get_chars (text, 8, 12);
   g_assert_cmpstr (chars, ==, "11");
-  g_free (chars);
+  free (chars);
 
   clutter_actor_destroy (CLUTTER_ACTOR (text));
 }

--- a/clutter/tests/conform/texture-fbo.c
+++ b/clutter/tests/conform/texture-fbo.c
@@ -107,7 +107,7 @@ validate_part (TestState *state,
         g_assert_cmpint (pixels[1], ==, correct_color->green);
         g_assert_cmpint (pixels[2], ==, correct_color->blue);
 
-        g_free (pixels);
+        free (pixels);
       }
 }
 

--- a/clutter/tests/conform/texture.c
+++ b/clutter/tests/conform/texture.c
@@ -5,7 +5,7 @@
 static CoglHandle
 make_texture (void)
 {
-  guint32 *data = g_malloc (100 * 100 * 4);
+  guint32 *data = malloc (100 * 100 * 4);
   int x;
   int y;
 

--- a/clutter/tests/conform/timeline.c
+++ b/clutter/tests/conform/timeline.c
@@ -38,7 +38,7 @@ timeline_data_init (TimelineData *data, int timeline_num)
 static void
 timeline_data_destroy (TimelineData *data)
 {
-  g_slist_foreach (data->markers_hit, (GFunc) g_free, NULL);
+  g_slist_foreach (data->markers_hit, (GFunc) free, NULL);
   g_slist_free (data->markers_hit);
 }
 
@@ -159,7 +159,7 @@ check_timeline (ClutterTimeline *timeline,
     }
 
   g_strfreev (markers);
-  g_free (marker_reached_count);
+  free (marker_reached_count);
 
   return succeeded;
 }
@@ -358,5 +358,5 @@ timeline_markers_from_script (TestConformSimpleFixture *fixture,
 
   g_object_unref (script);
 
-  g_free (test_file);
+  free (test_file);
 }

--- a/clutter/tests/conform/units.c
+++ b/clutter/tests/conform/units.c
@@ -107,7 +107,7 @@ units_string (void)
   clutter_units_from_pt (&units, 24.0);
   string = clutter_units_to_string (&units);
   g_assert_cmpstr (string, ==, "24.0 pt");
-  g_free (string);
+  free (string);
 
   clutter_units_from_em (&units, 3.0);
   string = clutter_units_to_string (&units);
@@ -121,7 +121,7 @@ units_string (void)
   g_assert (clutter_units_get_unit_type (&units) == CLUTTER_UNIT_EM);
   g_assert_cmpint ((int) clutter_units_get_unit_value (&units), ==, 3);
 
-  g_free (string);
+  free (string);
 }
 
 CLUTTER_TEST_SUITE (

--- a/clutter/tests/interactive/test-actors.c
+++ b/clutter/tests/interactive/test-actors.c
@@ -216,7 +216,7 @@ test_actors_main (int argc, char *argv[])
   if (real_hand == NULL)
     g_error ("image load failed: %s", error->message);
 
-  g_free (file);
+  free (file);
 
   /* create a new actor to hold other actors */
   oh->group = clutter_actor_new ();
@@ -309,8 +309,8 @@ test_actors_main (int argc, char *argv[])
   g_object_unref (oh->scaler_1);
   g_object_unref (oh->scaler_2);
   g_object_unref (oh->timeline);
-  g_free (oh->hand);
-  g_free (oh);
+  free (oh->hand);
+  free (oh);
 
   return EXIT_SUCCESS;
 }

--- a/clutter/tests/interactive/test-animator.c
+++ b/clutter/tests/interactive/test-animator.c
@@ -18,7 +18,7 @@ static ClutterActor *new_rect (gint r,
   rectangle = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
 
   clutter_actor_set_size (rectangle, 128, 128);
   clutter_color_free (color);

--- a/clutter/tests/interactive/test-cogl-multitexture.c
+++ b/clutter/tests/interactive/test-cogl-multitexture.c
@@ -226,7 +226,7 @@ test_cogl_multitexture_main (int argc, char *argv[])
   cogl_handle_unref (state->redhand_tex);
   cogl_handle_unref (state->light_tex0);
   cogl_handle_unref (state->light_tex1);
-  g_free (state);
+  free (state);
 
   return 0;
 }

--- a/clutter/tests/interactive/test-cogl-offscreen.c
+++ b/clutter/tests/interactive/test-cogl-offscreen.c
@@ -268,7 +268,7 @@ test_coglbox_init (TestCoglbox *self)
                                                  COGL_TEXTURE_NONE,
 						 COGL_PIXEL_FORMAT_ANY,
                                                  NULL);
-  g_free (file);
+  free (file);
 
   printf ("Creating texture with size\n");
   priv->texture_id = cogl_texture_new_with_size (200, 200,

--- a/clutter/tests/interactive/test-cogl-point-sprites.c
+++ b/clutter/tests/interactive/test-cogl-point-sprites.c
@@ -58,7 +58,7 @@ generate_round_texture (void)
   int x, y;
   CoglHandle tex;
 
-  p = data = g_malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
+  p = data = malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
 
   /* Generate a yellow circle which gets transparent towards the edges */
   for (y = 0; y < TEXTURE_SIZE; y++)

--- a/clutter/tests/interactive/test-cogl-point-sprites.c
+++ b/clutter/tests/interactive/test-cogl-point-sprites.c
@@ -83,7 +83,7 @@ generate_round_texture (void)
                                     TEXTURE_SIZE * 4,
                                     data);
 
-  g_free (data);
+  free (data);
 
   return tex;
 }

--- a/clutter/tests/interactive/test-cogl-tex-convert.c
+++ b/clutter/tests/interactive/test-cogl-tex-convert.c
@@ -8,7 +8,7 @@
  *--------------------------------------------------*/
 
 G_BEGIN_DECLS
-  
+
 #define TEST_TYPE_COGLBOX test_coglbox_get_type()
 
 #define TEST_COGLBOX(obj) \
@@ -43,7 +43,7 @@ struct _TestCoglbox
   TestCoglboxPrivate *priv;
 };
 
-struct _TestCoglboxClass 
+struct _TestCoglboxClass
 {
   ClutterActorClass parent_class;
 
@@ -129,10 +129,10 @@ static void
 test_coglbox_dispose (GObject *object)
 {
   TestCoglboxPrivate *priv;
-  
+
   priv = TEST_COGLBOX_GET_PRIVATE (object);
   cogl_handle_unref (priv->cogl_tex_id);
-  
+
   G_OBJECT_CLASS (test_coglbox_parent_class)->dispose (object);
 }
 
@@ -151,26 +151,26 @@ test_coglbox_init (TestCoglbox *self)
                                 COGL_TEXTURE_NONE,
 				COGL_PIXEL_FORMAT_ANY,
                                 NULL);
-  
+
   priv->cogl_tex_id[1] =
     cogl_texture_new_from_file (file,
                                 COGL_TEXTURE_NONE,
 				COGL_PIXEL_FORMAT_BGRA_8888,
                                 NULL);
-  
+
   priv->cogl_tex_id[2] =
     cogl_texture_new_from_file (file,
                                 COGL_TEXTURE_NONE,
 				COGL_PIXEL_FORMAT_ARGB_8888,
                                 NULL);
-  
+
   priv->cogl_tex_id[3] =
     cogl_texture_new_from_file (file,
                                 COGL_TEXTURE_NONE,
 				COGL_PIXEL_FORMAT_G_8,
                                 NULL);
 
-  g_free (file);
+  free (file);
 }
 
 static void
@@ -180,9 +180,9 @@ test_coglbox_class_init (TestCoglboxClass *klass)
   ClutterActorClass *actor_class   = CLUTTER_ACTOR_CLASS (klass);
 
   gobject_class->finalize     = test_coglbox_finalize;
-  gobject_class->dispose      = test_coglbox_dispose;  
+  gobject_class->dispose      = test_coglbox_dispose;
   actor_class->paint          = test_coglbox_paint;
-  
+
   g_type_class_add_private (gobject_class, sizeof (TestCoglboxPrivate));
 }
 
@@ -197,10 +197,10 @@ test_cogl_tex_convert_main (int argc, char *argv[])
 {
   ClutterActor     *stage;
   ClutterActor     *coglbox;
-  
+
   if (clutter_init (&argc, &argv) != CLUTTER_INIT_SUCCESS)
     return 1;
-  
+
   /* Stage */
   stage = clutter_stage_new ();
   clutter_actor_set_size (stage, 400, 400);
@@ -210,11 +210,11 @@ test_cogl_tex_convert_main (int argc, char *argv[])
   /* Cogl Box */
   coglbox = test_coglbox_new ();
   clutter_container_add_actor (CLUTTER_CONTAINER (stage), coglbox);
-  
+
   clutter_actor_show_all (stage);
-  
+
   clutter_main ();
-  
+
   return 0;
 }
 

--- a/clutter/tests/interactive/test-cogl-tex-polygon.c
+++ b/clutter/tests/interactive/test-cogl-tex-polygon.c
@@ -281,7 +281,7 @@ test_coglbox_init (TestCoglbox *self)
         g_warning ("Texture loading failed: <unknown>");
     }
 
-  g_free (file);
+  free (file);
 }
 
 static void

--- a/clutter/tests/interactive/test-cogl-tex-tile.c
+++ b/clutter/tests/interactive/test-cogl-tex-tile.c
@@ -146,7 +146,7 @@ test_coglbox_init (TestCoglbox *self)
                                                   COGL_TEXTURE_NONE,
                                                   COGL_PIXEL_FORMAT_ANY,
                                                   NULL);
-  g_free (file);
+  free (file);
 }
 
 static void

--- a/clutter/tests/interactive/test-cogl-vertex-buffer.c
+++ b/clutter/tests/interactive/test-cogl-vertex-buffer.c
@@ -268,10 +268,10 @@ init_quad_mesh (TestState *state)
    * are using degenerate triangles at the edges to link to the next row)
    */
   state->quad_mesh_verts =
-    g_malloc0 (sizeof (float) * 3 * (MESH_WIDTH + 1) * (MESH_HEIGHT + 1));
+    calloc (1, sizeof (float) * 3 * (MESH_WIDTH + 1) * (MESH_HEIGHT + 1));
 
   state->quad_mesh_colors =
-    g_malloc0 (sizeof (guint8) * 4 * (MESH_WIDTH + 1) * (MESH_HEIGHT + 1));
+    calloc (1, sizeof (guint8) * 4 * (MESH_WIDTH + 1) * (MESH_HEIGHT + 1));
 
   vert = state->quad_mesh_verts;
   color = state->quad_mesh_colors;

--- a/clutter/tests/interactive/test-cogl-vertex-buffer.c
+++ b/clutter/tests/interactive/test-cogl-vertex-buffer.c
@@ -167,7 +167,7 @@ init_static_index_arrays (TestState *state)
    * - It takes one extra index for linking between rows (MESH_HEIGHT - 1)
    * - A 2 x 3 mesh == 20 indices... */
   n_indices = (2 + 2 * MESH_WIDTH) * MESH_HEIGHT + (MESH_HEIGHT - 1);
-  state->static_indices = g_malloc (sizeof (guint16) * n_indices);
+  state->static_indices = malloc (sizeof (guint16) * n_indices);
   state->n_static_indices = n_indices;
 
 #define MESH_INDEX(X, Y) (Y) * (MESH_WIDTH + 1) + (X)

--- a/clutter/tests/interactive/test-content.c
+++ b/clutter/tests/interactive/test-content.c
@@ -209,8 +209,8 @@ test_content_main (int argc, char *argv[])
       name = g_strconcat ("Box <", color, ">", NULL);
       clutter_actor_set_name (box, name);
 
-      g_free (name);
-      g_free (color);
+      free (name);
+      free (color);
 
       clutter_actor_set_background_color (box, &bg_color);
       clutter_actor_set_content (box, content);

--- a/clutter/tests/interactive/test-easing.c
+++ b/clutter/tests/interactive/test-easing.c
@@ -98,7 +98,7 @@ on_button_press (ClutterActor       *actor,
                               n_easing_modes);
 
       clutter_text_set_text (CLUTTER_TEXT (easing_mode_label), text);
-      g_free (text);
+      free (text);
     }
   else if (event->button == CLUTTER_BUTTON_PRIMARY)
     {
@@ -250,7 +250,7 @@ test_easing_main (int argc, char *argv[])
   clutter_actor_add_constraint (label, clutter_align_constraint_new (stage, CLUTTER_ALIGN_Y_AXIS, 0.95));
   easing_mode_label = label;
 
-  g_free (text);
+  free (text);
 
   g_signal_connect (stage,
                     "button-press-event", G_CALLBACK (on_button_press),

--- a/clutter/tests/interactive/test-events.c
+++ b/clutter/tests/interactive/test-events.c
@@ -168,7 +168,7 @@ static void
 key_focus_in_cb (ClutterActor *actor,
 		 gpointer      data)
 {
-  ClutterActor *focus_box = CLUTTER_ACTOR (data);  
+  ClutterActor *focus_box = CLUTTER_ACTOR (data);
 
   if (CLUTTER_IS_STAGE (actor))
     clutter_actor_hide (focus_box);
@@ -232,7 +232,7 @@ input_cb (ClutterActor *actor,
 	  ClutterEvent *event,
 	  gpointer      data)
 {
-  ClutterActor *stage = clutter_actor_get_stage (actor); 
+  ClutterActor *stage = clutter_actor_get_stage (actor);
   ClutterActor *source_actor = clutter_event_get_source (event);
   ClutterPoint position;
   gchar *state;
@@ -375,11 +375,11 @@ input_cb (ClutterActor *actor,
       return FALSE;
     }
 
-  g_free (state);
+  free (state);
 
   if (source_actor == actor)
     g_print (" *source*");
-  
+
   g_print ("\n");
 
   return FALSE;
@@ -398,13 +398,13 @@ test_events_main (int argc, char *argv[])
   clutter_actor_set_name (stage, "Stage");
   g_signal_connect (stage, "destroy", G_CALLBACK (clutter_main_quit), NULL);
   g_signal_connect (stage, "event", G_CALLBACK (input_cb), "stage");
-  g_signal_connect (stage, "fullscreen", 
+  g_signal_connect (stage, "fullscreen",
 		    G_CALLBACK (stage_state_cb), "fullscreen");
-  g_signal_connect (stage, "unfullscreen", 
+  g_signal_connect (stage, "unfullscreen",
 		    G_CALLBACK (stage_state_cb), "unfullscreen");
-  g_signal_connect (stage, "activate", 
+  g_signal_connect (stage, "activate",
 		    G_CALLBACK (stage_state_cb), "activate");
-  g_signal_connect (stage, "deactivate", 
+  g_signal_connect (stage, "deactivate",
 		    G_CALLBACK (stage_state_cb), "deactivate");
 
   focus_box = clutter_rectangle_new_with_color (CLUTTER_COLOR_Black);

--- a/clutter/tests/interactive/test-fbo.c
+++ b/clutter/tests/interactive/test-fbo.c
@@ -24,7 +24,7 @@ make_source (void)
   if (!actor)
     g_error("pixbuf load failed: %s", error ? error->message : "Unknown");
 
-  g_free (file);
+  free (file);
 
   clutter_container_add_actor (CLUTTER_CONTAINER (source), actor);
 

--- a/clutter/tests/interactive/test-image.c
+++ b/clutter/tests/interactive/test-image.c
@@ -230,8 +230,8 @@ test_image_main (int argc, char *argv[])
       name = g_strconcat ("Box <", color, ">", NULL);
       clutter_actor_set_name (box, name);
 
-      g_free (name);
-      g_free (str);
+      free (name);
+      free (str);
 
       if ((i % 2) == 0)
         clutter_actor_set_content (box, color);

--- a/clutter/tests/interactive/test-keyframe-transition.c
+++ b/clutter/tests/interactive/test-keyframe-transition.c
@@ -97,7 +97,7 @@ test_keyframe_transition_main (int argc, char *argv[])
                         NULL);
       g_object_unref (group);
 
-      g_free (name);
+      free (name);
     }
 
   clutter_actor_show (stage);

--- a/clutter/tests/interactive/test-main.c
+++ b/clutter/tests/interactive/test-main.c
@@ -21,7 +21,7 @@ get_symbol_with_suffix (const char *unit_name,
 
   g_module_symbol (module, main_symbol_name, &func);
 
-  g_free (main_symbol_name);
+  free (main_symbol_name);
 
   return func;
 }
@@ -142,7 +142,7 @@ main (int argc, char **argv)
                    (int) (len - strlen (str)), " ",
                    str);
 
-          g_free (str);
+          free (str);
         }
 
       ret = EXIT_SUCCESS;
@@ -188,7 +188,7 @@ main (int argc, char **argv)
 
           g_print ("* %s:\n%s\n\n", unit_test, str);
 
-          g_free (str);
+          free (str);
 
           ret = EXIT_SUCCESS;
         }
@@ -205,12 +205,12 @@ main (int argc, char **argv)
 
           ret = unit_test_main (n_unit_names, unit_names);
 
-          g_free (unit_test);
+          free (unit_test);
 
           break;
         }
 
-      g_free (unit_test);
+      free (unit_test);
     }
 
 out:

--- a/clutter/tests/interactive/test-multistage.c
+++ b/clutter/tests/interactive/test-multistage.c
@@ -56,7 +56,7 @@ on_button_press (ClutterActor *actor,
     g_error ("pixbuf load failed");
 
   clutter_actor_set_reactive (tex, TRUE);
-  g_signal_connect (tex, "button-press-event", 
+  g_signal_connect (tex, "button-press-event",
                     G_CALLBACK (tex_button_cb), NULL);
 
   clutter_container_add_actor (CLUTTER_CONTAINER (new_stage), tex);
@@ -66,14 +66,14 @@ on_button_press (ClutterActor *actor,
 
   clutter_text_set_color (CLUTTER_TEXT (label), CLUTTER_COLOR_White);
   clutter_text_set_use_markup (CLUTTER_TEXT (label), TRUE);
-  width = (clutter_actor_get_width (new_stage) 
+  width = (clutter_actor_get_width (new_stage)
            - clutter_actor_get_width (label)) / 2;
-  height = (clutter_actor_get_height (new_stage) 
+  height = (clutter_actor_get_height (new_stage)
             - clutter_actor_get_height (label)) / 2;
   clutter_actor_set_position (label, width, height);
   clutter_container_add_actor (CLUTTER_CONTAINER (new_stage), label);
   clutter_actor_show (label);
-  g_free (stage_label);
+  free (stage_label);
 
   /*
   g_signal_connect (new_stage, "button-press-event",
@@ -88,13 +88,13 @@ on_button_press (ClutterActor *actor,
   r_behave = clutter_behaviour_rotate_new (alpha,
 					   CLUTTER_Y_AXIS,
 					   CLUTTER_ROTATE_CW,
-					   0.0, 360.0); 
+					   0.0, 360.0);
 
   clutter_behaviour_rotate_set_center (CLUTTER_BEHAVIOUR_ROTATE (r_behave),
-                                       clutter_actor_get_width (label)/2, 
-                                       0, 
+                                       clutter_actor_get_width (label)/2,
+                                       0,
                                        0);
-  
+
   clutter_behaviour_apply (r_behave, label);
   clutter_timeline_start (timeline);
 
@@ -102,7 +102,7 @@ on_button_press (ClutterActor *actor,
 
   stages = g_list_prepend (stages, new_stage);
 
-  g_free (stage_name);
+  free (stage_name);
 
   return TRUE;
 }
@@ -116,7 +116,7 @@ test_multistage_main (int argc, char *argv[])
 
   if (clutter_init (&argc, &argv) != CLUTTER_INIT_SUCCESS)
     return 1;
-  
+
   stage_default = clutter_stage_new ();
   clutter_stage_set_title (CLUTTER_STAGE (stage_default), "Default Stage");
   clutter_actor_set_name (stage_default, "Default Stage");
@@ -128,10 +128,10 @@ test_multistage_main (int argc, char *argv[])
                     NULL);
 
   label = clutter_text_new_with_text ("Mono 16", "Default stage");
-  width = (clutter_actor_get_width (stage_default) 
+  width = (clutter_actor_get_width (stage_default)
            - clutter_actor_get_width (label))
              / 2;
-  height = (clutter_actor_get_height (stage_default) 
+  height = (clutter_actor_get_height (stage_default)
             - clutter_actor_get_height (label))
             / 2;
   clutter_actor_set_position (label, width, height);

--- a/clutter/tests/interactive/test-paint-wrapper.c
+++ b/clutter/tests/interactive/test-paint-wrapper.c
@@ -335,7 +335,7 @@ test_paint_wrapper_main (int argc, char *argv[])
 	clutter_behaviour_apply (oh->scaler_2, oh->hand[i]);
     }
 
-  oh->paint_guards = g_malloc0 (sizeof (gboolean) * n_hands);
+  oh->paint_guards = calloc (1, sizeof (gboolean) * n_hands);
 
   /* Add the group to the stage */
   clutter_container_add_actor (CLUTTER_CONTAINER (stage),

--- a/clutter/tests/interactive/test-paint-wrapper.c
+++ b/clutter/tests/interactive/test-paint-wrapper.c
@@ -260,7 +260,7 @@ test_paint_wrapper_main (int argc, char *argv[])
   oh->scaler_1 = clutter_behaviour_scale_new (alpha, 0.5, 0.5, 1.0, 1.0);
   oh->scaler_2 = clutter_behaviour_scale_new (alpha, 1.0, 1.0, 0.5, 0.5);
 
-  real_hand = clutter_texture_new_from_file (TESTS_DATADIR 
+  real_hand = clutter_texture_new_from_file (TESTS_DATADIR
                                              G_DIR_SEPARATOR_S
                                              "redhand.png",
                                              &error);
@@ -356,9 +356,9 @@ test_paint_wrapper_main (int argc, char *argv[])
   g_object_unref (oh->scaler_1);
   g_object_unref (oh->scaler_2);
   g_object_unref (oh->timeline);
-  g_free (oh->paint_guards);
-  g_free (oh->hand);
-  g_free (oh);
+  free (oh->paint_guards);
+  free (oh->hand);
+  free (oh);
 
   return 0;
 }

--- a/clutter/tests/interactive/test-path-constraint.c
+++ b/clutter/tests/interactive/test-path-constraint.c
@@ -91,7 +91,7 @@ on_node_reached (ClutterPathConstraint *constraint,
 
   str = node_to_string (&node);
   g_print ("Node %d reached: %s\n", index_, str);
-  g_free (str);
+  free (str);
 }
 
 G_MODULE_EXPORT int

--- a/clutter/tests/interactive/test-script.c
+++ b/clutter/tests/interactive/test-script.c
@@ -162,11 +162,11 @@ test_script_main (int argc, char *argv[])
                "***   %s\n", error->message);
       g_error_free (error);
       g_object_unref (script);
-      g_free (file);
+      free (file);
       return EXIT_FAILURE;
     }
 
-  g_free (file);
+  free (file);
 
   merge_id = clutter_script_load_from_data (script, test_unmerge, -1, &error);
   if (error)

--- a/clutter/tests/interactive/test-shader-effects.c
+++ b/clutter/tests/interactive/test-shader-effects.c
@@ -32,7 +32,7 @@ test_shader_effects_main (int argc, char *argv[])
   if (!hand)
     g_error("Unable to load '%s'", file);
 
-  g_free (file);
+  free (file);
 
   clutter_actor_set_position (hand, 326, 265);
   clutter_actor_add_effect_with_name (hand, "desaturate", clutter_desaturate_effect_new (0.75));
@@ -69,7 +69,7 @@ test_shader_effects_main (int argc, char *argv[])
                                        NULL);
 
   clutter_container_add (CLUTTER_CONTAINER (stage), rect, hand, label, NULL);
-  
+
   /* start the timeline and thus the animations */
   clutter_timeline_start (timeline);
 

--- a/clutter/tests/interactive/test-stage-read-pixels.c
+++ b/clutter/tests/interactive/test-stage-read-pixels.c
@@ -31,7 +31,7 @@ make_label (void)
 		    NULL, NULL, &text, NULL, NULL, NULL))
     {
       clutter_text_set_text (CLUTTER_TEXT (label), text);
-      g_free (text);
+      free (text);
     }
 
   return label;
@@ -110,7 +110,7 @@ on_motion_idle (gpointer user_data)
 				     pixels, TRUE,
 				     TEX_SIZE, TEX_SIZE,
 				     TEX_SIZE * 4, 4, 0, NULL);
-  g_free (pixels);
+  free (pixels);
 
   return FALSE;
 }

--- a/clutter/tests/interactive/test-state-animator.c
+++ b/clutter/tests/interactive/test-state-animator.c
@@ -38,7 +38,7 @@ static ClutterActor *new_rect (gint r,
   rectangle = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
 
   clutter_actor_set_size (rectangle, 128, 128);
   clutter_color_free (color);

--- a/clutter/tests/interactive/test-state.c
+++ b/clutter/tests/interactive/test-state.c
@@ -79,7 +79,7 @@ static ClutterActor *new_rect (gint r,
   hand = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
   clutter_actor_set_size (hand, ACTOR_WIDTH,ACTOR_HEIGHT);
 
   clutter_actor_set_background_color (rectangle, color);
@@ -134,7 +134,7 @@ test_state_main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/interactive/test-swipe-action.c
+++ b/clutter/tests/interactive/test-swipe-action.c
@@ -39,7 +39,7 @@ swept_cb (ClutterSwipeAction    *action,
       char *old_str = direction_str;
 
       direction_str = g_strconcat (direction_str, " up", NULL);
-      g_free (old_str);
+      free (old_str);
     }
 
   if (direction & CLUTTER_SWIPE_DIRECTION_DOWN)
@@ -47,7 +47,7 @@ swept_cb (ClutterSwipeAction    *action,
       char *old_str = direction_str;
 
       direction_str = g_strconcat (direction_str, " down", NULL);
-      g_free (old_str);
+      free (old_str);
     }
 
   if (direction & CLUTTER_SWIPE_DIRECTION_LEFT)
@@ -55,7 +55,7 @@ swept_cb (ClutterSwipeAction    *action,
       char *old_str = direction_str;
 
       direction_str = g_strconcat (direction_str, " left", NULL);
-      g_free (old_str);
+      free (old_str);
     }
 
   if (direction & CLUTTER_SWIPE_DIRECTION_RIGHT)
@@ -63,12 +63,12 @@ swept_cb (ClutterSwipeAction    *action,
       char *old_str = direction_str;
 
       direction_str = g_strconcat (direction_str, " right", NULL);
-      g_free (old_str);
+      free (old_str);
     }
 
   g_print ("swept: '%s': %s\n", clutter_actor_get_name (actor), direction_str);
 
-  g_free (direction_str);
+  free (direction_str);
 }
 
 static void

--- a/clutter/tests/interactive/test-table-layout.c
+++ b/clutter/tests/interactive/test-table-layout.c
@@ -46,7 +46,7 @@ toggle_expand (ClutterActor *actor, ClutterEvent *event, ClutterBox *box)
   label = g_strdup_printf ("Expand = %d", x_expand);
   set_text (actor, label);
 
-  g_free (label);
+  free (label);
 }
 
 static const gchar *
@@ -88,7 +88,7 @@ randomise_align (ClutterActor *actor, ClutterEvent *event, ClutterBox *box)
                            get_alignment_name (x_align),
                            get_alignment_name (y_align));
   set_text (actor, label);
-  g_free (label);
+  free (label);
 }
 
 static void
@@ -190,7 +190,7 @@ test_table_layout_main (int argc, char *argv[])
   actor1 = create_text ("label 1", "#f66f");
   file = g_build_filename (TESTS_DATADIR, "redhand.png", NULL);
   actor2 = create_image (file, "#bbcf");
-  g_free (file);
+  free (file);
   actor3 = create_text ("label 3", "#6f6f");
   actor4 = create_text ("Expand = 1", "#66ff");
   actor5 = create_text ("label 5", "#f6ff");

--- a/clutter/tests/interactive/test-texture-async.c
+++ b/clutter/tests/interactive/test-texture-async.c
@@ -135,7 +135,7 @@ test_texture_async_main (int argc, char *argv[])
   path = (argc > 1)
        ? g_strdup (argv[1])
        : g_build_filename (TESTS_DATADIR, "redhand.png", NULL);
- 
+
   clutter_threads_add_timeout_full (G_PRIORITY_DEFAULT, 500,
                                     task, path,
                                     cleanup_task);
@@ -144,7 +144,7 @@ test_texture_async_main (int argc, char *argv[])
   clutter_main ();
   clutter_threads_leave ();
 
-  g_free (path);
+  free (path);
 
   return EXIT_SUCCESS;
 }

--- a/clutter/tests/interactive/test-texture-quality.c
+++ b/clutter/tests/interactive/test-texture-quality.c
@@ -79,10 +79,10 @@ test_texture_quality_main (int argc, char *argv[])
   if (error)
     g_error ("Unable to load image: %s", error->message);
 
-  g_free (file);
+  free (file);
 
   /* center the image */
-  clutter_actor_set_position (image, 
+  clutter_actor_set_position (image,
     (clutter_actor_get_width (stage) - clutter_actor_get_width (image))/2,
     (clutter_actor_get_height (stage) - clutter_actor_get_height (image))/2);
   clutter_container_add (CLUTTER_CONTAINER (stage), image, NULL);

--- a/clutter/tests/interactive/test-texture-slicing.c
+++ b/clutter/tests/interactive/test-texture-slicing.c
@@ -27,16 +27,16 @@ make_rgba_data (int width, int height, int bpp, int has_alpha, int *rowstride_p)
       for (x = 0; x < width; x++)
 	{
 	  guchar *p;
-	  
+
 	  p = pixels + y * rowstride + x * bpp;
-	  
+
 	  p[0] = p[1] = p[2] = 0; p[3] = 0xff;
-	  
+
 	  if (x && y && y % CHECK_SIZE && x % CHECK_SIZE)
 	    {
 	      if (x % CHECK_SIZE == 1)
 		{
-		  if (++i > 3) 
+		  if (++i > 3)
 		    i = 0;
 		}
 	      p[i] = 0xff;
@@ -98,17 +98,17 @@ test_textures_main (int argc, char *argv[])
                                                 bpp,
                                                 0, NULL))
           g_error("texture creation failed");
-        g_free(pixels);
-	
+        free(pixels);
+
 	printf("uploaded to texture...\n");
-	
+
 	clutter_container_add (CLUTTER_CONTAINER (stage), texture, NULL);
 	clutter_actor_set_size (texture, 400, 400);
 	clutter_actor_show (texture);
 
 	/* Hide & show to unreaise then realise the texture */
 	clutter_actor_hide (texture);
-	clutter_actor_show (texture);	
+	clutter_actor_show (texture);
 
 	SPIN();
 

--- a/clutter/tests/micro-bench/test-text-perf.c
+++ b/clutter/tests/micro-bench/test-text-perf.c
@@ -95,7 +95,7 @@ create_label (void)
   label = clutter_text_new_with_text (font_name, str->str);
   clutter_text_set_color (CLUTTER_TEXT (label), &label_color);
 
-  g_free (font_name);
+  free (font_name);
   g_string_free (str, TRUE);
 
   return label;

--- a/clutter/tests/performance/test-state-hidden.c
+++ b/clutter/tests/performance/test-state-hidden.c
@@ -42,7 +42,7 @@ static ClutterActor *new_rect (gint r,
 
   gchar *file = g_build_filename (TESTS_DATA_DIR, "redhand.png", NULL);
 
-  g_free (file);
+  free (file);
   clutter_actor_set_size (rectangle, ACTOR_WIDTH,ACTOR_HEIGHT);
   clutter_color_free (color);
   clutter_container_add (CLUTTER_CONTAINER (group), rectangle, NULL);
@@ -87,7 +87,7 @@ main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/performance/test-state-interactive.c
+++ b/clutter/tests/performance/test-state-interactive.c
@@ -80,7 +80,7 @@ static ClutterActor *new_rect (gint r,
   hand = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
   clutter_actor_set_size (hand, ACTOR_WIDTH,ACTOR_HEIGHT);
 
   clutter_actor_set_size (rectangle, ACTOR_WIDTH,ACTOR_HEIGHT);
@@ -128,7 +128,7 @@ main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/performance/test-state-mini.c
+++ b/clutter/tests/performance/test-state-mini.c
@@ -47,7 +47,7 @@ static ClutterActor *new_rect (gint r,
   hand = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
   clutter_actor_set_size (hand, ACTOR_WIDTH,ACTOR_HEIGHT);
 
   clutter_actor_set_size (rectangle, ACTOR_WIDTH,ACTOR_HEIGHT);
@@ -92,7 +92,7 @@ main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/performance/test-state-pick.c
+++ b/clutter/tests/performance/test-state-pick.c
@@ -52,7 +52,7 @@ static ClutterActor *new_rect (gint r,
   hand = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
   clutter_actor_set_size (hand, ACTOR_WIDTH,ACTOR_HEIGHT);
 
   clutter_actor_set_size (rectangle, ACTOR_WIDTH,ACTOR_HEIGHT);
@@ -97,7 +97,7 @@ main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/performance/test-state.c
+++ b/clutter/tests/performance/test-state.c
@@ -52,7 +52,7 @@ static ClutterActor *new_rect (gint r,
   hand = clutter_texture_new_from_file (file, &error);
   if (rectangle == NULL)
     g_error ("image load failed: %s", error->message);
-  g_free (file);
+  free (file);
   clutter_actor_set_size (hand, ACTOR_WIDTH,ACTOR_HEIGHT);
 
   clutter_actor_set_size (rectangle, ACTOR_WIDTH,ACTOR_HEIGHT);
@@ -97,7 +97,7 @@ main (gint    argc,
 
       clutter_state_set (layout_state, NULL, "active",
             actor, "delayed::x", CLUTTER_LINEAR,
-                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS), 
+                                         ACTOR_WIDTH * 1.0 * ((TOTAL-1-i) % COLS),
                                         ((row*1.0/ROWS))/2, (1.0-(row*1.0/ROWS))/2,
             actor, "delayed::y", CLUTTER_LINEAR,
                                          ACTOR_HEIGHT * 1.0 * ((TOTAL-1-i) / COLS),

--- a/clutter/tests/performance/test-text-perf.c
+++ b/clutter/tests/performance/test-text-perf.c
@@ -71,7 +71,7 @@ create_label (void)
   label = clutter_text_new_with_text (font_name, str->str);
   clutter_text_set_color (CLUTTER_TEXT (label), &label_color);
 
-  g_free (font_name);
+  free (font_name);
   g_string_free (str, TRUE);
 
   return label;

--- a/cogl/cogl-pango/cogl-pango-display-list.c
+++ b/cogl/cogl-pango/cogl-pango-display-list.c
@@ -333,7 +333,7 @@ emit_vertex_buffer_geometry (CoglFramebuffer *fb,
                                 0, /* offset */
                                 verts,
                                 sizeof (CoglVertexP2T2) * n_verts);
-          g_free (verts);
+          free (verts);
         }
       else
         cogl_buffer_unmap (COGL_BUFFER (buffer));

--- a/cogl/cogl-pango/cogl-pango-fontmap.c
+++ b/cogl/cogl-pango/cogl-pango-fontmap.c
@@ -69,7 +69,7 @@ free_priv (gpointer data)
   cogl_object_unref (priv->ctx);
   cogl_object_unref (priv->renderer);
 
-  g_free (priv);
+  free (priv);
 }
 
 PangoFontMap *

--- a/cogl/cogl-pango/cogl-pango-glyph-cache.c
+++ b/cogl/cogl-pango/cogl-pango-glyph-cache.c
@@ -123,7 +123,7 @@ cogl_pango_glyph_cache_new (CoglContext *ctx,
 {
   CoglPangoGlyphCache *cache;
 
-  cache = g_malloc (sizeof (CoglPangoGlyphCache));
+  cache = malloc (sizeof (CoglPangoGlyphCache));
 
   /* Note: as a rule we don't take references to a CoglContext
    * internally since */

--- a/cogl/cogl-pango/cogl-pango-glyph-cache.c
+++ b/cogl/cogl-pango/cogl-pango-glyph-cache.c
@@ -182,7 +182,7 @@ cogl_pango_glyph_cache_free (CoglPangoGlyphCache *cache)
 
   g_hook_list_clear (&cache->reorganize_callbacks);
 
-  g_free (cache);
+  free (cache);
 }
 
 static void

--- a/cogl/cogl-pango/cogl-pango-pipeline-cache.c
+++ b/cogl/cogl-pango/cogl-pango-pipeline-cache.c
@@ -238,5 +238,5 @@ _cogl_pango_pipeline_cache_free (CoglPangoPipelineCache *cache)
 
   cogl_object_unref (cache->ctx);
 
-  g_free (cache);
+  free (cache);
 }

--- a/cogl/cogl-path/cogl-path.c
+++ b/cogl/cogl-path/cogl-path.c
@@ -95,7 +95,7 @@ _cogl_path_data_clear_vbos (CoglPathData *data)
       for (i = 0; i < data->stroke_n_attributes; i++)
         cogl_object_unref (data->stroke_attributes[i]);
 
-      g_free (data->stroke_attributes);
+      free (data->stroke_attributes);
 
       data->stroke_attribute_buffer = NULL;
     }

--- a/cogl/cogl-path/tesselator/memalloc.h
+++ b/cogl/cogl-path/tesselator/memalloc.h
@@ -37,7 +37,7 @@
 #include <glib.h>
 
 #define memRealloc g_realloc
-#define memAlloc   g_malloc
+#define memAlloc   malloc
 #define memFree    free
 #define memInit(x) 1
 

--- a/cogl/cogl-path/tesselator/memalloc.h
+++ b/cogl/cogl-path/tesselator/memalloc.h
@@ -38,7 +38,7 @@
 
 #define memRealloc g_realloc
 #define memAlloc   g_malloc
-#define memFree    g_free
+#define memFree    free
 #define memInit(x) 1
 
 /* tess.c defines TRUE and FALSE itself unconditionally so we need to

--- a/cogl/cogl/cogl-atlas-texture.c
+++ b/cogl/cogl/cogl-atlas-texture.c
@@ -184,7 +184,7 @@ _cogl_atlas_texture_post_reorganize_cb (void *user_data)
             cogl_object_unref (data.textures[i]);
         }
 
-      g_free (data.textures);
+      free (data.textures);
     }
 
   /* Notify any listeners that an atlas has changed */

--- a/cogl/cogl/cogl-atlas.c
+++ b/cogl/cogl/cogl-atlas.c
@@ -409,12 +409,12 @@ _cogl_atlas_reserve_space (CoglAtlas             *atlas,
   /* Get an array of all the textures currently in the atlas. */
   data.n_textures = 0;
   if (atlas->map == NULL)
-    data.textures = g_malloc (sizeof (CoglAtlasRepositionData));
+    data.textures = malloc (sizeof (CoglAtlasRepositionData));
   else
     {
       unsigned int n_rectangles =
         _cogl_rectangle_map_get_n_rectangles (atlas->map);
-      data.textures = g_malloc (sizeof (CoglAtlasRepositionData) *
+      data.textures = malloc (sizeof (CoglAtlasRepositionData) *
                                 (n_rectangles + 1));
       _cogl_rectangle_map_foreach (atlas->map,
                                    _cogl_atlas_get_rectangles_cb,

--- a/cogl/cogl/cogl-atlas.c
+++ b/cogl/cogl/cogl-atlas.c
@@ -83,7 +83,7 @@ _cogl_atlas_free (CoglAtlas *atlas)
   g_hook_list_clear (&atlas->pre_reorganize_callbacks);
   g_hook_list_clear (&atlas->post_reorganize_callbacks);
 
-  g_free (atlas);
+  free (atlas);
 }
 
 typedef struct _CoglAtlasRepositionData
@@ -318,7 +318,7 @@ _cogl_atlas_create_texture (CoglAtlas *atlas,
 
       cogl_object_unref (clear_bmp);
 
-      g_free (clear_data);
+      free (clear_data);
     }
   else
     {
@@ -528,7 +528,7 @@ _cogl_atlas_reserve_space (CoglAtlas             *atlas,
       ret = TRUE;
     }
 
-  g_free (data.textures);
+  free (data.textures);
 
   _cogl_atlas_notify_post_reorganize (atlas);
 

--- a/cogl/cogl/cogl-atlas.c
+++ b/cogl/cogl/cogl-atlas.c
@@ -296,7 +296,7 @@ _cogl_atlas_create_texture (CoglAtlas *atlas,
       int bpp = _cogl_pixel_format_get_bytes_per_pixel (atlas->texture_format);
 
       /* Create a buffer of zeroes to initially clear the texture */
-      clear_data = g_malloc0 (width * height * bpp);
+      clear_data = calloc (1, width * height * bpp);
       clear_bmp = cogl_bitmap_new_for_data (ctx,
                                             width,
                                             height,

--- a/cogl/cogl/cogl-attribute.c
+++ b/cogl/cogl/cogl-attribute.c
@@ -164,7 +164,7 @@ _cogl_attribute_register_attribute_name (CoglContext *context,
   return name_state;
 
 error:
-  g_free (name_state);
+  free (name_state);
   return NULL;
 }
 

--- a/cogl/cogl/cogl-bitmap-conversion.c
+++ b/cogl/cogl/cogl-bitmap-conversion.c
@@ -481,7 +481,7 @@ _cogl_bitmap_convert_into_bitmap (CoglBitmap *src_bmp,
   _cogl_bitmap_unmap (src_bmp);
   _cogl_bitmap_unmap (dst_bmp);
 
-  g_free (tmp_row);
+  free (tmp_row);
 
   return TRUE;
 }
@@ -674,7 +674,7 @@ _cogl_bitmap_unpremult (CoglBitmap *bmp,
         }
     }
 
-  g_free (tmp_row);
+  free (tmp_row);
 
   _cogl_bitmap_unmap (bmp);
 
@@ -738,7 +738,7 @@ _cogl_bitmap_premult (CoglBitmap *bmp,
         }
     }
 
-  g_free (tmp_row);
+  free (tmp_row);
 
   _cogl_bitmap_unmap (bmp);
 

--- a/cogl/cogl/cogl-bitmap-conversion.c
+++ b/cogl/cogl/cogl-bitmap-conversion.c
@@ -439,7 +439,7 @@ _cogl_bitmap_convert_into_bitmap (CoglBitmap *src_bmp,
   use_16 = _cogl_bitmap_needs_short_temp_buffer (dst_format);
 
   /* Allocate a buffer to hold a temporary RGBA row */
-  tmp_row = g_malloc (width *
+  tmp_row = malloc (width *
                       (use_16 ? sizeof (uint16_t) : sizeof (uint8_t)) * 4);
 
   /* FIXME: Optimize */
@@ -644,7 +644,7 @@ _cogl_bitmap_unpremult (CoglBitmap *bmp,
   if (_cogl_bitmap_can_fast_premult (format))
     tmp_row = NULL;
   else
-    tmp_row = g_malloc (sizeof (uint16_t) * 4 * width);
+    tmp_row = malloc (sizeof (uint16_t) * 4 * width);
 
   for (y = 0; y < height; y++)
     {
@@ -711,7 +711,7 @@ _cogl_bitmap_premult (CoglBitmap *bmp,
   if (_cogl_bitmap_can_fast_premult (format))
     tmp_row = NULL;
   else
-    tmp_row = g_malloc (sizeof (uint16_t) * 4 * width);
+    tmp_row = malloc (sizeof (uint16_t) * 4 * width);
 
   for (y = 0; y < height; y++)
     {

--- a/cogl/cogl/cogl-bitmap-private.h
+++ b/cogl/cogl/cogl-bitmap-private.h
@@ -73,7 +73,7 @@ struct _CoglBitmap
  * @error: A #CoglError for catching exceptional errors or %NULL
  *
  * This is equivalent to cogl_bitmap_new_with_size() except that it
- * allocated the buffer using g_malloc() instead of creating a
+ * allocated the buffer using malloc() instead of creating a
  * #CoglPixelBuffer. The buffer will be automatically destroyed when
  * the bitmap is freed.
  *

--- a/cogl/cogl/cogl-bitmap.c
+++ b/cogl/cogl/cogl-bitmap.c
@@ -236,7 +236,7 @@ _cogl_bitmap_new_with_malloc_buffer (CoglContext *context,
   cogl_object_set_user_data (COGL_OBJECT (bitmap),
                              &bitmap_free_key,
                              data,
-                             g_free);
+                             free);
 
   return bitmap;
 }

--- a/cogl/cogl/cogl-bitmask.h
+++ b/cogl/cogl/cogl-bitmask.h
@@ -48,7 +48,7 @@ COGL_BEGIN_DECLS
  * Internally a CoglBitmask is a pointer. If the least significant bit
  * of the pointer is 1 then the rest of the bits are directly used as
  * part of the bitmask, otherwise it is a pointer to a GArray of
- * unsigned ints. This relies on the fact the g_malloc will return a
+ * unsigned ints. This relies on the fact the malloc will return a
  * pointer aligned to at least two bytes (so that the least
  * significant bit of the address is always 0). It also assumes that
  * the size of a pointer is always greater than or equal to the size

--- a/cogl/cogl/cogl-blit.c
+++ b/cogl/cogl/cogl-blit.c
@@ -277,7 +277,7 @@ _cogl_blit_get_tex_data_begin (CoglBlitData *data)
   data->format = _cogl_texture_get_format (data->src_tex);
   data->bpp = _cogl_pixel_format_get_bytes_per_pixel (data->format);
 
-  data->image_data = g_malloc (data->bpp * data->src_width *
+  data->image_data = malloc (data->bpp * data->src_width *
                                data->src_height);
   cogl_texture_get_data (data->src_tex, data->format,
                          data->src_width * data->bpp, data->image_data);

--- a/cogl/cogl/cogl-blit.c
+++ b/cogl/cogl/cogl-blit.c
@@ -312,7 +312,7 @@ _cogl_blit_get_tex_data_blit (CoglBlitData *data,
 static void
 _cogl_blit_get_tex_data_end (CoglBlitData *data)
 {
-  g_free (data->image_data);
+  free (data->image_data);
 }
 
 /* These should be specified in order of preference */

--- a/cogl/cogl/cogl-blit.h
+++ b/cogl/cogl/cogl-blit.h
@@ -69,7 +69,7 @@ struct _CoglBlitData
 
   const CoglBlitMode *blit_mode;
 
-  /* If we're not using an FBO then we g_malloc a buffer and copy the
+  /* If we're not using an FBO then we malloc a buffer and copy the
      complete texture data in */
   unsigned char *image_data;
   CoglPixelFormat format;

--- a/cogl/cogl/cogl-boxed-value.c
+++ b/cogl/cogl/cogl-boxed-value.c
@@ -141,7 +141,7 @@ _cogl_boxed_value_set_x (CoglBoxedValue *bv,
   if (count == 1)
     {
       if (bv->count > 1)
-        g_free (bv->v.array);
+        free (bv->v.array);
 
       if (transpose)
         _cogl_boxed_value_tranpose (bv->v.float_value,
@@ -158,7 +158,7 @@ _cogl_boxed_value_set_x (CoglBoxedValue *bv,
               bv->size != size ||
               bv->type != type)
             {
-              g_free (bv->v.array);
+              free (bv->v.array);
               bv->v.array = g_malloc (count * value_size);
             }
         }
@@ -280,7 +280,7 @@ void
 _cogl_boxed_value_destroy (CoglBoxedValue *bv)
 {
   if (bv->count > 1)
-    g_free (bv->v.array);
+    free (bv->v.array);
 }
 
 void

--- a/cogl/cogl/cogl-boxed-value.c
+++ b/cogl/cogl/cogl-boxed-value.c
@@ -159,11 +159,11 @@ _cogl_boxed_value_set_x (CoglBoxedValue *bv,
               bv->type != type)
             {
               free (bv->v.array);
-              bv->v.array = g_malloc (count * value_size);
+              bv->v.array = malloc (count * value_size);
             }
         }
       else
-        bv->v.array = g_malloc (count * value_size);
+        bv->v.array = malloc (count * value_size);
 
       if (transpose)
         {

--- a/cogl/cogl/cogl-buffer.c
+++ b/cogl/cogl/cogl-buffer.c
@@ -152,7 +152,7 @@ _cogl_buffer_initialize (CoglBuffer *buffer,
       buffer->vtable.unmap = malloc_unmap;
       buffer->vtable.set_data = malloc_set_data;
 
-      buffer->data = g_malloc (size);
+      buffer->data = malloc (size);
     }
   else
     {

--- a/cogl/cogl/cogl-buffer.c
+++ b/cogl/cogl/cogl-buffer.c
@@ -175,7 +175,7 @@ _cogl_buffer_fini (CoglBuffer *buffer)
   if (buffer->flags & COGL_BUFFER_FLAG_BUFFER_OBJECT)
     buffer->context->driver_vtable->buffer_destroy (buffer);
   else
-    g_free (buffer->data);
+    free (buffer->data);
 }
 
 unsigned int

--- a/cogl/cogl/cogl-config.c
+++ b/cogl/cogl/cogl-config.c
@@ -69,7 +69,7 @@ _cogl_config_process (GKeyFile *key_file)
       _cogl_parse_debug_string (value,
                                 TRUE /* enable the flags */,
                                 TRUE /* ignore help option */);
-      g_free (value);
+      free (value);
     }
 
   value = g_key_file_get_string (key_file, "global", "COGL_NO_DEBUG", NULL);
@@ -78,7 +78,7 @@ _cogl_config_process (GKeyFile *key_file)
       _cogl_parse_debug_string (value,
                                 FALSE /* disable the flags */,
                                 TRUE /* ignore help option */);
-      g_free (value);
+      free (value);
     }
 
   for (i = 0; i < G_N_ELEMENTS (cogl_config_string_options); i++)
@@ -89,7 +89,7 @@ _cogl_config_process (GKeyFile *key_file)
       value = g_key_file_get_string (key_file, "global", conf_name, NULL);
       if (value)
         {
-          g_free (*variable);
+          free (*variable);
           *variable = value;
         }
     }
@@ -111,7 +111,7 @@ _cogl_config_read (void)
                                           filename,
                                           0,
                                           NULL);
-      g_free (filename);
+      free (filename);
       if (status)
         {
           _cogl_config_process (key_file);
@@ -126,7 +126,7 @@ _cogl_config_read (void)
                                       filename,
                                       0,
                                       NULL);
-  g_free (filename);
+  free (filename);
 
   if (status)
     _cogl_config_process (key_file);

--- a/cogl/cogl/cogl-context.c
+++ b/cogl/cogl/cogl-context.c
@@ -189,7 +189,7 @@ cogl_context_new (CoglDisplay *display,
 #endif
 
   /* Allocate context memory */
-  context = g_malloc0 (sizeof (CoglContext));
+  context = calloc (1, sizeof (CoglContext));
 
   /* Convert the context into an object immediately in case any of the
      code below wants to verify that the context pointer is a valid

--- a/cogl/cogl/cogl-context.c
+++ b/cogl/cogl/cogl-context.c
@@ -219,7 +219,7 @@ cogl_context_new (CoglDisplay *display,
       CoglRenderer *renderer = cogl_renderer_new ();
       if (!cogl_renderer_connect (renderer, error))
         {
-          g_free (context);
+          free (context);
           return NULL;
         }
 
@@ -232,7 +232,7 @@ cogl_context_new (CoglDisplay *display,
   if (!cogl_display_setup (display, error))
     {
       cogl_object_unref (display);
-      g_free (context);
+      free (context);
       return NULL;
     }
 
@@ -255,12 +255,12 @@ cogl_context_new (CoglDisplay *display,
   if (!winsys->context_init (context, error))
     {
       cogl_object_unref (display);
-      g_free (context);
+      free (context);
       return NULL;
     }
 
   context->attribute_name_states_hash =
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+    g_hash_table_new_full (g_str_hash, g_str_equal, free, free);
   context->attribute_name_index_map = NULL;
   context->n_attribute_names = 0;
 
@@ -270,7 +270,7 @@ cogl_context_new (CoglDisplay *display,
 
 
   context->uniform_names =
-    g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
+    g_ptr_array_new_with_free_func ((GDestroyNotify) free);
   context->uniform_name_hash = g_hash_table_new (g_str_hash, g_str_equal);
   context->n_uniform_names = 0;
 
@@ -625,7 +625,7 @@ _cogl_context_free (CoglContext *context)
 
   cogl_object_unref (context->display);
 
-  g_free (context);
+  free (context);
 }
 
 CoglContext *
@@ -763,7 +763,7 @@ _cogl_context_get_gl_extensions (CoglContext *context)
           continue;
 
         disabled:
-          g_free (*src);
+          free (*src);
           continue;
         }
 

--- a/cogl/cogl/cogl-context.c
+++ b/cogl/cogl/cogl-context.c
@@ -701,7 +701,7 @@ _cogl_context_get_gl_extensions (CoglContext *context)
 
       context->glGetIntegerv (GL_NUM_EXTENSIONS, &num_extensions);
 
-      ret = g_malloc (sizeof (char *) * (num_extensions + 1));
+      ret = malloc (sizeof (char *) * (num_extensions + 1));
 
       for (i = 0; i < num_extensions; i++)
         {

--- a/cogl/cogl/cogl-debug.h
+++ b/cogl/cogl/cogl-debug.h
@@ -104,7 +104,7 @@ extern unsigned long _cogl_debug_flags[COGL_DEBUG_N_LONGS];
         if (G_UNLIKELY (COGL_DEBUG_ENABLED (COGL_DEBUG_##type))) {            \
           char *_fmt = g_strdup_printf (__VA_ARGS__);                         \
           _cogl_profile_trace_message ("[" #type "] " G_STRLOC " & %s", _fmt);\
-          g_free (_fmt);                                                      \
+          free (_fmt);                                                      \
         }                                           } G_STMT_END
 
 #endif /* __GNUC__ */

--- a/cogl/cogl/cogl-feature-private.c
+++ b/cogl/cogl/cogl-feature-private.c
@@ -160,7 +160,7 @@ _cogl_feature_check (CoglRenderer *renderer,
       func = _cogl_renderer_get_proc_address (renderer,
                                               full_function_name,
                                               in_core);
-      g_free (full_function_name);
+      free (full_function_name);
 
       if (func == NULL)
         goto error;

--- a/cogl/cogl/cogl-framebuffer.c
+++ b/cogl/cogl/cogl-framebuffer.c
@@ -2013,7 +2013,7 @@ get_wire_line_indices (CoglContext *ctx,
   n_lines = get_line_count (mode, n_vertices_in);
 
   /* Note: we are using COGL_INDICES_TYPE_UNSIGNED_INT so 4 bytes per index. */
-  line_indices = g_malloc (4 * n_lines * 2);
+  line_indices = malloc (4 * n_lines * 2);
 
   pos = 0;
 

--- a/cogl/cogl/cogl-framebuffer.c
+++ b/cogl/cogl/cogl-framebuffer.c
@@ -728,7 +728,7 @@ _cogl_offscreen_free (CoglOffscreen *offscreen)
   if (offscreen->depth_texture != NULL)
     cogl_object_unref (offscreen->depth_texture);
 
-  g_free (offscreen);
+  free (offscreen);
 }
 
 CoglBool
@@ -2082,7 +2082,7 @@ get_wire_line_indices (CoglContext *ctx,
                           line_indices,
                           *n_indices);
 
-  g_free (line_indices);
+  free (line_indices);
 
   return ret;
 }

--- a/cogl/cogl/cogl-gles2-context.c
+++ b/cogl/cogl/cogl-gles2-context.c
@@ -878,7 +878,7 @@ gl_shader_source_wrapper (GLuint shader,
       /* Note: we don't need to free the last entry in string_copy[]
        * because it is our static wrapper string... */
       for (i = 0; i < count; i++)
-        g_free (string_copy[i]);
+        free (string_copy[i]);
     }
   else
     gles2_ctx->context->glShaderSource (shader, count, string, length);
@@ -1539,9 +1539,9 @@ _cogl_gles2_context_free (CoglGLES2Context *gles2_context)
                                  NULL);
     }
 
-  g_free (gles2_context->vtable);
+  free (gles2_context->vtable);
 
-  g_free (gles2_context);
+  free (gles2_context);
 }
 
 static void
@@ -1591,7 +1591,7 @@ cogl_gles2_context_new (CoglContext *ctx, CoglError **error)
   gles2_ctx->winsys = winsys->context_create_gles2_context (ctx, error);
   if (gles2_ctx->winsys == NULL)
     {
-      g_free (gles2_ctx);
+      free (gles2_ctx);
       return NULL;
     }
 

--- a/cogl/cogl/cogl-gles2-context.c
+++ b/cogl/cogl/cogl-gles2-context.c
@@ -1581,7 +1581,7 @@ cogl_gles2_context_new (CoglContext *ctx, CoglError **error)
       return NULL;
     }
 
-  gles2_ctx = g_malloc0 (sizeof (CoglGLES2Context));
+  gles2_ctx = calloc (1, sizeof (CoglGLES2Context));
 
   gles2_ctx->context = ctx;
 
@@ -1602,7 +1602,7 @@ cogl_gles2_context_new (CoglContext *ctx, CoglError **error)
   gles2_ctx->front_face = GL_CCW;
   gles2_ctx->pack_alignment = 4;
 
-  gles2_ctx->vtable = g_malloc0 (sizeof (CoglGLES2Vtable));
+  gles2_ctx->vtable = calloc (1, sizeof (CoglGLES2Vtable));
 #define COGL_EXT_BEGIN(name, \
                        min_gl_major, min_gl_minor, \
                        gles_availability, \

--- a/cogl/cogl/cogl-glsl-shader.c
+++ b/cogl/cogl/cogl-glsl-shader.c
@@ -196,5 +196,5 @@ _cogl_glsl_shader_set_source_with_boilerplate (CoglContext *ctx,
   GE( ctx, glShaderSource (shader_gl_handle, count,
                            (const char **) strings, lengths) );
 
-  g_free (version_string);
+  free (version_string);
 }

--- a/cogl/cogl/cogl-indices.c
+++ b/cogl/cogl/cogl-indices.c
@@ -197,7 +197,7 @@ cogl_get_rectangle_indices (CoglContext *ctx, int n_rectangles)
       /* Generate the byte array if we haven't already */
       if (ctx->rectangle_byte_indices == NULL)
         {
-          uint8_t *byte_array = g_malloc (256 / 4 * 6 * sizeof (uint8_t));
+          uint8_t *byte_array = malloc (256 / 4 * 6 * sizeof (uint8_t));
           uint8_t *p = byte_array;
           int i, vert_num = 0;
 
@@ -240,7 +240,7 @@ cogl_get_rectangle_indices (CoglContext *ctx, int n_rectangles)
             ctx->rectangle_short_indices_len *= 2;
 
           /* Over-allocate to generate a whole number of quads */
-          p = short_array = g_malloc ((ctx->rectangle_short_indices_len
+          p = short_array = malloc ((ctx->rectangle_short_indices_len
                                        + 5) / 6 * 6
                                       * sizeof (uint16_t));
 

--- a/cogl/cogl/cogl-indices.c
+++ b/cogl/cogl/cogl-indices.c
@@ -218,7 +218,7 @@ cogl_get_rectangle_indices (CoglContext *ctx, int n_rectangles)
                                 byte_array,
                                 256 / 4 * 6);
 
-          g_free (byte_array);
+          free (byte_array);
         }
 
       return ctx->rectangle_byte_indices;
@@ -262,7 +262,7 @@ cogl_get_rectangle_indices (CoglContext *ctx, int n_rectangles)
                                 short_array,
                                 ctx->rectangle_short_indices_len);
 
-          g_free (short_array);
+          free (short_array);
         }
 
       return ctx->rectangle_short_indices;

--- a/cogl/cogl/cogl-journal.c
+++ b/cogl/cogl/cogl-journal.c
@@ -520,7 +520,7 @@ create_attribute_cb (CoglPipeline *pipeline,
                         COGL_ATTRIBUTE_TYPE_FLOAT);
 
   if (layer_number >= 8)
-    g_free (name);
+    free (name);
 
   state->current++;
 

--- a/cogl/cogl/cogl-magazine.c
+++ b/cogl/cogl/cogl-magazine.c
@@ -80,5 +80,5 @@ void
 _cogl_magazine_free (CoglMagazine *magazine)
 {
   _cogl_memory_stack_free (magazine->stack);
-  g_free (magazine);
+  free (magazine);
 }

--- a/cogl/cogl/cogl-memory-stack.c
+++ b/cogl/cogl/cogl-memory-stack.c
@@ -176,7 +176,7 @@ _cogl_memory_stack_rewind (CoglMemoryStack *stack)
 static void
 _cogl_memory_sub_stack_free (CoglMemorySubStack *sub_stack)
 {
-  g_free (sub_stack->data);
+  free (sub_stack->data);
   g_slice_free (CoglMemorySubStack, sub_stack);
 }
 

--- a/cogl/cogl/cogl-memory-stack.c
+++ b/cogl/cogl/cogl-memory-stack.c
@@ -85,7 +85,7 @@ _cogl_memory_sub_stack_alloc (size_t bytes)
 {
   CoglMemorySubStack *sub_stack = g_slice_new (CoglMemorySubStack);
   sub_stack->bytes = bytes;
-  sub_stack->data = g_malloc (bytes);
+  sub_stack->data = malloc (bytes);
   return sub_stack;
 }
 

--- a/cogl/cogl/cogl-object.h
+++ b/cogl/cogl/cogl-object.h
@@ -93,7 +93,7 @@ cogl_object_unref (void *object);
  * static void
  * destroy_path_private_cb (void *data)
  * {
- *   g_free (data);
+ *   free (data);
  * }
  *
  * static void

--- a/cogl/cogl/cogl-onscreen.c
+++ b/cogl/cogl/cogl-onscreen.c
@@ -172,7 +172,7 @@ _cogl_onscreen_free (CoglOnscreen *onscreen)
   /* Chain up to parent */
   _cogl_framebuffer_free (framebuffer);
 
-  g_free (onscreen);
+  free (onscreen);
 }
 
 static void

--- a/cogl/cogl/cogl-output.c
+++ b/cogl/cogl/cogl-output.c
@@ -56,7 +56,7 @@ _cogl_output_new (const char *name)
 static void
 _cogl_output_free (CoglOutput *output)
 {
-  g_free (output->name);
+  free (output->name);
 
   g_slice_free (CoglOutput, output);
 }

--- a/cogl/cogl/cogl-pipeline-cache.c
+++ b/cogl/cogl/cogl-pipeline-cache.c
@@ -91,7 +91,7 @@ _cogl_pipeline_cache_free (CoglPipelineCache *cache)
   _cogl_pipeline_hash_table_destroy (&cache->fragment_hash);
   _cogl_pipeline_hash_table_destroy (&cache->vertex_hash);
   _cogl_pipeline_hash_table_destroy (&cache->combined_hash);
-  g_free (cache);
+  free (cache);
 }
 
 CoglPipelineCacheEntry *
@@ -136,7 +136,7 @@ create_pipelines (CoglPipeline **pipelines,
                           NULL, /* declarations */
                           source);
 
-      g_free (source);
+      free (source);
 
       pipelines[i] = cogl_pipeline_new (test_ctx);
       cogl_pipeline_add_snippet (pipelines[i], snippet);

--- a/cogl/cogl/cogl-pipeline-state.c
+++ b/cogl/cogl/cogl-pipeline-state.c
@@ -1571,7 +1571,7 @@ _cogl_pipeline_override_uniform (CoglPipeline *pipeline,
               old_values + override_index,
               sizeof (CoglBoxedValue) * (old_size - override_index));
 
-      g_free (old_values);
+      free (old_values);
     }
 
   _cogl_boxed_value_init (uniforms_state->override_values + override_index);

--- a/cogl/cogl/cogl-pipeline.c
+++ b/cogl/cogl/cogl-pipeline.c
@@ -1088,7 +1088,7 @@ _cogl_pipeline_copy_differences (CoglPipeline *dest,
       int i;
 
       big_state->uniforms_state.override_values =
-        g_malloc (n_overrides * sizeof (CoglBoxedValue));
+        malloc (n_overrides * sizeof (CoglBoxedValue));
 
       for (i = 0; i < n_overrides; i++)
         {

--- a/cogl/cogl/cogl-pipeline.c
+++ b/cogl/cogl/cogl-pipeline.c
@@ -486,7 +486,7 @@ _cogl_pipeline_free (CoglPipeline *pipeline)
 
       for (i = 0; i < n_overrides; i++)
         _cogl_boxed_value_destroy (uniforms_state->override_values + i);
-      g_free (uniforms_state->override_values);
+      free (uniforms_state->override_values);
 
       _cogl_bitmask_destroy (&uniforms_state->override_mask);
       _cogl_bitmask_destroy (&uniforms_state->changed_mask);

--- a/cogl/cogl/cogl-primitives.c
+++ b/cogl/cogl/cogl-primitives.c
@@ -1066,7 +1066,7 @@ cogl_polygon (const CoglTextureVertex *vertices,
                                               2,
                                               COGL_ATTRIBUTE_TYPE_FLOAT);
 
-      g_free (allocated_name);
+      free (allocated_name);
     }
 
   if (use_color)

--- a/cogl/cogl/cogl-rectangle-map.c
+++ b/cogl/cogl/cogl-rectangle-map.c
@@ -703,7 +703,7 @@ _cogl_rectangle_map_free (CoglRectangleMap *map)
 
   g_array_free (map->stack, TRUE);
 
-  g_free (map);
+  free (map);
 }
 
 #if defined (COGL_ENABLE_DEBUG) && defined (HAVE_CAIRO)

--- a/cogl/cogl/cogl-renderer.c
+++ b/cogl/cogl/cogl-renderer.c
@@ -216,7 +216,7 @@ _cogl_renderer_free (CoglRenderer *renderer)
 
   g_array_free (renderer->poll_fds, TRUE);
 
-  g_free (renderer);
+  free (renderer);
 }
 
 CoglRenderer *

--- a/cogl/cogl/cogl-sampler-cache.c
+++ b/cogl/cogl/cogl-sampler-cache.c
@@ -367,5 +367,5 @@ _cogl_sampler_cache_free (CoglSamplerCache *cache)
 
   g_hash_table_destroy (cache->hash_table_cogl);
 
-  g_free (cache);
+  free (cache);
 }

--- a/cogl/cogl/cogl-snippet.c
+++ b/cogl/cogl/cogl-snippet.c
@@ -95,7 +95,7 @@ cogl_snippet_set_declarations (CoglSnippet *snippet,
   if (!_cogl_snippet_modify (snippet))
     return;
 
-  g_free (snippet->declarations);
+  free (snippet->declarations);
   snippet->declarations = declarations ? g_strdup (declarations) : NULL;
 }
 
@@ -116,7 +116,7 @@ cogl_snippet_set_pre (CoglSnippet *snippet,
   if (!_cogl_snippet_modify (snippet))
     return;
 
-  g_free (snippet->pre);
+  free (snippet->pre);
   snippet->pre = pre ? g_strdup (pre) : NULL;
 }
 
@@ -137,7 +137,7 @@ cogl_snippet_set_replace (CoglSnippet *snippet,
   if (!_cogl_snippet_modify (snippet))
     return;
 
-  g_free (snippet->replace);
+  free (snippet->replace);
   snippet->replace = replace ? g_strdup (replace) : NULL;
 }
 
@@ -158,7 +158,7 @@ cogl_snippet_set_post (CoglSnippet *snippet,
   if (!_cogl_snippet_modify (snippet))
     return;
 
-  g_free (snippet->post);
+  free (snippet->post);
   snippet->post = post ? g_strdup (post) : NULL;
 }
 
@@ -179,9 +179,9 @@ _cogl_snippet_make_immutable (CoglSnippet *snippet)
 static void
 _cogl_snippet_free (CoglSnippet *snippet)
 {
-  g_free (snippet->declarations);
-  g_free (snippet->pre);
-  g_free (snippet->replace);
-  g_free (snippet->post);
+  free (snippet->declarations);
+  free (snippet->pre);
+  free (snippet->replace);
+  free (snippet->post);
   g_slice_free (CoglSnippet, snippet);
 }

--- a/cogl/cogl/cogl-texture-2d-sliced.c
+++ b/cogl/cogl/cogl-texture-2d-sliced.c
@@ -389,7 +389,7 @@ _cogl_texture_2d_sliced_upload_bitmap (CoglTexture2DSliced *tex_2ds,
                                                      error))
             {
               if (waste_buf)
-                g_free (waste_buf);
+                free (waste_buf);
               return FALSE;
             }
 
@@ -419,14 +419,14 @@ _cogl_texture_2d_sliced_upload_bitmap (CoglTexture2DSliced *tex_2ds,
                                                   error)) /* dst_y */
             {
               if (waste_buf)
-                g_free (waste_buf);
+                free (waste_buf);
               return FALSE;
             }
         }
     }
 
   if (waste_buf)
-    g_free (waste_buf);
+    free (waste_buf);
 
   return TRUE;
 }
@@ -523,7 +523,7 @@ _cogl_texture_2d_sliced_upload_subregion (CoglTexture2DSliced *tex_2ds,
                                                      error))
             {
               if (waste_buf)
-                g_free (waste_buf);
+                free (waste_buf);
               return FALSE;
             }
 
@@ -538,14 +538,14 @@ _cogl_texture_2d_sliced_upload_subregion (CoglTexture2DSliced *tex_2ds,
                                                   error))
             {
               if (waste_buf)
-                g_free (waste_buf);
+                free (waste_buf);
               return FALSE;
             }
         }
     }
 
   if (waste_buf)
-    g_free (waste_buf);
+    free (waste_buf);
 
   return TRUE;
 }

--- a/cogl/cogl/cogl-texture-2d-sliced.c
+++ b/cogl/cogl/cogl-texture-2d-sliced.c
@@ -174,7 +174,7 @@ _cogl_texture_2d_sliced_allocate_waste_buffer (CoglTexture2DSliced *tex_2ds,
       unsigned int right_size = first_y_span->size * last_x_span->waste;
       unsigned int bottom_size = first_x_span->size * last_y_span->waste;
 
-      waste_buf = g_malloc (MAX (right_size, bottom_size) * bpp);
+      waste_buf = malloc (MAX (right_size, bottom_size) * bpp);
     }
 
   return waste_buf;

--- a/cogl/cogl/cogl-texture.c
+++ b/cogl/cogl/cogl-texture.c
@@ -182,7 +182,7 @@ _cogl_texture_free (CoglTexture *texture)
 {
   _cogl_texture_free_loader (texture);
 
-  g_free (texture);
+  free (texture);
 }
 
 CoglBool
@@ -654,7 +654,7 @@ get_texture_bits_via_copy (CoglTexture *texture,
   else
     ret = FALSE;
 
-  g_free (full_bits);
+  free (full_bits);
 
   return ret;
 }

--- a/cogl/cogl/cogl-texture.c
+++ b/cogl/cogl/cogl-texture.c
@@ -633,7 +633,7 @@ get_texture_bits_via_copy (CoglTexture *texture,
   bpp = _cogl_pixel_format_get_bytes_per_pixel (dst_format);
 
   full_rowstride = bpp * full_tex_width;
-  full_bits = g_malloc (full_rowstride * full_tex_height);
+  full_bits = malloc (full_rowstride * full_tex_height);
 
   if (texture->vtable->get_data (texture,
                                  dst_format,

--- a/cogl/cogl/deprecated/cogl-program.c
+++ b/cogl/cogl/deprecated/cogl-program.c
@@ -72,10 +72,10 @@ _cogl_program_free (CoglProgram *program)
       CoglProgramUniform *uniform =
         &g_array_index (program->custom_uniforms, CoglProgramUniform, i);
 
-      g_free (uniform->name);
+      free (uniform->name);
 
       if (uniform->value.count > 1)
-        g_free (uniform->value.v.array);
+        free (uniform->value.v.array);
     }
 
   g_array_free (program->custom_uniforms, TRUE);
@@ -373,7 +373,7 @@ get_local_param_index (const char *uniform_name)
 
   _COGL_RETURN_VAL_IF_FAIL (_index >= 0, -1);
 
-  g_free (input);
+  free (input);
 
   return _index;
 }

--- a/cogl/cogl/deprecated/cogl-shader.h
+++ b/cogl/cogl/deprecated/cogl-shader.h
@@ -335,7 +335,7 @@ cogl_shader_compile (CoglHandle handle);
  * debugging purposes.
  *
  * Return value: a newly allocated string containing the info log. Use
- *   g_free() to free it
+ *   free() to free it
  * Deprecated: 1.16: Use #CoglSnippet api
  */
 COGL_DEPRECATED_IN_1_16_FOR (cogl_snippet_)

--- a/cogl/cogl/deprecated/cogl-vertex-buffer.c
+++ b/cogl/cogl/deprecated/cogl-vertex-buffer.c
@@ -559,7 +559,7 @@ cogl_vertex_buffer_add (CoglHandle         handle,
     buffer->new_attributes =
       g_list_prepend (buffer->new_attributes, attribute);
 
-  g_free (cogl_attribute_name);
+  free (cogl_attribute_name);
 }
 
 static void
@@ -567,7 +567,7 @@ _cogl_vertex_buffer_attrib_free (CoglVertexBufferAttrib *attribute)
 {
   if (attribute->attribute)
     cogl_object_unref (attribute->attribute);
-  g_free (attribute->name_without_detail);
+  free (attribute->name_without_detail);
   g_slice_free (CoglVertexBufferAttrib, attribute);
 }
 
@@ -580,7 +580,7 @@ cogl_vertex_buffer_delete (CoglHandle handle,
   GQuark name = g_quark_from_string (cogl_attribute_name);
   GList *tmp;
 
-  g_free (cogl_attribute_name);
+  free (cogl_attribute_name);
 
   if (!cogl_is_vertex_buffer (handle))
     return;
@@ -621,7 +621,7 @@ set_attribute_enable (CoglHandle handle,
   GQuark name_quark = g_quark_from_string (cogl_attribute_name);
   GList *tmp;
 
-  g_free (cogl_attribute_name);
+  free (cogl_attribute_name);
 
   if (!cogl_is_vertex_buffer (handle))
     return;

--- a/cogl/cogl/driver/gl/cogl-pipeline-fragend-glsl.c
+++ b/cogl/cogl/driver/gl/cogl-pipeline-fragend-glsl.c
@@ -148,7 +148,7 @@ destroy_shader_state (void *user_data,
       if (shader_state->gl_shader)
         GE( ctx, glDeleteShader (shader_state->gl_shader) );
 
-      g_free (shader_state->unit_state);
+      free (shader_state->unit_state);
 
       g_slice_free (CoglPipelineShaderState, shader_state);
     }
@@ -495,10 +495,10 @@ ensure_texture_lookup_generated (CoglPipelineShaderState *shader_state,
 
   _cogl_pipeline_snippet_generate_code (&snippet_data);
 
-  g_free ((char *) snippet_data.chain_function);
-  g_free ((char *) snippet_data.final_name);
-  g_free ((char *) snippet_data.function_prefix);
-  g_free ((char *) snippet_data.argument_declarations);
+  free ((char *) snippet_data.chain_function);
+  free ((char *) snippet_data.final_name);
+  free ((char *) snippet_data.function_prefix);
+  free ((char *) snippet_data.argument_declarations);
 }
 
 static void
@@ -881,9 +881,9 @@ ensure_layer_generated (CoglPipeline *pipeline,
 
   _cogl_pipeline_snippet_generate_code (&snippet_data);
 
-  g_free ((char *) snippet_data.chain_function);
-  g_free ((char *) snippet_data.final_name);
-  g_free ((char *) snippet_data.function_prefix);
+  free ((char *) snippet_data.chain_function);
+  free ((char *) snippet_data.final_name);
+  free ((char *) snippet_data.function_prefix);
 
   g_string_append_printf (shader_state->source,
                           "  cogl_layer%i = cogl_generate_layer%i ();\n",

--- a/cogl/cogl/driver/gl/cogl-pipeline-progend-glsl.c
+++ b/cogl/cogl/driver/gl/cogl-pipeline-progend-glsl.c
@@ -341,7 +341,7 @@ link_program (GLint gl_program)
 
       GE( ctx, glGetProgramiv (gl_program, GL_INFO_LOG_LENGTH, &log_length) );
 
-      log = g_malloc (log_length);
+      log = malloc (log_length);
 
       GE( ctx, glGetProgramInfoLog (gl_program, log_length,
                                     &out_log_length, log) );

--- a/cogl/cogl/driver/gl/cogl-pipeline-progend-glsl.c
+++ b/cogl/cogl/driver/gl/cogl-pipeline-progend-glsl.c
@@ -283,7 +283,7 @@ destroy_program_state (void *user_data,
       if (program_state->program)
         GE( ctx, glDeleteProgram (program_state->program) );
 
-      g_free (program_state->unit_state);
+      free (program_state->unit_state);
 
       if (program_state->uniform_locations)
         g_array_free (program_state->uniform_locations, TRUE);
@@ -349,7 +349,7 @@ link_program (GLint gl_program)
       g_warning ("Failed to link GLSL program:\n%.*s\n",
                  log_length, log);
 
-      g_free (log);
+      free (log);
     }
 }
 

--- a/cogl/cogl/driver/gl/cogl-pipeline-vertend-glsl.c
+++ b/cogl/cogl/driver/gl/cogl-pipeline-vertend-glsl.c
@@ -390,9 +390,9 @@ _cogl_pipeline_vertend_glsl_add_layer (CoglPipeline *pipeline,
 
   _cogl_pipeline_snippet_generate_code (&snippet_data);
 
-  g_free ((char *) snippet_data.chain_function);
-  g_free ((char *) snippet_data.final_name);
-  g_free ((char *) snippet_data.function_prefix);
+  free ((char *) snippet_data.chain_function);
+  free ((char *) snippet_data.final_name);
+  free ((char *) snippet_data.function_prefix);
 
   g_string_append_printf (shader_state->source,
                           "  cogl_tex_coord%i_out = "

--- a/cogl/cogl/driver/gl/gl/cogl-driver-gl.c
+++ b/cogl/cogl/driver/gl/gl/cogl-driver-gl.c
@@ -421,7 +421,7 @@ _cogl_driver_update_features (CoglContext *ctx,
                  _cogl_context_get_gl_version (ctx),
                  all_extensions);
 
-      g_free (all_extensions);
+      free (all_extensions);
     }
 
   _cogl_get_gl_version (ctx, &gl_major, &gl_minor);

--- a/cogl/cogl/driver/gl/gl/cogl-pipeline-fragend-arbfp.c
+++ b/cogl/cogl/driver/gl/gl/cogl-pipeline-fragend-arbfp.c
@@ -145,7 +145,7 @@ destroy_shader_state (void *user_data,
           shader_state->gl_program = 0;
         }
 
-      g_free (shader_state->unit_state);
+      free (shader_state->unit_state);
 
       g_slice_free (CoglPipelineShaderState, shader_state);
     }

--- a/cogl/cogl/driver/gl/gles/cogl-driver-gles.c
+++ b/cogl/cogl/driver/gl/gles/cogl-driver-gles.c
@@ -289,7 +289,7 @@ _cogl_driver_update_features (CoglContext *context,
                  _cogl_context_get_gl_version (context),
                  all_extensions);
 
-      g_free (all_extensions);
+      free (all_extensions);
     }
 
   context->glsl_major = 1;

--- a/cogl/cogl/winsys/cogl-texture-pixmap-x11.c
+++ b/cogl/cogl/winsys/cogl-texture-pixmap-x11.c
@@ -308,7 +308,7 @@ _cogl_texture_pixmap_x11_new (CoglContext *ctxt,
                      &pixmap_width, &pixmap_height,
                      &pixmap_border_width, &tex_pixmap->depth))
     {
-      g_free (tex_pixmap);
+      free (tex_pixmap);
       _cogl_set_error (error,
                    COGL_TEXTURE_PIXMAP_X11_ERROR,
                    COGL_TEXTURE_PIXMAP_X11_ERROR_X11,
@@ -340,7 +340,7 @@ _cogl_texture_pixmap_x11_new (CoglContext *ctxt,
      it from the pixmap's root window */
   if (!XGetWindowAttributes (display, pixmap_root_window, &window_attributes))
     {
-      g_free (tex_pixmap);
+      free (tex_pixmap);
       _cogl_set_error (error,
                    COGL_TEXTURE_PIXMAP_X11_ERROR,
                    COGL_TEXTURE_PIXMAP_X11_ERROR_X11,

--- a/cogl/cogl/winsys/cogl-winsys-egl-x11.c
+++ b/cogl/cogl/winsys/cogl-winsys-egl-x11.c
@@ -791,7 +791,7 @@ _cogl_winsys_texture_pixmap_x11_create (CoglTexturePixmapX11 *tex_pixmap)
                             attribs);
   if (egl_tex_pixmap->image == EGL_NO_IMAGE_KHR)
     {
-      g_free (egl_tex_pixmap);
+      free (egl_tex_pixmap);
       return FALSE;
     }
 
@@ -833,7 +833,7 @@ _cogl_winsys_texture_pixmap_x11_free (CoglTexturePixmapX11 *tex_pixmap)
     _cogl_egl_destroy_image (ctx, egl_tex_pixmap->image);
 
   tex_pixmap->winsys = NULL;
-  g_free (egl_tex_pixmap);
+  free (egl_tex_pixmap);
 }
 
 static CoglBool

--- a/cogl/cogl/winsys/cogl-winsys-egl.c
+++ b/cogl/cogl/winsys/cogl-winsys-egl.c
@@ -558,7 +558,7 @@ _cogl_winsys_context_deinit (CoglContext *context)
   if (egl_renderer->platform_vtable->context_deinit)
     egl_renderer->platform_vtable->context_deinit (context);
 
-  g_free (context->winsys);
+  free (context->winsys);
 }
 
 typedef struct _CoglGLES2ContextEGL

--- a/cogl/cogl/winsys/cogl-winsys-glx.c
+++ b/cogl/cogl/winsys/cogl-winsys-glx.c
@@ -1341,7 +1341,7 @@ _cogl_winsys_context_deinit (CoglContext *context)
   cogl_xlib_renderer_remove_filter (context->display->renderer,
                                     glx_event_filter_cb,
                                     context);
-  g_free (context->winsys);
+  free (context->winsys);
 }
 
 static CoglBool
@@ -1577,7 +1577,7 @@ _cogl_winsys_onscreen_deinit (CoglOnscreen *onscreen)
 
       _cogl_poll_renderer_remove_fd (context->display->renderer,
                                      glx_onscreen->swap_wait_pipe[0]);
-      
+
       close (glx_onscreen->swap_wait_pipe[0]);
       close (glx_onscreen->swap_wait_pipe[1]);
 
@@ -1971,7 +1971,7 @@ start_threaded_swap_wait (CoglOnscreen *onscreen,
       int i;
 
       ensure_ust_type (display->renderer, drawable);
-      
+
       if ((pipe (glx_onscreen->swap_wait_pipe) == -1))
         g_error ("Couldn't create pipe for swap notification: %s\n",
                  g_strerror (errno));
@@ -2742,7 +2742,7 @@ _cogl_winsys_texture_pixmap_x11_create (CoglTexturePixmapX11 *tex_pixmap)
   if (!try_create_glx_pixmap (ctx, tex_pixmap, FALSE))
     {
       tex_pixmap->winsys = NULL;
-      g_free (glx_tex_pixmap);
+      free (glx_tex_pixmap);
       return FALSE;
     }
 
@@ -2817,7 +2817,7 @@ _cogl_winsys_texture_pixmap_x11_free (CoglTexturePixmapX11 *tex_pixmap)
     cogl_object_unref (glx_tex_pixmap->right.glx_tex);
 
   tex_pixmap->winsys = NULL;
-  g_free (glx_tex_pixmap);
+  free (glx_tex_pixmap);
 }
 
 static CoglBool

--- a/cogl/config-custom.h
+++ b/cogl/config-custom.h
@@ -30,3 +30,4 @@
    intended for extra configuration that needs to be included by all
    Cogl source files. */
 
+#include <stdlib.h>

--- a/cogl/test-fixtures/test-utils.c
+++ b/cogl/test-fixtures/test-utils.c
@@ -309,7 +309,7 @@ test_utils_check_region (CoglFramebuffer *test_fb,
 {
   uint8_t *pixels, *p;
 
-  pixels = p = g_malloc (width * height * 4);
+  pixels = p = malloc (width * height * 4);
   cogl_framebuffer_read_pixels (test_fb,
                                 x,
                                 y,

--- a/cogl/test-fixtures/test-utils.c
+++ b/cogl/test-fixtures/test-utils.c
@@ -157,7 +157,7 @@ test_utils_init (TestFlags requirement_flags,
     {
       char *debug = g_strconcat (g_getenv ("G_DEBUG"), ",fatal-warnings", NULL);
       g_setenv ("G_DEBUG", debug, TRUE);
-      g_free (debug);
+      free (debug);
     }
   else
     g_setenv ("G_DEBUG", "fatal-warnings", TRUE);
@@ -240,8 +240,8 @@ test_utils_compare_pixel_and_alpha (const uint8_t *screen_pixel,
 
       g_assert_cmpstr (screen_pixel_string, ==, expected_pixel_string);
 
-      g_free (screen_pixel_string);
-      g_free (expected_pixel_string);
+      free (screen_pixel_string);
+      free (expected_pixel_string);
     }
 }
 
@@ -261,8 +261,8 @@ test_utils_compare_pixel (const uint8_t *screen_pixel, uint32_t expected_pixel)
 
       g_assert_cmpstr (screen_pixel_string, ==, expected_pixel_string);
 
-      g_free (screen_pixel_string);
-      g_free (expected_pixel_string);
+      free (screen_pixel_string);
+      free (expected_pixel_string);
     }
 }
 
@@ -326,7 +326,7 @@ test_utils_check_region (CoglFramebuffer *test_fb,
         p += 4;
       }
 
-  g_free (pixels);
+  free (pixels);
 }
 
 CoglTexture *

--- a/cogl/tests/conform/test-atlas-migration.c
+++ b/cogl/tests/conform/test-atlas-migration.c
@@ -63,7 +63,7 @@ create_texture (int size)
                                               size * 4,
                                               data);
 
-  g_free (data);
+  free (data);
 
   return texture;
 }
@@ -108,7 +108,7 @@ verify_texture (CoglTexture *texture, int size)
         }
     }
 
-  g_free (data);
+  free (data);
 }
 
 void

--- a/cogl/tests/conform/test-atlas-migration.c
+++ b/cogl/tests/conform/test-atlas-migration.c
@@ -31,7 +31,7 @@ create_texture (int size)
   /* Create a red, green or blue texture depending on the size */
   color = COLOR_FOR_SIZE (size);
 
-  p = data = g_malloc (size * size * 4);
+  p = data = malloc (size * size * 4);
 
   /* Fill the data with the color but fade the opacity out with
      increasing y coordinates so that we can see the blending it the
@@ -77,7 +77,7 @@ verify_texture (CoglTexture *texture, int size)
 
   color = COLOR_FOR_SIZE (size);
 
-  p = data = g_malloc (size * size * 4);
+  p = data = malloc (size * size * 4);
 
   cogl_texture_get_data (texture,
                          COGL_PIXEL_FORMAT_RGBA_8888_PRE,

--- a/cogl/tests/conform/test-backface-culling.c
+++ b/cogl/tests/conform/test-backface-culling.c
@@ -274,7 +274,7 @@ make_texture (void)
                                           TEXTURE_SIZE * 4,
                                           tex_data);
 
-  g_free (tex_data);
+  free (tex_data);
 
   return tex;
 }

--- a/cogl/tests/conform/test-backface-culling.c
+++ b/cogl/tests/conform/test-backface-culling.c
@@ -256,7 +256,7 @@ make_texture (void)
   guchar *tex_data, *p;
   CoglTexture *tex;
 
-  tex_data = g_malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
+  tex_data = malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
 
   for (p = tex_data + TEXTURE_SIZE * TEXTURE_SIZE * 4; p > tex_data;)
     {

--- a/cogl/tests/conform/test-blend-strings.c
+++ b/cogl/tests/conform/test-blend-strings.c
@@ -184,7 +184,7 @@ make_texture (uint32_t color)
   uint8_t a = MASK_ALPHA (color);
   CoglTexture *tex;
 
-  tex_data = g_malloc (QUAD_WIDTH * QUAD_WIDTH * 4);
+  tex_data = malloc (QUAD_WIDTH * QUAD_WIDTH * 4);
 
   for (p = tex_data + QUAD_WIDTH * QUAD_WIDTH * 4; p > tex_data;)
     {

--- a/cogl/tests/conform/test-blend-strings.c
+++ b/cogl/tests/conform/test-blend-strings.c
@@ -204,7 +204,7 @@ make_texture (uint32_t color)
                                           QUAD_WIDTH * 4,
                                           tex_data);
 
-  g_free (tex_data);
+  free (tex_data);
 
   return tex;
 }

--- a/cogl/tests/conform/test-gles2-context.c
+++ b/cogl/tests/conform/test-gles2-context.c
@@ -627,7 +627,7 @@ verify_read_pixels (const PaintData *data)
                             data->fb_height * 3 / 4 * stride,
                             0xff0000ff);
 
-  g_free (buf);
+  free (buf);
 }
 
 void
@@ -759,7 +759,7 @@ verify_region (const CoglGLES2Vtable *gles2,
   for (p = buf + width * height * 4; p > buf; p -= 4)
     test_utils_compare_pixel (p - 4, expected_pixel);
 
-  g_free (buf);
+  free (buf);
 }
 
 void

--- a/cogl/tests/conform/test-gles2-context.c
+++ b/cogl/tests/conform/test-gles2-context.c
@@ -609,7 +609,7 @@ static void
 verify_read_pixels (const PaintData *data)
 {
   int stride = data->fb_width * 4;
-  uint8_t *buf = g_malloc (data->fb_height * stride);
+  uint8_t *buf = malloc (data->fb_height * stride);
 
   data->gles2->glReadPixels (0, 0, /* x/y */
                              data->fb_width, data->fb_height,
@@ -752,7 +752,7 @@ verify_region (const CoglGLES2Vtable *gles2,
 {
   uint8_t *buf, *p;
 
-  buf = g_malloc (width * height * 4);
+  buf = malloc (width * height * 4);
 
   gles2->glReadPixels (x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buf);
 

--- a/cogl/tests/conform/test-just-vertex-shader.c
+++ b/cogl/tests/conform/test-just-vertex-shader.c
@@ -73,7 +73,7 @@ paint_legacy (TestState *state)
     {
       char *log = cogl_shader_get_info_log (shader);
       g_warning ("Shader compilation failed:\n%s", log);
-      g_free (log);
+      free (log);
       g_assert_not_reached ();
     }
 
@@ -143,7 +143,7 @@ paint (TestState *state)
     {
       char *log = cogl_shader_get_info_log (shader);
       g_warning ("Shader compilation failed:\n%s", log);
-      g_free (log);
+      free (log);
       g_assert_not_reached ();
     }
 

--- a/cogl/tests/conform/test-multitexture.c
+++ b/cogl/tests/conform/test-multitexture.c
@@ -43,7 +43,7 @@ assert_region_color (int x,
                   pixel[BLUE] == blue);
 #endif
       }
-  g_free (data);
+  free (data);
 }
 
 /* Creates a texture divided into 4 quads with colors arranged as follows:
@@ -93,7 +93,7 @@ make_texture (guchar ref)
                                     QUAD_WIDTH * 8,
                                     tex_data);
 
-  g_free (tex_data);
+  free (tex_data);
 
   return tex;
 }

--- a/cogl/tests/conform/test-multitexture.c
+++ b/cogl/tests/conform/test-multitexture.c
@@ -68,7 +68,7 @@ make_texture (guchar ref)
   CoglHandle tex;
   guchar val;
 
-  tex_data = g_malloc (QUAD_WIDTH * QUAD_WIDTH * 16);
+  tex_data = malloc (QUAD_WIDTH * QUAD_WIDTH * 16);
 
   for (y = 0; y < QUAD_WIDTH * 2; y++)
     for (x = 0; x < QUAD_WIDTH * 2; x++)

--- a/cogl/tests/conform/test-multitexture.c
+++ b/cogl/tests/conform/test-multitexture.c
@@ -28,7 +28,7 @@ assert_region_color (int x,
                      uint8_t blue,
                      uint8_t alpha)
 {
-  uint8_t *data = g_malloc0 (width * height * 4);
+  uint8_t *data = calloc (1, width * height * 4);
   cogl_read_pixels (x, y, width, height,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     COGL_PIXEL_FORMAT_RGBA_8888_PRE,

--- a/cogl/tests/conform/test-npot-texture.c
+++ b/cogl/tests/conform/test-npot-texture.c
@@ -60,7 +60,7 @@ make_texture (void)
   CoglTexture *tex;
   int partx, party, width, height;
 
-  p = tex_data = g_malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
+  p = tex_data = malloc (TEXTURE_SIZE * TEXTURE_SIZE * 4);
 
   /* Make a texture with a different color for each part */
   for (party = 0; party < PARTS; party++)

--- a/cogl/tests/conform/test-npot-texture.c
+++ b/cogl/tests/conform/test-npot-texture.c
@@ -95,7 +95,7 @@ make_texture (void)
                                           TEXTURE_SIZE * 4,
                                           tex_data);
 
-  g_free (tex_data);
+  free (tex_data);
 
   if (cogl_test_verbose ())
     {

--- a/cogl/tests/conform/test-path.c
+++ b/cogl/tests/conform/test-path.c
@@ -61,7 +61,7 @@ check_block (int block_x, int block_y, int block_mask)
                                         (y + TEST_INSET) * BLOCK_SIZE);
 	      char *screen_pixel = g_strdup_printf ("#%06x", GUINT32_FROM_BE (*p) >> 8);
 	      g_assert_cmpstr (screen_pixel, ==, intended_pixel);
-	      g_free (screen_pixel);
+	      free (screen_pixel);
             }
       }
 }

--- a/cogl/tests/conform/test-pipeline-uniforms.c
+++ b/cogl/tests/conform/test-pipeline-uniforms.c
@@ -156,7 +156,7 @@ init_long_pipeline_state (TestState *state)
       state->long_uniform_locations[i] =
         cogl_pipeline_get_uniform_location (state->long_pipeline,
                                             uniform_name);
-      g_free (uniform_name);
+      free (uniform_name);
     }
 }
 

--- a/cogl/tests/conform/test-pipeline-user-matrix.c
+++ b/cogl/tests/conform/test-pipeline-user-matrix.c
@@ -30,7 +30,7 @@ validate_result (TestState *state)
     {
       screen_pixel = g_strdup_printf ("#%06x", GUINT32_FROM_BE (*p) >> 8);
       g_assert_cmpstr (screen_pixel, ==, intended_pixel);
-      g_free (screen_pixel);
+      free (screen_pixel);
     }
 }
 

--- a/cogl/tests/conform/test-pipeline-user-matrix.c
+++ b/cogl/tests/conform/test-pipeline-user-matrix.c
@@ -20,7 +20,7 @@ validate_result (TestState *state)
   /* The textures are setup so that when added together with the
      correct matrices then all of the pixels should be white. We can
      verify this by reading back the entire stage */
-  pixels = g_malloc (state->width * state->height * 4);
+  pixels = malloc (state->width * state->height * 4);
 
   cogl_framebuffer_read_pixels (test_fb, 0, 0, state->width, state->height,
                                 COGL_PIXEL_FORMAT_RGBA_8888_PRE,

--- a/cogl/tests/conform/test-pixel-buffer.c
+++ b/cogl/tests/conform/test-pixel-buffer.c
@@ -174,7 +174,7 @@ test_pixel_buffer_set_data (void)
 
   stride = cogl_bitmap_get_rowstride (bitmap);
 
-  data = g_malloc (stride * BITMAP_SIZE);
+  data = malloc (stride * BITMAP_SIZE);
 
   generate_bitmap_data (data, stride);
 
@@ -211,7 +211,7 @@ static CoglTexture *
 create_white_texture (void)
 {
   CoglTexture2D *texture;
-  uint8_t *data = g_malloc (BITMAP_SIZE * BITMAP_SIZE * 4);
+  uint8_t *data = malloc (BITMAP_SIZE * BITMAP_SIZE * 4);
 
   memset (data, 255, BITMAP_SIZE * BITMAP_SIZE * 4);
 

--- a/cogl/tests/conform/test-pixel-buffer.c
+++ b/cogl/tests/conform/test-pixel-buffer.c
@@ -184,7 +184,7 @@ test_pixel_buffer_set_data (void)
                         stride * (BITMAP_SIZE - 1) +
                         BITMAP_SIZE * 4);
 
-  g_free (data);
+  free (data);
 
   texture = create_texture_from_bitmap (bitmap);
   pipeline = create_pipeline_from_texture (texture);
@@ -223,7 +223,7 @@ create_white_texture (void)
                                            data,
                                            NULL); /* don't catch errors */
 
-  g_free (data);
+  free (data);
 
   return texture;
 }

--- a/cogl/tests/conform/test-premult.c
+++ b/cogl/tests/conform/test-premult.c
@@ -66,7 +66,7 @@ make_texture (uint32_t color,
     cogl_texture_set_premultiplied (tex_2d, FALSE);
 
   cogl_object_unref (bmp);
-  g_free (tex_data);
+  free (tex_data);
 
   return tex_2d;
 }

--- a/cogl/tests/conform/test-premult.c
+++ b/cogl/tests/conform/test-premult.c
@@ -31,7 +31,7 @@ gen_tex_data (uint32_t color)
   uint8_t b = MASK_BLUE (color);
   uint8_t a = MASK_ALPHA (color);
 
-  tex_data = g_malloc (QUAD_WIDTH * QUAD_WIDTH * 4);
+  tex_data = malloc (QUAD_WIDTH * QUAD_WIDTH * 4);
 
   for (p = tex_data + QUAD_WIDTH * QUAD_WIDTH * 4; p > tex_data;)
     {

--- a/cogl/tests/conform/test-primitive.c
+++ b/cogl/tests/conform/test-primitive.c
@@ -251,7 +251,7 @@ test_copy (TestState *state)
                                           16, /* offset */
                                           2, /* components */
                                           COGL_ATTRIBUTE_TYPE_FLOAT);
-      g_free (name);
+      free (name);
     }
 
   prim_a = cogl_primitive_new_with_attributes (COGL_VERTICES_MODE_TRIANGLES,

--- a/cogl/tests/conform/test-read-texture-formats.c
+++ b/cogl/tests/conform/test-read-texture-formats.c
@@ -60,8 +60,8 @@ test_read_short (CoglTexture2D *tex_2d,
   received_value_str = g_strdup_printf ("0x%04x", received_value);
   expected_value_str = g_strdup_printf ("0x%04x", expected_value);
   g_assert_cmpstr (received_value_str, ==, expected_value_str);
-  g_free (received_value_str);
-  g_free (expected_value_str);
+  free (received_value_str);
+  free (expected_value_str);
 }
 
 static void
@@ -115,8 +115,8 @@ test_read_8888 (CoglTexture2D *tex_2d,
   received_value_str = g_strdup_printf ("0x%08x", received_pixel);
   expected_value_str = g_strdup_printf ("0x%08x", expected_pixel);
   g_assert_cmpstr (received_value_str, ==, expected_value_str);
-  g_free (received_value_str);
-  g_free (expected_value_str);
+  free (received_value_str);
+  free (expected_value_str);
 }
 
 static void
@@ -154,8 +154,8 @@ test_read_int (CoglTexture2D *tex_2d,
   received_value_str = g_strdup_printf ("0x%08x", received_value);
   expected_value_str = g_strdup_printf ("0x%08x", expected_value);
   g_assert_cmpstr (received_value_str, ==, expected_value_str);
-  g_free (received_value_str);
-  g_free (expected_value_str);
+  free (received_value_str);
+  free (expected_value_str);
 }
 
 void

--- a/cogl/tests/conform/test-readpixels.c
+++ b/cogl/tests/conform/test-readpixels.c
@@ -43,7 +43,7 @@ on_paint (ClutterActor *actor, void *state)
    * verify is reading back grid of colors from a CoglOffscreen framebuffer
    */
 
-  data = g_malloc (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
+  data = malloc (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
   tex = test_utils_texture_new_from_data (FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
                                     TEST_UTILS_TEXTURE_NO_SLICING,
                                     COGL_PIXEL_FORMAT_RGBA_8888, /* data fmt */

--- a/cogl/tests/conform/test-readpixels.c
+++ b/cogl/tests/conform/test-readpixels.c
@@ -68,7 +68,7 @@ on_paint (ClutterActor *actor, void *state)
   cogl_set_source_color4ub (0xff, 0xff, 0xff, 0xff);
   cogl_rectangle (0, 0, 1, -1);
 
-  pixels = g_malloc0 (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
+  pixels = calloc (1, FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
   cogl_read_pixels (0, 0, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     COGL_PIXEL_FORMAT_RGBA_8888_PRE,
@@ -89,7 +89,7 @@ on_paint (ClutterActor *actor, void *state)
   cogl_set_source_texture (tex);
   cogl_rectangle (-1, 1, 1, -1);
 
-  pixels = g_malloc0 (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
+  pixels = calloc (1, FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
   cogl_read_pixels (0, 0, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     COGL_PIXEL_FORMAT_RGBA_8888_PRE,
@@ -106,7 +106,7 @@ on_paint (ClutterActor *actor, void *state)
   cogl_set_source_texture (tex);
   cogl_rectangle (-1, 1, 1, -1);
 
-  pixelsc = g_malloc0 (FRAMEBUFFER_WIDTH * 3 * FRAMEBUFFER_HEIGHT);
+  pixelsc = calloc (1, FRAMEBUFFER_WIDTH * 3 * FRAMEBUFFER_HEIGHT);
   cogl_read_pixels (0, 0, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     COGL_PIXEL_FORMAT_BGR_888,

--- a/cogl/tests/conform/test-readpixels.c
+++ b/cogl/tests/conform/test-readpixels.c
@@ -50,7 +50,7 @@ on_paint (ClutterActor *actor, void *state)
                                     COGL_PIXEL_FORMAT_ANY, /* internal fmt */
                                     FRAMEBUFFER_WIDTH * 4, /* rowstride */
                                     data);
-  g_free (data);
+  free (data);
   offscreen = cogl_offscreen_new_with_texture (tex);
 
   cogl_push_framebuffer (offscreen);
@@ -78,7 +78,7 @@ on_paint (ClutterActor *actor, void *state)
   g_assert_cmpint (pixels[FRAMEBUFFER_WIDTH - 1], ==, 0xff00ff00);
   g_assert_cmpint (pixels[(FRAMEBUFFER_HEIGHT - 1) * FRAMEBUFFER_WIDTH], ==, 0xffff0000);
   g_assert_cmpint (pixels[(FRAMEBUFFER_HEIGHT - 1) * FRAMEBUFFER_WIDTH + FRAMEBUFFER_WIDTH - 1], ==, 0xffffffff);
-  g_free (pixels);
+  free (pixels);
 
   cogl_pop_framebuffer ();
   cogl_handle_unref (offscreen);
@@ -99,7 +99,7 @@ on_paint (ClutterActor *actor, void *state)
   g_assert_cmpint (pixels[FRAMEBUFFER_WIDTH - 1], ==, 0xff00ff00);
   g_assert_cmpint (pixels[(FRAMEBUFFER_HEIGHT - 1) * FRAMEBUFFER_WIDTH], ==, 0xffff0000);
   g_assert_cmpint (pixels[(FRAMEBUFFER_HEIGHT - 1) * FRAMEBUFFER_WIDTH + FRAMEBUFFER_WIDTH - 1], ==, 0xffffffff);
-  g_free (pixels);
+  free (pixels);
 
   /* Verify using BGR format */
 
@@ -120,7 +120,7 @@ on_paint (ClutterActor *actor, void *state)
   g_assert_cmpint (pixelsc[(FRAMEBUFFER_WIDTH - 1) * 3 + 1], ==, 0xff);
   g_assert_cmpint (pixelsc[(FRAMEBUFFER_WIDTH - 1) * 3 + 2], ==, 0x00);
 
-  g_free (pixelsc);
+  free (pixelsc);
 
   cogl_handle_unref (tex);
 

--- a/cogl/tests/conform/test-snippets.c
+++ b/cogl/tests/conform/test-snippets.c
@@ -158,9 +158,9 @@ lots_snippets (TestState *state)
       cogl_pipeline_add_snippet (pipeline, snippet);
       cogl_object_unref (snippet);
 
-      g_free (code);
-      g_free (uniform_name);
-      g_free (declarations);
+      free (code);
+      free (uniform_name);
+      free (declarations);
     }
 
   cogl_framebuffer_draw_rectangle (test_fb, pipeline, 30, 0, 40, 10);

--- a/cogl/tests/conform/test-sub-texture.c
+++ b/cogl/tests/conform/test-sub-texture.c
@@ -89,7 +89,7 @@ create_test_texture (TestState *state)
                                        256 * 4,
                                        data,
                                        NULL);
-  g_free (data);
+  free (data);
 
   return tex;
 }
@@ -225,7 +225,7 @@ validate_result (TestState *state)
         g_assert (*(p++) == y + 20);
         p += 2;
       }
-  g_free (texture_data);
+  free (texture_data);
 
   /* Try reading back the texture data */
   sub_texture = cogl_sub_texture_new (test_ctx,
@@ -253,7 +253,7 @@ validate_result (TestState *state)
         g_assert (color == reference);
         p += 4;
       }
-  g_free (texture_data);
+  free (texture_data);
   cogl_object_unref (sub_texture);
 
   /* Create a 256x256 test texture */
@@ -268,7 +268,7 @@ validate_result (TestState *state)
                            0, 0, 32, 32, 64, 64, 256, 256,
                            COGL_PIXEL_FORMAT_RGBA_8888_PRE, 256 * 4,
                            texture_data);
-  g_free (texture_data);
+  free (texture_data);
   cogl_object_unref (sub_texture);
   /* Get the texture data */
   p = texture_data = g_malloc (256 * 256 * 4);
@@ -296,7 +296,7 @@ validate_result (TestState *state)
             g_assert ((*p++) == 255);
           }
       }
-  g_free (texture_data);
+  free (texture_data);
   cogl_object_unref (test_tex);
 }
 

--- a/cogl/tests/conform/test-sub-texture.c
+++ b/cogl/tests/conform/test-sub-texture.c
@@ -29,7 +29,7 @@ static CoglTexture2D *
 create_source (TestState *state)
 {
   int dx, dy;
-  uint8_t *data = g_malloc (SOURCE_SIZE * SOURCE_SIZE * 4);
+  uint8_t *data = malloc (SOURCE_SIZE * SOURCE_SIZE * 4);
   CoglTexture2D *tex;
 
   /* Create a texture with a different coloured rectangle at each
@@ -67,7 +67,7 @@ static CoglTexture2D *
 create_test_texture (TestState *state)
 {
   CoglTexture2D *tex;
-  uint8_t *data = g_malloc (256 * 256 * 4), *p = data;
+  uint8_t *data = malloc (256 * 256 * 4), *p = data;
   int x, y;
 
   /* Create a texture that is 256x256 where the red component ranges
@@ -169,7 +169,7 @@ validate_part (int xpos, int ypos,
 static uint8_t *
 create_update_data (void)
 {
-  uint8_t *data = g_malloc (256 * 256 * 4), *p = data;
+  uint8_t *data = malloc (256 * 256 * 4), *p = data;
   int x, y;
 
   /* Create some image data that is 256x256 where the blue component
@@ -212,7 +212,7 @@ validate_result (TestState *state)
                      corner_colors[division_num]);
 
   /* Sub sub texture */
-  p = texture_data = g_malloc (10 * 10 * 4);
+  p = texture_data = malloc (10 * 10 * 4);
   cogl_flush ();
   cogl_framebuffer_read_pixels (test_fb,
                                 0, SOURCE_SIZE * 2, 10, 10,
@@ -236,7 +236,7 @@ validate_result (TestState *state)
                                       SOURCE_SIZE / 2);
   tex_width = cogl_texture_get_width (sub_texture);
   tex_height = cogl_texture_get_height (sub_texture);
-  p = texture_data = g_malloc (tex_width * tex_height * 4);
+  p = texture_data = malloc (tex_width * tex_height * 4);
   cogl_texture_get_data (sub_texture,
                          COGL_PIXEL_FORMAT_RGBA_8888,
                          tex_width * 4,
@@ -271,7 +271,7 @@ validate_result (TestState *state)
   free (texture_data);
   cogl_object_unref (sub_texture);
   /* Get the texture data */
-  p = texture_data = g_malloc (256 * 256 * 4);
+  p = texture_data = malloc (256 * 256 * 4);
   cogl_texture_get_data (test_tex,
                          COGL_PIXEL_FORMAT_RGBA_8888_PRE,
                          256 * 4, texture_data);

--- a/cogl/tests/conform/test-texture-3d.c
+++ b/cogl/tests/conform/test-texture-3d.c
@@ -21,7 +21,7 @@ static CoglTexture3D *
 create_texture_3d (CoglContext *context)
 {
   int x, y, z;
-  uint8_t *data = g_malloc (TEX_IMAGE_STRIDE * TEX_DEPTH);
+  uint8_t *data = malloc (TEX_IMAGE_STRIDE * TEX_DEPTH);
   uint8_t *p = data;
   CoglTexture3D *tex;
   CoglError *error = NULL;

--- a/cogl/tests/conform/test-texture-3d.c
+++ b/cogl/tests/conform/test-texture-3d.c
@@ -64,7 +64,7 @@ create_texture_3d (CoglContext *context)
       g_assert_not_reached ();
     }
 
-  g_free (data);
+  free (data);
 
   return tex;
 }
@@ -157,7 +157,7 @@ draw_frame (TestState *state)
 
   cogl_primitive_draw (primitive, test_fb, pipeline);
 
-  g_free (verts);
+  free (verts);
 
   cogl_object_unref (primitive);
   cogl_object_unref (attributes[0]);

--- a/cogl/tests/conform/test-texture-get-set-data.c
+++ b/cogl/tests/conform/test-texture-get-set-data.c
@@ -125,7 +125,7 @@ check_texture (int width, int height, TestUtilsTextureFlags flags)
       }
 
   cogl_object_unref (tex);
-  g_free (data);
+  free (data);
 }
 
 void

--- a/cogl/tests/conform/test-texture-get-set-data.c
+++ b/cogl/tests/conform/test-texture-get-set-data.c
@@ -13,7 +13,7 @@ check_texture (int width, int height, TestUtilsTextureFlags flags)
   int rowstride;
   CoglBitmap *bmp;
 
-  p = data = g_malloc (width * height * 4);
+  p = data = malloc (width * height * 4);
   for (y = 0; y < height; y++)
     for (x = 0; x < width; x++)
       {

--- a/cogl/tests/conform/test-texture-mipmaps.c
+++ b/cogl/tests/conform/test-texture-mipmaps.c
@@ -18,7 +18,7 @@ typedef struct _TestState
 static CoglHandle
 make_texture (void)
 {
-  guchar *tex_data = g_malloc (TEX_SIZE * TEX_SIZE * 3), *p = tex_data;
+  guchar *tex_data = malloc (TEX_SIZE * TEX_SIZE * 3), *p = tex_data;
   CoglHandle tex;
   int x, y;
 

--- a/cogl/tests/conform/test-texture-mipmaps.c
+++ b/cogl/tests/conform/test-texture-mipmaps.c
@@ -39,7 +39,7 @@ make_texture (void)
                                     TEX_SIZE * 3,
                                     tex_data);
 
-  g_free (tex_data);
+  free (tex_data);
 
   return tex;
 }

--- a/cogl/tests/conform/test-texture-no-allocate.c
+++ b/cogl/tests/conform/test-texture-no-allocate.c
@@ -37,7 +37,7 @@ test_texture_no_allocate (void)
                                       tex_data,
                                       &error);
 
-  g_free (tex_data);
+  free (tex_data);
 
   /* It's ok if this causes an error, we just don't want it to
    * crash */

--- a/cogl/tests/conform/test-texture-no-allocate.c
+++ b/cogl/tests/conform/test-texture-no-allocate.c
@@ -18,7 +18,7 @@ test_texture_no_allocate (void)
   CoglTexture2D *texture_2d;
   GError *error = NULL;
 
-  tex_data = g_malloc (BIG_TEX_WIDTH * BIG_TEX_HEIGHT * 4);
+  tex_data = malloc (BIG_TEX_WIDTH * BIG_TEX_HEIGHT * 4);
 
   /* NB: if we make the atlas and sliced texture APIs public then this
    * could changed to explicitly use that instead of the magic texture

--- a/cogl/tests/conform/test-texture-pixmap-x11.c
+++ b/cogl/tests/conform/test-texture-pixmap-x11.c
@@ -88,7 +88,7 @@ check_paint (TestState *state, int x, int y, int scale)
 {
   uint8_t *data, *p, update_value = 0;
 
-  p = data = g_malloc (PIXMAP_WIDTH * PIXMAP_HEIGHT * 4);
+  p = data = malloc (PIXMAP_WIDTH * PIXMAP_HEIGHT * 4);
 
   cogl_read_pixels (x, y, PIXMAP_WIDTH / scale, PIXMAP_HEIGHT / scale,
                     COGL_READ_PIXELS_COLOR_BUFFER,

--- a/cogl/tests/conform/test-texture-pixmap-x11.c
+++ b/cogl/tests/conform/test-texture-pixmap-x11.c
@@ -125,7 +125,7 @@ check_paint (TestState *state, int x, int y, int scale)
           }
       }
 
-  g_free (data);
+  free (data);
 
   return update_value == 0x00;
 }

--- a/cogl/tests/conform/test-texture-rectangle.c
+++ b/cogl/tests/conform/test-texture-rectangle.c
@@ -67,7 +67,7 @@ create_source_rect (void)
 
   g_assert (glGetError () == GL_NO_ERROR);
 
-  g_free (data);
+  free (data);
 
   tex = test_utils_texture_new_from_foreign (gl_tex,
                                        GL_TEXTURE_RECTANGLE_ARB,
@@ -105,7 +105,7 @@ create_source_2d (void)
                                     256 * 4,
                                     data);
 
-  g_free (data);
+  free (data);
 
   return tex;
 }
@@ -188,7 +188,7 @@ validate_result (TestState *state)
         p += 4;
       }
 
-  g_free (data);
+  free (data);
 
   /* Comment this out to see what the test paints */
   clutter_main_quit ();

--- a/cogl/tests/conform/test-texture-rectangle.c
+++ b/cogl/tests/conform/test-texture-rectangle.c
@@ -21,7 +21,7 @@ create_source_rect (void)
   GLint prev_unpack_skip_rows;
   GLint prev_unpack_skip_pixles;
   GLint prev_rectangle_binding;
-  uint8_t *data = g_malloc (256 * 256 * 4), *p = data;
+  uint8_t *data = malloc (256 * 256 * 4), *p = data;
   CoglHandle tex;
   GLuint gl_tex;
 
@@ -87,7 +87,7 @@ static CoglHandle
 create_source_2d (void)
 {
   int x, y;
-  uint8_t *data = g_malloc (256 * 256 * 4), *p = data;
+  uint8_t *data = malloc (256 * 256 * 4), *p = data;
   CoglHandle tex;
 
   for (y = 0; y < 256; y++)
@@ -163,7 +163,7 @@ validate_result (TestState *state)
   uint8_t *data, *p;
   int x, y;
 
-  p = data = g_malloc (512 * 384 * 4);
+  p = data = malloc (512 * 384 * 4);
 
   cogl_read_pixels (0, 0, 512, 384,
                     COGL_READ_PIXELS_COLOR_BUFFER,

--- a/cogl/tests/conform/test-viewport.c
+++ b/cogl/tests/conform/test-viewport.c
@@ -209,7 +209,7 @@ on_paint (ClutterActor *actor, void *state)
   /*
    * Next test offscreen drawing...
    */
-  data = g_malloc (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
+  data = malloc (FRAMEBUFFER_WIDTH * 4 * FRAMEBUFFER_HEIGHT);
   tex = test_utils_texture_new_from_data (FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
                                     TEST_UTILS_TEXTURE_NO_SLICING,
                                     COGL_PIXEL_FORMAT_RGBA_8888, /* data fmt */

--- a/cogl/tests/conform/test-viewport.c
+++ b/cogl/tests/conform/test-viewport.c
@@ -24,7 +24,7 @@ assert_region_color (int x,
                      uint8_t blue,
                      uint8_t alpha)
 {
-  uint8_t *data = g_malloc0 (width * height * 4);
+  uint8_t *data = calloc (1, width * height * 4);
   cogl_read_pixels (x, y, width, height,
                     COGL_READ_PIXELS_COLOR_BUFFER,
                     COGL_PIXEL_FORMAT_RGBA_8888_PRE,

--- a/cogl/tests/conform/test-viewport.c
+++ b/cogl/tests/conform/test-viewport.c
@@ -40,7 +40,7 @@ assert_region_color (int x,
                   pixel[ALPHA] == alpha);
 #endif
       }
-  g_free (data);
+  free (data);
 }
 
 static void
@@ -216,7 +216,7 @@ on_paint (ClutterActor *actor, void *state)
                                     COGL_PIXEL_FORMAT_ANY, /* internal fmt */
                                     FRAMEBUFFER_WIDTH * 4, /* rowstride */
                                     data);
-  g_free (data);
+  free (data);
   offscreen = cogl_offscreen_new_with_texture (tex);
 
   cogl_push_framebuffer (offscreen);

--- a/cogl/tests/conform/test-wrap-modes.c
+++ b/cogl/tests/conform/test-wrap-modes.c
@@ -35,7 +35,7 @@ create_texture (TestUtilsTextureFlags flags)
                                           COGL_PIXEL_FORMAT_RGBA_8888_PRE,
                                           TEX_SIZE * 4,
                                           data);
-  g_free (data);
+  free (data);
 
   return tex;
 }

--- a/cogl/tests/conform/test-wrap-modes.c
+++ b/cogl/tests/conform/test-wrap-modes.c
@@ -17,7 +17,7 @@ typedef struct _TestState
 static CoglTexture *
 create_texture (TestUtilsTextureFlags flags)
 {
-  uint8_t *data = g_malloc (TEX_SIZE * TEX_SIZE * 4), *p = data;
+  uint8_t *data = malloc (TEX_SIZE * TEX_SIZE * 4), *p = data;
   CoglTexture *tex;
   int x, y;
 

--- a/src/compositor/meta-module.c
+++ b/src/compositor/meta-module.c
@@ -122,7 +122,7 @@ meta_module_finalize (GObject *object)
 {
   MetaModulePrivate *priv = META_MODULE (object)->priv;
 
-  g_free (priv->path);
+  free (priv->path);
   priv->path = NULL;
 
   G_OBJECT_CLASS (meta_module_parent_class)->finalize (object);
@@ -139,7 +139,7 @@ meta_module_set_property (GObject      *object,
   switch (prop_id)
     {
     case PROP_PATH:
-      g_free (priv->path);
+      free (priv->path);
       priv->path = g_value_dup_string (value);
       break;
     default:

--- a/src/compositor/meta-plugin-manager.c
+++ b/src/compositor/meta-plugin-manager.c
@@ -82,7 +82,7 @@ meta_plugin_manager_load (const gchar *plugin_name)
   meta_plugin_manager_set_plugin_type (meta_module_get_plugin_type (module));
 
   g_type_module_unuse (G_TYPE_MODULE (module));
-  g_free (path);
+  free (path);
 }
 
 MetaPluginManager *

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -726,7 +726,7 @@ make_shadow (MetaShadow     *shadow,
   if (buffer_width < buffer_height && buffer_width > (3 * buffer_height) / 4)
     buffer_width = buffer_height;
 
-  buffer = g_malloc0 (buffer_width * buffer_height);
+  buffer = calloc (1, buffer_width * buffer_height);
 
   /* Blurring with multiple box-blur passes is fast, but (especially for
    * large shadow sizes) we can improve efficiency by restricting the blur

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -560,7 +560,7 @@ blur_rows (cairo_region_t   *convolve_region,
   int n_rectangles;
   guchar *tmp_buffer;
 
-  tmp_buffer = g_malloc (buffer_width);
+  tmp_buffer = malloc (buffer_width);
 
   n_rectangles = cairo_region_num_rectangles (convolve_region);
   for (i = 0; i < n_rectangles; i++)
@@ -662,7 +662,7 @@ flip_buffer (guchar *buffer,
     }
   else
     {
-      guchar *new_buffer = g_malloc (height * width);
+      guchar *new_buffer = malloc (height * width);
       int i0, j0;
 
       for (i0 = 0; i0 < width; i0 += BLOCK_SIZE)

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -377,7 +377,7 @@ meta_shadow_get_bounds  (MetaShadow            *shadow,
 static void
 meta_shadow_class_info_free (MetaShadowClassInfo *class_info)
 {
-  g_free ((char *)class_info->name);
+  free ((char *)class_info->name);
   g_slice_free (MetaShadowClassInfo, class_info);
 }
 
@@ -596,7 +596,7 @@ blur_rows (cairo_region_t   *convolve_region,
 	}
     }
 
-  g_free (tmp_buffer);
+  free (tmp_buffer);
 }
 
 static void
@@ -677,7 +677,7 @@ flip_buffer (guchar *buffer,
 		new_buffer[i * height + j] = buffer[j * width + i];
 	  }
 
-      g_free (buffer);
+      free (buffer);
 
       return new_buffer;
     }
@@ -789,7 +789,7 @@ make_shadow (MetaShadow     *shadow,
 
   cairo_region_destroy (row_convolve_region);
   cairo_region_destroy (column_convolve_region);
-  g_free (buffer);
+  free (buffer);
 
   shadow->pipeline = meta_create_texture_pipeline (shadow->texture);
 }

--- a/src/compositor/meta-sync-ring.c
+++ b/src/compositor/meta-sync-ring.c
@@ -222,7 +222,7 @@ check_gl_extensions (void)
         g_strfreev (split);
 
         const char *extensions = meta_gl_get_string (GL_EXTENSIONS);
-        return version_ok && 
+        return version_ok &&
                (extensions != NULL &&
                 strstr (extensions, "GL_ARB_sync") != NULL &&
                 strstr (extensions, "GL_EXT_x11_sync_object") != NULL);
@@ -449,7 +449,7 @@ meta_sync_free (MetaSync *self)
   XSyncDestroyCounter (self->xdisplay, self->xcounter);
   XSyncDestroyAlarm (self->xdisplay, self->xalarm);
 
-  g_free (self);
+  free (self);
 }
 
 gboolean

--- a/src/compositor/meta-sync-ring.c
+++ b/src/compositor/meta-sync-ring.c
@@ -358,7 +358,7 @@ meta_sync_new (Display *xdisplay)
   MetaSync *self;
   XSyncAlarmAttributes attrs;
 
-  self = g_malloc0 (sizeof (MetaSync));
+  self = calloc (1, sizeof (MetaSync));
 
   self->xdisplay = xdisplay;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -567,7 +567,7 @@ meta_window_actor_dispose (GObject *object)
   g_clear_pointer (&priv->opaque_region, cairo_region_destroy);
   g_clear_pointer (&priv->shadow_clip, cairo_region_destroy);
 
-  g_clear_pointer (&priv->shadow_class, g_free);
+  g_clear_pointer (&priv->shadow_class, free);
   g_clear_pointer (&priv->focused_shadow, meta_shadow_unref);
   g_clear_pointer (&priv->unfocused_shadow, meta_shadow_unref);
   g_clear_pointer (&priv->shadow_shape, meta_window_shape_unref);
@@ -640,7 +640,7 @@ meta_window_actor_set_property (GObject      *object,
         if (g_strcmp0 (newv, priv->shadow_class) == 0)
           return;
 
-        g_free (priv->shadow_class);
+        free (priv->shadow_class);
         priv->shadow_class = g_strdup (newv);
 
         meta_window_actor_invalidate_shadow (self);

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -3170,7 +3170,7 @@ meta_window_actor_ensure_mask (MetaWindowActor *self,
       stride = cairo_format_stride_for_width (CAIRO_FORMAT_A8, tex_width);
 
       /* Create data for an empty image */
-      mask_data = g_malloc0 (stride * tex_height);
+      mask_data = calloc (1, stride * tex_height);
 
       /* Fill in each rectangle. */
       for (i = 0; i < n_rects; i ++)
@@ -3207,7 +3207,7 @@ meta_window_actor_ensure_mask (MetaWindowActor *self,
                                                                       stride,
                                                                       mask_data);
 
-      g_free (mask_data);
+      free (mask_data);
     }
 }
 

--- a/src/compositor/meta-window-shape.c
+++ b/src/compositor/meta-window-shape.c
@@ -176,7 +176,7 @@ meta_window_shape_unref (MetaWindowShape *shape)
   shape->ref_count--;
   if (shape->ref_count == 0)
     {
-      g_free (shape->rectangles);
+      free (shape->rectangles);
       g_slice_free (MetaWindowShape, shape);
     }
 }

--- a/src/compositor/plugins/default.c
+++ b/src/compositor/plugins/default.c
@@ -430,7 +430,7 @@ on_minimize_effect_complete (ClutterTimeline *timeline, EffectCompleteData *data
   /* Now notify the manager that we are done with this effect */
   meta_plugin_minimize_completed (plugin, window_actor);
 
-  g_free (data);
+  free (data);
 }
 
 /*
@@ -509,7 +509,7 @@ on_maximize_effect_complete (ClutterTimeline *timeline, EffectCompleteData *data
   /* Now notify the manager that we are done with this effect */
   meta_plugin_maximize_completed (plugin, window_actor);
 
-  g_free (data);
+  free (data);
 }
 
 /*
@@ -623,7 +623,7 @@ on_map_effect_complete (ClutterTimeline *timeline, EffectCompleteData *data)
   /* Now notify the manager that we are done with this effect */
   meta_plugin_map_completed (plugin, window_actor);
 
-  g_free (data);
+  free (data);
 }
 
 /*

--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -6,14 +6,14 @@
  * @short_description: Simple box operations
  */
 
-/* 
+/*
  * Copyright (C) 2005, 2006 Elijah Newren
  * [meta_rectangle_intersect() is copyright the GTK+ Team according to Havoc,
  * see gdkrectangle.c.  As far as Havoc knows, he probably wrote
  * meta_rectangle_equal(), and I'm guessing it's (C) Red Hat.  So...]
  * Copyright (C) 1995-2000  GTK+ Team
  * Copyright (C) 2002 Red Hat, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -23,7 +23,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -39,7 +39,7 @@
 
 /* It would make sense to use GSlice here, but until we clean up the
  * rest of this file and the internal API to use these functions, we
- * leave it using g_malloc()/g_free() for consistency.
+ * leave it using g_malloc()/free() for consistency.
  */
 
 MetaRectangle *
@@ -51,7 +51,7 @@ meta_rectangle_copy (const MetaRectangle *rect)
 void
 meta_rectangle_free (MetaRectangle *rect)
 {
-  g_free (rect);
+  free (rect);
 }
 
 GType
@@ -74,7 +74,7 @@ meta_rectangle_to_string (const MetaRectangle *rect,
    * Should be more than enough space.  Note that of this space, the
    * trailing \0 will be overwritten for all but the last rectangle.
    */
-  g_snprintf (output, RECT_LENGTH, "%d,%d +%d,%d", 
+  g_snprintf (output, RECT_LENGTH, "%d,%d +%d,%d",
               rect->x, rect->y, rect->width, rect->height);
 
   return output;
@@ -101,7 +101,7 @@ meta_rectangle_region_to_string (GList      *region,
   while (tmp)
     {
       MetaRectangle *rect = tmp->data;
-      g_snprintf (rect_string, RECT_LENGTH, "[%d,%d +%d,%d]", 
+      g_snprintf (rect_string, RECT_LENGTH, "[%d,%d +%d,%d]",
                   rect->x, rect->y, rect->width, rect->height);
       cur = g_stpcpy (cur, rect_string);
       tmp = tmp->next;
@@ -123,7 +123,7 @@ meta_rectangle_edge_to_string (const MetaEdge *edge,
    * Plus 2 for parenthesis, 4 for 2 more numbers, 2 more commas, and
    * 2 more spaces, for a total of 10 more.
    */
-  g_snprintf (output, EDGE_LENGTH, "[%d,%d +%d,%d], %2d, %2d", 
+  g_snprintf (output, EDGE_LENGTH, "[%d,%d +%d,%d], %2d, %2d",
               edge->rect.x, edge->rect.y, edge->rect.width, edge->rect.height,
               edge->side_type, edge->edge_type);
 
@@ -155,7 +155,7 @@ meta_rectangle_edge_list_to_string (GList      *edge_list,
     {
       MetaEdge      *edge = tmp->data;
       MetaRectangle *rect = &edge->rect;
-      g_snprintf (rect_string, EDGE_LENGTH, "([%d,%d +%d,%d], %2d, %2d)", 
+      g_snprintf (rect_string, EDGE_LENGTH, "([%d,%d +%d,%d], %2d, %2d)",
                   rect->x, rect->y, rect->width, rect->height,
                   edge->side_type, edge->edge_type);
       cur = g_stpcpy (cur, rect_string);
@@ -215,7 +215,7 @@ meta_rectangle_intersect (const MetaRectangle *src1,
   dest_y = MAX (src1->y, src2->y);
   dest_w = MIN (src1->x + src1->width, src2->x + src2->width) - dest_x;
   dest_h = MIN (src1->y + src1->height, src2->y + src2->height) - dest_y;
-  
+
   if (dest_w > 0 && dest_h > 0)
     {
       dest->x = dest_x;
@@ -325,7 +325,7 @@ gboolean
 meta_rectangle_contains_rect  (const MetaRectangle *outer_rect,
                                const MetaRectangle *inner_rect)
 {
-  return 
+  return
     inner_rect->x                      >= outer_rect->x &&
     inner_rect->y                      >= outer_rect->y &&
     inner_rect->x + inner_rect->width  <= outer_rect->x + outer_rect->width &&
@@ -344,7 +344,7 @@ meta_rectangle_resize_with_gravity (const MetaRectangle *old_rect,
    * boxes.h has a good comment, but I'm not sure if the below info is also
    * helpful on top of that (or whether it has superfluous info).
    */
- 
+
   /* These formulas may look overly simplistic at first but you can work
    * everything out with a left_frame_with, right_frame_width,
    * border_width, and old and new client area widths (instead of old total
@@ -394,7 +394,7 @@ meta_rectangle_resize_with_gravity (const MetaRectangle *old_rect,
       break;
     }
   rect->width = new_width;
-  
+
   /* Next, the y direction */
   switch (gravity)
     {
@@ -526,7 +526,7 @@ merge_spanning_rects_in_region (GList *region)
                 }
 
               /* Okay, we can free it now */
-              g_free (delete_me->data);
+              free (delete_me->data);
               region = g_list_delete_link (region, delete_me);
             }
 
@@ -654,7 +654,7 @@ meta_rectangle_get_minimal_spanning_set_for_region (
 
   for (strut_iter = all_struts; strut_iter; strut_iter = strut_iter->next)
     {
-      GList *rect_iter; 
+      GList *rect_iter;
       MetaStrut *strut = (MetaStrut*)strut_iter->data;
       MetaRectangle *strut_rect = &strut->rect;
 
@@ -664,7 +664,7 @@ meta_rectangle_get_minimal_spanning_set_for_region (
       while (rect_iter)
         {
           MetaRectangle *rect = (MetaRectangle*) rect_iter->data;
-          
+
           if (!meta_rectangle_overlap (strut_rect, rect) ||
               !check_strut_align (strut, basic_rect))
             ret = g_list_prepend (ret, rect);
@@ -708,7 +708,7 @@ meta_rectangle_get_minimal_spanning_set_for_region (
                   temp_rect->y = new_y;
                   ret = g_list_prepend (ret, temp_rect);
                 }
-              g_free (rect);
+              free (rect);
             }
           rect_iter = rect_iter->next;
         }
@@ -949,7 +949,7 @@ meta_rectangle_expand_to_avoiding_struts (MetaRectangle       *rect,
    */
   g_assert ((direction == META_DIRECTION_HORIZONTAL) ^
             (direction == META_DIRECTION_VERTICAL  ));
- 
+
   if (direction == META_DIRECTION_HORIZONTAL)
     {
       rect->x      = expand_to->x;
@@ -961,12 +961,12 @@ meta_rectangle_expand_to_avoiding_struts (MetaRectangle       *rect,
       rect->height = expand_to->height;
     }
 
- 
+
   /* Run over all struts */
   for (strut_iter = all_struts; strut_iter; strut_iter = strut_iter->next)
     {
       MetaStrut *strut = (MetaStrut*) strut_iter->data;
- 
+
       /* Skip struts that don't overlap */
       if (!meta_rectangle_overlap (&strut->rect, rect))
         continue;
@@ -1007,8 +1007,8 @@ meta_rectangle_expand_to_avoiding_struts (MetaRectangle       *rect,
 LOCAL_SYMBOL void
 meta_rectangle_free_list_and_elements (GList *filled_list)
 {
-  g_list_foreach (filled_list, 
-                  (void (*)(gpointer,gpointer))&g_free, /* ew, for ugly */
+  g_list_foreach (filled_list,
+                  (void (*)(gpointer,gpointer))&free, /* ew, for ugly */
                   NULL);
   g_list_free (filled_list);
 }
@@ -1085,20 +1085,20 @@ meta_rectangle_clamp_to_fit_into_region (const GList         *spanning_rects,
     {
       MetaRectangle *compare_rect = temp->data;
       int            maximal_overlap_amount_for_compare;
-      
+
       /* If x is fixed and the entire width of rect doesn't fit in compare,
        * skip this rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_X) &&
-          (compare_rect->x > rect->x || 
+          (compare_rect->x > rect->x ||
            compare_rect->x + compare_rect->width < rect->x + rect->width))
         continue;
-        
+
       /* If y is fixed and the entire height of rect doesn't fit in compare,
        * skip this rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_Y) &&
-          (compare_rect->y > rect->y || 
+          (compare_rect->y > rect->y ||
            compare_rect->y + compare_rect->height < rect->y + rect->height))
         continue;
 
@@ -1155,20 +1155,20 @@ meta_rectangle_clip_to_region (const GList         *spanning_rects,
       MetaRectangle *compare_rect = temp->data;
       MetaRectangle  overlap;
       int            maximal_overlap_amount_for_compare;
-     
+
       /* If x is fixed and the entire width of rect doesn't fit in compare,
        * skip the rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_X) &&
-          (compare_rect->x > rect->x || 
+          (compare_rect->x > rect->x ||
            compare_rect->x + compare_rect->width < rect->x + rect->width))
         continue;
-        
+
       /* If y is fixed and the entire height of rect doesn't fit in compare,
        * skip the rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_Y) &&
-          (compare_rect->y > rect->y || 
+          (compare_rect->y > rect->y ||
            compare_rect->y + compare_rect->height < rect->y + rect->height))
         continue;
 
@@ -1228,26 +1228,26 @@ meta_rectangle_shove_into_region (const GList         *spanning_rects,
   /* First, find best rectangle from spanning_rects to which we will shove
    * rect into.
    */
-  
+
   for (temp = spanning_rects; temp; temp = temp->next)
     {
       MetaRectangle *compare_rect = temp->data;
       int            maximal_overlap_amount_for_compare;
       int            dist_to_compare;
-      
+
       /* If x is fixed and the entire width of rect doesn't fit in compare,
        * skip this rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_X) &&
-          (compare_rect->x > rect->x || 
+          (compare_rect->x > rect->x ||
            compare_rect->x + compare_rect->width < rect->x + rect->width))
         continue;
-        
+
       /* If y is fixed and the entire height of rect doesn't fit in compare,
        * skip this rectangle.
        */
       if ((fixed_directions & FIXED_DIRECTION_Y) &&
-          (compare_rect->y > rect->y || 
+          (compare_rect->y > rect->y ||
            compare_rect->y + compare_rect->height < rect->y + rect->height))
         continue;
 
@@ -1403,7 +1403,7 @@ meta_rectangle_edge_aligns (const MetaRectangle *rect, const MetaEdge *edge)
 }
 
 static GList*
-get_rect_minus_overlap (const GList   *rect_in_list, 
+get_rect_minus_overlap (const GList   *rect_in_list,
                         MetaRectangle *overlap)
 {
   MetaRectangle *temp;
@@ -1448,7 +1448,7 @@ get_rect_minus_overlap (const GList   *rect_in_list,
 }
 
 static GList*
-replace_rect_with_list (GList *old_element, 
+replace_rect_with_list (GList *old_element,
                         GList *new_list)
 {
   GList *ret;
@@ -1477,7 +1477,7 @@ replace_rect_with_list (GList *old_element,
     }
 
   /* Free the old_element and return the appropriate "next" point */
-  g_free (old_element->data);
+  free (old_element->data);
   g_list_free_1 (old_element);
   return ret;
 }
@@ -1505,7 +1505,7 @@ get_disjoint_strut_rect_list_in_region (const GSList        *old_struts,
       if (meta_rectangle_intersect (copy, region, copy))
         strut_rects = g_list_prepend (strut_rects, copy);
       else
-        g_free (copy);
+        free (copy);
 
       old_struts = old_struts->next;
     }
@@ -1660,7 +1660,7 @@ rectangle_and_edge_intersection (const MetaRectangle *rect,
   overlap->edge_type = -1;
   overlap->side_type = -1;
 
-  /* Figure out what the intersection is */  
+  /* Figure out what the intersection is */
   result->x = MAX (rect->x, rect2->x);
   result->y = MAX (rect->y, rect2->y);
   result->width  = MIN (BOX_RIGHT (*rect),  BOX_RIGHT (*rect2))  - result->x;
@@ -1731,7 +1731,7 @@ rectangle_and_edge_intersection (const MetaRectangle *rect,
  * TOP<->BOTTOM).
  */
 static GList*
-add_edges (GList               *cur_edges, 
+add_edges (GList               *cur_edges,
            const MetaRectangle *rect,
            gboolean             rect_is_internal)
 {
@@ -1745,23 +1745,23 @@ add_edges (GList               *cur_edges,
       switch (i)
         {
         case 0:
-          temp_edge->side_type = 
+          temp_edge->side_type =
             rect_is_internal ? META_SIDE_LEFT : META_SIDE_RIGHT;
           temp_edge->rect.width = 0;
           break;
         case 1:
-          temp_edge->side_type = 
+          temp_edge->side_type =
             rect_is_internal ? META_SIDE_RIGHT : META_SIDE_LEFT;
           temp_edge->rect.x     += temp_edge->rect.width;
           temp_edge->rect.width  = 0;
           break;
         case 2:
-          temp_edge->side_type = 
+          temp_edge->side_type =
             rect_is_internal ? META_SIDE_TOP : META_SIDE_BOTTOM;
           temp_edge->rect.height = 0;
           break;
         case 3:
-          temp_edge->side_type = 
+          temp_edge->side_type =
             rect_is_internal ? META_SIDE_BOTTOM : META_SIDE_TOP;
           temp_edge->rect.y      += temp_edge->rect.height;
           temp_edge->rect.height  = 0;
@@ -1778,8 +1778,8 @@ add_edges (GList               *cur_edges,
  * edges to cur_list.  Return cur_list when finished.
  */
 static GList*
-split_edge (GList *cur_list, 
-            const MetaEdge *old_edge, 
+split_edge (GList *cur_list,
+            const MetaEdge *old_edge,
             const MetaEdge *remove)
 {
   MetaEdge *temp_edge;
@@ -1838,7 +1838,7 @@ split_edge (GList *cur_list,
  * if and how rect and edge intersect.
  */
 static void
-fix_up_edges (MetaRectangle *rect,         MetaEdge *edge, 
+fix_up_edges (MetaRectangle *rect,         MetaEdge *edge,
               GList         **strut_edges, GList    **edge_splits,
               gboolean      *edge_needs_removal)
 {
@@ -1873,7 +1873,7 @@ fix_up_edges (MetaRectangle *rect,         MetaEdge *edge,
 
               /* Delete the old one */
               tmp = tmp->next;
-              g_free (cur);
+              free (cur);
               *strut_edges = g_list_delete_link (*strut_edges, delete_me);
             }
           else
@@ -1936,7 +1936,7 @@ meta_rectangle_remove_intersections_with_boxes_from_edges (
                   edges = split_edge (edges, edge, &overlap);
 
                   /* Now free the edge... */
-                  g_free (edge);
+                  free (edge);
                   edges = g_list_delete_link (edges, delete_me);
                 }
             }
@@ -1962,7 +1962,7 @@ meta_rectangle_find_onscreen_edges (const MetaRectangle *basic_rect,
 {
   GList        *ret;
   GList        *fixed_strut_rects;
-  GList        *edge_iter; 
+  GList        *edge_iter;
   const GList  *strut_rect_iter;
 
   /* The algorithm is basically as follows:
@@ -2002,7 +2002,7 @@ meta_rectangle_find_onscreen_edges (const MetaRectangle *basic_rect,
           GList *splits_of_cur_edge = NULL;
           gboolean edge_needs_removal = FALSE;
 
-          fix_up_edges (strut_rect,       cur_edge, 
+          fix_up_edges (strut_rect,       cur_edge,
                         &new_strut_edges, &splits_of_cur_edge,
                         &edge_needs_removal);
 
@@ -2011,7 +2011,7 @@ meta_rectangle_find_onscreen_edges (const MetaRectangle *basic_rect,
               /* Delete the old edge */
               GList *delete_me = edge_iter;
               edge_iter = edge_iter->next;
-              g_free (cur_edge);
+              free (cur_edge);
               ret = g_list_delete_link (ret, delete_me);
 
               /* Add the new split parts of the edge */
@@ -2166,7 +2166,7 @@ meta_rectangle_find_nonintersected_monitor_edges (
   for (; all_struts; all_struts = all_struts->next)
     temp_rects = g_slist_prepend (temp_rects,
                                   &((MetaStrut*)all_struts->data)->rect);
-  ret = meta_rectangle_remove_intersections_with_boxes_from_edges (ret, 
+  ret = meta_rectangle_remove_intersections_with_boxes_from_edges (ret,
                                                                    temp_rects);
   g_slist_free (temp_rects);
 

--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -39,7 +39,7 @@
 
 /* It would make sense to use GSlice here, but until we clean up the
  * rest of this file and the internal API to use these functions, we
- * leave it using g_malloc()/free() for consistency.
+ * leave it using malloc()/free() for consistency.
  */
 
 MetaRectangle *

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -44,7 +44,7 @@
  //      "constrain_whatever".
  //   3) Add your function to the all_constraints and all_constraint_names
  //      arrays (the latter of which is for debugging purposes)
- // 
+ //
  // An example constraint function, constrain_whatever:
  //
  // /* constrain_whatever does the following:
@@ -257,7 +257,7 @@ do_all_constraints (MetaWindow         *window,
           /* Log how the constraint modified the position */
           meta_topic (META_DEBUG_GEOMETRY,
                       "info->current is %d,%d +%d,%d after %s\n",
-                      info->current.x, info->current.y, 
+                      info->current.x, info->current.y,
                       info->current.width, info->current.height,
                       constraint->name);
         }
@@ -299,7 +299,7 @@ meta_window_constrain (MetaWindow          *window,
               new->x,  new->y,  new->width,  new->height);
 
   setup_constraint_info (&info,
-                         window, 
+                         window,
                          orig_borders,
                          flags,
                          resize_gravity,
@@ -313,7 +313,7 @@ meta_window_constrain (MetaWindow          *window,
     /* Individually enforce all the high-enough priority constraints */
     do_all_constraints (window, &info, priority, !check_only);
 
-    /* Check if all high-enough priority constraints are simultaneously 
+    /* Check if all high-enough priority constraints are simultaneously
      * satisfied
      */
     satisfied = do_all_constraints (window, &info, priority, check_only);
@@ -336,7 +336,7 @@ meta_window_constrain (MetaWindow          *window,
    * smart pointers would be so much nicer here.  *shrug*
    */
   if (info.must_free_borders)
-    g_free (info.borders);
+    free (info.borders);
 }
 
 static void
@@ -436,10 +436,10 @@ setup_constraint_info (ConstraintInfo      *info,
     }
 
   cur_workspace = window->screen->active_workspace;
-  info->usable_screen_region   = 
+  info->usable_screen_region   =
     meta_workspace_get_onscreen_region (cur_workspace);
-  info->usable_monitor_region = 
-    meta_workspace_get_onmonitor_region (cur_workspace, 
+  info->usable_monitor_region =
+    meta_workspace_get_onmonitor_region (cur_workspace,
                                          monitor_info->number);
 
   /* Log all this information for debugging */
@@ -454,7 +454,7 @@ setup_constraint_info (ConstraintInfo      *info,
               "  work_area_monitor: %d,%d +%d,%d\n"
               "  entire_monitor   : %d,%d +%d,%d\n",
               info->orig.x, info->orig.y, info->orig.width, info->orig.height,
-              info->current.x, info->current.y, 
+              info->current.x, info->current.y,
                 info->current.width, info->current.height,
               (info->action_type == ACTION_MOVE) ? "Move" :
                 (info->action_type == ACTION_RESIZE) ? "Resize" :
@@ -467,7 +467,7 @@ setup_constraint_info (ConstraintInfo      *info,
                 (info->fixed_directions == FIXED_DIRECTION_Y) ? "Y fixed" :
                 "Freakin' Invalid Stupid",
               info->work_area_monitor.x, info->work_area_monitor.y,
-                info->work_area_monitor.width, 
+                info->work_area_monitor.width,
                 info->work_area_monitor.height,
               info->entire_monitor.x, info->entire_monitor.y,
                 info->entire_monitor.width, info->entire_monitor.height);
@@ -510,8 +510,8 @@ place_window_if_needed(MetaWindow     *window,
                                              monitor_info->number,
                                              &info->work_area_monitor);
       cur_workspace = window->screen->active_workspace;
-      info->usable_monitor_region = 
-        meta_workspace_get_onmonitor_region (cur_workspace, 
+      info->usable_monitor_region =
+        meta_workspace_get_onmonitor_region (cur_workspace,
                                              monitor_info->number);
 
 
@@ -553,7 +553,7 @@ place_window_if_needed(MetaWindow     *window,
 
           if (window->maximize_horizontally_after_placement ||
               window->maximize_vertically_after_placement)
-            meta_window_maximize_internal (window,   
+            meta_window_maximize_internal (window,
                 (window->maximize_horizontally_after_placement ?
                  META_MAXIMIZE_HORIZONTAL : 0 ) |
                 (window->maximize_vertically_after_placement ?
@@ -680,7 +680,7 @@ update_onscreen_requirements (MetaWindow     *window,
   if (old ^ window->require_on_single_monitor)
     meta_topic (META_DEBUG_GEOMETRY,
                 "require_on_single_monitor for %s toggled to %s\n",
-                window->desc, 
+                window->desc,
                 window->require_on_single_monitor ? "TRUE" : "FALSE");
 
   /* Update whether we want future constraint runs to require the
@@ -1096,7 +1096,7 @@ constrain_size_increments (MetaWindow         *window,
     return TRUE;
 
   /* Determine whether constraint applies; exit if it doesn't */
-  if (META_WINDOW_MAXIMIZED (window) || window->fullscreen || 
+  if (META_WINDOW_MAXIMIZED (window) || window->fullscreen ||
       META_WINDOW_TILED_OR_SNAPPED (window) ||
       info->action_type == ACTION_MOVE ||
       window->resizing_tile_type != META_WINDOW_TILE_TYPE_NONE)
@@ -1115,7 +1115,7 @@ constrain_size_increments (MetaWindow         *window,
   if (window->maximized_vertically)
     extra_height *= 0;
   /* constraint is satisfied iff there is no extra height or width */
-  constraint_already_satisfied = 
+  constraint_already_satisfied =
     (extra_height == 0 && extra_width == 0);
 
   if (check_only || constraint_already_satisfied)
@@ -1141,10 +1141,10 @@ constrain_size_increments (MetaWindow         *window,
     start_rect = &info->current;
   else
     start_rect = &info->orig;
-    
+
   /* Resize to the new size */
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1189,7 +1189,7 @@ constrain_size_limits (MetaWindow         *window,
   /*** Enforce constraint ***/
   new_width  = CLAMP (info->current.width,  min_size.width,  max_size.width);
   new_height = CLAMP (info->current.height, min_size.height, max_size.height);
-  
+
   /* Figure out what original rect to pass to meta_rectangle_resize_with_gravity
    * See bug 448183
    */
@@ -1197,9 +1197,9 @@ constrain_size_limits (MetaWindow         *window,
     start_rect = &info->current;
   else
     start_rect = &info->orig;
-  
+
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1229,7 +1229,7 @@ constrain_aspect_ratio (MetaWindow         *window,
          (double)window->size_hints.max_aspect.y;
   constraints_are_inconsistent = minr > maxr;
   if (constraints_are_inconsistent ||
-      META_WINDOW_MAXIMIZED (window) || window->fullscreen || 
+      META_WINDOW_MAXIMIZED (window) || window->fullscreen ||
       META_WINDOW_TILED_OR_SNAPPED (window) ||
       info->action_type == ACTION_MOVE)
     return TRUE;
@@ -1269,7 +1269,7 @@ constrain_aspect_ratio (MetaWindow         *window,
       fudge = 1;
       break;
     }
-  constraint_already_satisfied = 
+  constraint_already_satisfied =
     info->current.width - (info->current.height * minr ) > -minr*fudge &&
     info->current.width - (info->current.height * maxr ) <  maxr*fudge;
   if (check_only || constraint_already_satisfied)
@@ -1333,7 +1333,7 @@ constrain_aspect_ratio (MetaWindow         *window,
     start_rect = &info->orig;
 
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1382,7 +1382,7 @@ do_screen_and_monitor_relative_constraints (
     exit_early = TRUE;
 
   /* Determine whether constraint is already satisfied; exit if it is */
-  constraint_satisfied = 
+  constraint_satisfied =
     meta_rectangle_contained_in_region (region_spanning_rectangles,
                                         &info->current);
   if (exit_early || constraint_satisfied || check_only)
@@ -1427,7 +1427,7 @@ constrain_to_single_monitor (MetaWindow         *window,
     return TRUE;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut) and we can't apply it to frameless windows
    * or else users will be unable to move windows such as XMMS across monitors.
    */
@@ -1440,7 +1440,7 @@ constrain_to_single_monitor (MetaWindow         *window,
     return TRUE;
 
   /* Have a helper function handle the constraint for us */
-  return do_screen_and_monitor_relative_constraints (window, 
+  return do_screen_and_monitor_relative_constraints (window,
                                                      info->usable_monitor_region,
                                                      info,
                                                      check_only);
@@ -1459,19 +1459,19 @@ constrain_fully_onscreen (MetaWindow         *window,
 
   transient_for = meta_window_get_transient_for(window);
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
       window->type == META_WINDOW_DOCK    ||
       window->fullscreen                  ||
       (transient_for && transient_for->fullscreen)           ||
-      !window->require_fully_onscreen     || 
+      !window->require_fully_onscreen     ||
       info->is_user_action)
     return TRUE;
 
   /* Have a helper function handle the constraint for us */
-  return do_screen_and_monitor_relative_constraints (window, 
+  return do_screen_and_monitor_relative_constraints (window,
                                                      info->usable_screen_region,
                                                      info,
                                                      check_only);
@@ -1500,7 +1500,7 @@ constrain_titlebar_visible (MetaWindow         *window,
     info->is_user_action && !window->display->grab_frame_action;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
@@ -1546,13 +1546,13 @@ constrain_titlebar_visible (MetaWindow         *window,
    */
   meta_rectangle_expand_region_conditionally (info->usable_screen_region,
                                               horiz_amount_offscreen,
-                                              horiz_amount_offscreen, 
+                                              horiz_amount_offscreen,
                                               0, /* Don't let titlebar off */
                                               bottom_amount,
                                               horiz_amount_onscreen,
                                               vert_amount_onscreen);
   retval =
-    do_screen_and_monitor_relative_constraints (window, 
+    do_screen_and_monitor_relative_constraints (window,
                                                 info->usable_screen_region,
                                                 info,
                                                 check_only);
@@ -1582,7 +1582,7 @@ constrain_partially_onscreen (MetaWindow         *window,
     return TRUE;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
@@ -1626,13 +1626,13 @@ constrain_partially_onscreen (MetaWindow         *window,
    */
   meta_rectangle_expand_region_conditionally (info->usable_screen_region,
                                               horiz_amount_offscreen,
-                                              horiz_amount_offscreen, 
+                                              horiz_amount_offscreen,
                                               top_amount,
                                               bottom_amount,
                                               horiz_amount_onscreen,
                                               vert_amount_onscreen);
   retval =
-    do_screen_and_monitor_relative_constraints (window, 
+    do_screen_and_monitor_relative_constraints (window,
                                                 info->usable_screen_region,
                                                 info,
                                                 check_only);

--- a/src/core/delete.c
+++ b/src/core/delete.c
@@ -2,10 +2,10 @@
 
 /* Muffin window deletion */
 
-/* 
+/*
  * Copyright (C) 2001, 2002 Havoc Pennington
  * Copyright (C) 2004 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -77,7 +77,7 @@ delete_ping_timeout_func (MetaDisplay *display,
   char *window_title;
   gchar *window_content, *tmp;
   GPid dialog_pid;
-  
+
   meta_topic (META_DEBUG_PING,
               "Got delete ping timeout for %s\n",
               window->desc);
@@ -99,7 +99,7 @@ delete_ping_timeout_func (MetaDisplay *display,
         window_title = NULL;
       else
         window_title = window->title;
-      g_free (tmp);
+      free (tmp);
     }
   else
     {
@@ -116,7 +116,7 @@ delete_ping_timeout_func (MetaDisplay *display,
       tmp = g_strdup_printf (_("<tt>%s</tt> is not responding."),
                              unmarkup_title);
 
-      g_free (unmarkup_title);
+      free (unmarkup_title);
     }
   else
     tmp = g_strdup (_("Application is not responding."));
@@ -134,8 +134,8 @@ delete_ping_timeout_func (MetaDisplay *display,
                       _("_Wait"), _("_Force Quit"), window->xwindow,
                       NULL, NULL);
 
-  g_free (window_content);
-  g_free (tmp);
+  free (window_content);
+  free (tmp);
 
   window->dialog_pid = dialog_pid;
   g_child_watch_add (dialog_pid, dialog_exited, window);
@@ -171,10 +171,10 @@ meta_window_delete (MetaWindow  *window,
                             delete_ping_reply_func,
                             delete_ping_timeout_func,
                             window);
-  
+
   if (window->has_focus)
     {
-      /* FIXME Clean this up someday 
+      /* FIXME Clean this up someday
        * http://bugzilla.gnome.org/show_bug.cgi?id=108706
        */
 #if 0
@@ -246,7 +246,7 @@ meta_window_present_delete_dialog (MetaWindow *window, guint32 timestamp)
   meta_topic (META_DEBUG_PING,
               "Presenting existing ping dialog for %s\n",
               window->desc);
-  
+
   if (window->dialog_pid >= 0)
     {
       GSList *windows;
@@ -255,7 +255,7 @@ meta_window_present_delete_dialog (MetaWindow *window, guint32 timestamp)
       /* Activate transient for window that belongs to
        * muffin-dialog
        */
-      
+
       windows = meta_display_list_windows (window->display, META_LIST_DEFAULT);
       tmp = windows;
       while (tmp != NULL)
@@ -269,7 +269,7 @@ meta_window_present_delete_dialog (MetaWindow *window, guint32 timestamp)
               meta_window_activate (w, timestamp);
               break;
             }
-          
+
           tmp = tmp->next;
         }
 

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2,12 +2,12 @@
 
 /* Muffin X display handler */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003, 2004 Red Hat, Inc.
  * Copyright (C) 2003, 2004 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -17,7 +17,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -113,7 +113,7 @@
  *
  * \ingroup pings
  */
-typedef struct 
+typedef struct
 {
   MetaDisplay *display;
   Window       xwindow;
@@ -124,7 +124,7 @@ typedef struct
   guint        ping_timeout_id;
 } MetaPingData;
 
-typedef struct 
+typedef struct
 {
   MetaDisplay *display;
   Window xwindow;
@@ -356,7 +356,7 @@ ping_data_free (MetaPingData *ping_data)
     ping_data->ping_timeout_id = 0;
   }
 
-  g_free (ping_data);
+  free (ping_data);
 }
 
 /*
@@ -376,7 +376,7 @@ remove_pending_pings_for_window (MetaDisplay *display, Window xwindow)
   GSList *dead;
 
   /* could obviously be more efficient, don't care */
-  
+
   /* build list to be removed */
   dead = NULL;
   for (tmp = display->pending_pings; tmp; tmp = tmp->next)
@@ -445,11 +445,11 @@ enable_compositor (MetaDisplay *display,
 
   if (!display->compositor)
     return;
-  
+
   for (list = display->screens; list != NULL; list = list->next)
     {
       MetaScreen *screen = list->data;
-      
+
       meta_compositor_manage_screen (screen->display->compositor,
 				     screen);
 
@@ -493,11 +493,11 @@ meta_display_open (void)
 #undef item
   };
   Atom atoms[G_N_ELEMENTS(atom_names)];
-  
+
   meta_verbose ("Opening display '%s'\n", XDisplayName (NULL));
 
   xdisplay = meta_ui_get_display ();
-  
+
   if (xdisplay == NULL)
     {
       meta_warning (_("Failed to open X Window System display '%s'\n"),
@@ -507,12 +507,12 @@ meta_display_open (void)
 
   if (meta_is_syncing ())
     XSynchronize (xdisplay, True);
-  
+
   g_assert (the_display == NULL);
   the_display = g_object_new (META_TYPE_DISPLAY, NULL);
 
   the_display->closing = 0;
-  
+
   /* here we use XDisplayName which is what the user
    * probably put in, vs. DisplayString(display) which is
    * canonicalized by XOpenDisplay()
@@ -547,7 +547,7 @@ meta_display_open (void)
 
   /* FIXME copy the checks from GDK probably */
   the_display->static_gravity_works = g_getenv ("MUFFIN_USE_STATIC_GRAVITY") != NULL;
-  
+
   meta_bell_init (the_display);
 
   meta_display_init_keys (the_display);
@@ -562,7 +562,7 @@ meta_display_open (void)
   XInternAtoms (the_display->xdisplay, atom_names, G_N_ELEMENTS (atom_names),
                 False, atoms);
   {
-    int i = 0;    
+    int i = 0;
 #define item(x) the_display->atom_##x = atoms[i++];
 #include <meta/atomnames.h>
 #undef item
@@ -572,7 +572,7 @@ meta_display_open (void)
   meta_display_init_window_prop_hooks (the_display);
   the_display->group_prop_hooks = NULL;
   meta_display_init_group_prop_hooks (the_display);
-  
+
   /* Offscreen unmapped window used for _NET_SUPPORTING_WM_CHECK,
    * created in screen_new
    */
@@ -585,26 +585,26 @@ meta_display_open (void)
 
   the_display->window_with_menu = NULL;
   the_display->window_menu = NULL;
-  
+
   the_display->screens = NULL;
   the_display->active_screen = NULL;
-  
+
 #ifdef HAVE_STARTUP_NOTIFICATION
   the_display->sn_display = sn_display_new (the_display->xdisplay,
                                         sn_error_trap_push,
                                         sn_error_trap_pop);
 #endif
-  
+
   the_display->events = NULL;
 
   /* Get events */
   meta_ui_add_event_func (the_display->xdisplay,
                           event_callback,
                           the_display);
-  
+
   the_display->window_ids = g_hash_table_new (meta_unsigned_long_hash,
                                           meta_unsigned_long_equal);
-  
+
   i = 0;
   while (i < N_IGNORED_CROSSING_SERIALS)
     {
@@ -612,14 +612,14 @@ meta_display_open (void)
       ++i;
     }
   the_display->ungrab_should_not_cause_focus_window = None;
-  
+
   the_display->current_time = CurrentTime;
   the_display->sentinel_counter = 0;
 
   the_display->grab_resize_timeout_id = 0;
   the_display->grab_have_keyboard = FALSE;
-  
-#ifdef HAVE_XKB  
+
+#ifdef HAVE_XKB
   the_display->last_bell_time = 0;
 #endif
 
@@ -637,14 +637,14 @@ meta_display_open (void)
     int major, minor;
 
     the_display->have_xsync = FALSE;
-    
+
     the_display->xsync_error_base = 0;
     the_display->xsync_event_base = 0;
 
     /* I don't think we really have to fill these in */
     major = SYNC_MAJOR_VERSION;
     minor = SYNC_MINOR_VERSION;
-    
+
     if (!XSyncQueryExtension (the_display->xdisplay,
                               &the_display->xsync_event_base,
                               &the_display->xsync_error_base) ||
@@ -673,10 +673,10 @@ meta_display_open (void)
 #ifdef HAVE_SHAPE
   {
     the_display->have_shape = FALSE;
-    
+
     the_display->shape_error_base = 0;
     the_display->shape_event_base = 0;
-    
+
     if (!XShapeQueryExtension (the_display->xdisplay,
                                &the_display->shape_event_base,
                                &the_display->shape_error_base))
@@ -686,7 +686,7 @@ meta_display_open (void)
       }
     else
       the_display->have_shape = TRUE;
-    
+
     meta_verbose ("Attempted to init Shape, found error base %d event base %d\n",
                   the_display->shape_error_base,
                   the_display->shape_event_base);
@@ -697,10 +697,10 @@ meta_display_open (void)
 
   {
     the_display->have_render = FALSE;
-    
+
     the_display->render_error_base = 0;
     the_display->render_event_base = 0;
-    
+
     if (!XRenderQueryExtension (the_display->xdisplay,
                                 &the_display->render_event_base,
                                 &the_display->render_error_base))
@@ -710,7 +710,7 @@ meta_display_open (void)
       }
     else
       the_display->have_render = TRUE;
-    
+
     meta_verbose ("Attempted to init Render, found error base %d event base %d\n",
                   the_display->render_error_base,
                   the_display->render_event_base);
@@ -728,7 +728,7 @@ meta_display_open (void)
       {
         the_display->composite_error_base = 0;
         the_display->composite_event_base = 0;
-      } 
+      }
     else
       {
         the_display->composite_major_version = 0;
@@ -748,7 +748,7 @@ meta_display_open (void)
 
     meta_verbose ("Attempted to init Composite, found error base %d event base %d "
                   "extn ver %d %d\n",
-                  the_display->composite_error_base, 
+                  the_display->composite_error_base,
                   the_display->composite_event_base,
                   the_display->composite_major_version,
                   the_display->composite_minor_version);
@@ -764,12 +764,12 @@ meta_display_open (void)
       {
         the_display->damage_error_base = 0;
         the_display->damage_event_base = 0;
-      } 
+      }
     else
       the_display->have_damage = TRUE;
 
     meta_verbose ("Attempted to init Damage, found error base %d event base %d\n",
-                  the_display->damage_error_base, 
+                  the_display->damage_error_base,
                   the_display->damage_event_base);
 
     the_display->have_xfixes = FALSE;
@@ -783,15 +783,15 @@ meta_display_open (void)
       {
         the_display->xfixes_error_base = 0;
         the_display->xfixes_event_base = 0;
-      } 
+      }
     else
       the_display->have_xfixes = TRUE;
 
     meta_verbose ("Attempted to init XFixes, found error base %d event base %d\n",
-                  the_display->xfixes_error_base, 
+                  the_display->xfixes_error_base,
                   the_display->xfixes_event_base);
   }
-      
+
 #ifdef HAVE_XCURSOR
   {
     XcursorSetTheme (the_display->xdisplay, meta_prefs_get_cursor_theme ());
@@ -830,7 +830,7 @@ meta_display_open (void)
                                     the_display->leader_window,
                                     the_display->atom__GNOME_WM_KEYBINDINGS,
                                     "Muffin,Metacity");
-    
+
     meta_prop_set_utf8_string_hint (the_display,
                                     the_display->leader_window,
                                     the_display->atom__MUFFIN_VERSION,
@@ -873,7 +873,7 @@ meta_display_open (void)
   the_display->debug_button_grabs = g_getenv ("MUFFIN_DEBUG_BUTTON_GRABS") != NULL;
 
   screens = NULL;
-  
+
   i = 0;
   while (i < ScreenCount (xdisplay))
     {
@@ -885,9 +885,9 @@ meta_display_open (void)
         screens = g_slist_prepend (screens, screen);
       ++i;
     }
-  
+
   the_display->screens = screens;
-  
+
   if (screens == NULL)
     {
       /* This would typically happen because all the screens already
@@ -905,15 +905,15 @@ meta_display_open (void)
      faster with the call to meta_screen_manage_all_windows further down
      the code */
   enable_compositor (the_display, FALSE);
-   
+
   meta_display_grab (the_display);
-  
+
   /* Now manage all existing windows */
   tmp = the_display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-	
+
       meta_screen_manage_all_windows (screen);
 
       tmp = tmp->next;
@@ -1000,7 +1000,7 @@ meta_display_list_windows (MetaDisplay          *display,
       GSList *next;
 
       next = tmp->next;
-      
+
       if (next &&
           next->data == tmp->data)
         {
@@ -1011,7 +1011,7 @@ meta_display_list_windows (MetaDisplay          *display,
 
           if (tmp == winlist)
             winlist = next;
-          
+
           g_slist_free_1 (tmp);
 
           /* leave prev unchanged */
@@ -1020,7 +1020,7 @@ meta_display_list_windows (MetaDisplay          *display,
         {
           prev = tmp;
         }
-      
+
       tmp = next;
     }
 
@@ -1047,17 +1047,17 @@ meta_display_close (MetaDisplay *display,
   display->closing += 1;
 
   meta_prefs_remove_listener (prefs_changed_callback, display);
-  
+
   meta_display_remove_autoraise_callback (display);
 
   if (display->grab_old_window_stacking)
     g_list_free (display->grab_old_window_stacking);
-  
+
   /* Stop caring about events */
   meta_ui_remove_event_func (display->xdisplay,
                              event_callback,
                              display);
-  
+
   /* Free all screens */
   tmp = display->screens;
   while (tmp != NULL)
@@ -1077,7 +1077,7 @@ meta_display_close (MetaDisplay *display,
       display->sn_display = NULL;
     }
 #endif
-  
+
   /* Must be after all calls to meta_window_unmanage() since they
    * unregister windows
    */
@@ -1090,15 +1090,15 @@ meta_display_close (MetaDisplay *display,
 
   meta_display_free_window_prop_hooks (display);
   meta_display_free_group_prop_hooks (display);
-  
-  g_free (display->hostname);
-  g_free (display->name);
+
+  free (display->hostname);
+  free (display->name);
 
   meta_display_shutdown_keys (display);
 
   if (display->compositor)
     meta_compositor_destroy (display->compositor);
-  
+
   g_object_unref (display);
   the_display = NULL;
 
@@ -1139,7 +1139,7 @@ meta_display_screen_for_xwindow (MetaDisplay *display,
 {
   XWindowAttributes attr;
   int result;
-  
+
   meta_error_trap_push (display);
   attr.screen = NULL;
   result = XGetWindowAttributes (display->xdisplay, xwindow, &attr);
@@ -1151,7 +1151,7 @@ meta_display_screen_for_xwindow (MetaDisplay *display,
    */
   if (result == 0 || attr.screen == NULL)
     return NULL;
-  
+
   return meta_display_screen_for_x_screen (display, attr.screen);
 }
 
@@ -1193,7 +1193,7 @@ meta_display_ungrab (MetaDisplay *display)
 {
   if (display->server_grab_count == 0)
     meta_bug ("Ungrabbed non-grabbed server\n");
-  
+
   display->server_grab_count -= 1;
   if (display->server_grab_count == 0)
     {
@@ -1227,7 +1227,7 @@ meta_display_for_x_display (Display *xdisplay)
 
   meta_warning ("Could not find display for X display %p, probably going to crash\n",
                 xdisplay);
-  
+
   return NULL;
 }
 
@@ -1254,8 +1254,8 @@ grab_op_is_mouse_only (MetaGrabOp op)
     {
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1275,8 +1275,8 @@ grab_op_is_mouse (MetaGrabOp op)
     {
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1336,8 +1336,8 @@ meta_grab_op_is_resizing (MetaGrabOp op)
   switch (op)
     {
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1367,7 +1367,7 @@ meta_grab_op_is_moving (MetaGrabOp op)
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_KEYBOARD_MOVING:
       return TRUE;
-      
+
     default:
       return FALSE;
     }
@@ -1422,7 +1422,7 @@ guint32
 meta_display_get_current_time_roundtrip (MetaDisplay *display)
 {
   guint32 timestamp;
-  
+
   timestamp = meta_display_get_current_time (display);
   if (timestamp == CurrentTime)
     {
@@ -1480,7 +1480,7 @@ meta_display_add_ignored_crossing_serial (MetaDisplay  *display,
   /* don't add the same serial more than once */
   if (display->ignored_crossing_serials[N_IGNORED_CROSSING_SERIALS-1] == serial)
     return;
-  
+
   /* shift serials to the left */
   i = 0;
   while (i < (N_IGNORED_CROSSING_SERIALS - 1))
@@ -1523,7 +1523,7 @@ reset_ignored_crossing_serials (MetaDisplay *display)
   display->ungrab_should_not_cause_focus_window = None;
 }
 
-static gboolean 
+static gboolean
 window_raise_with_delay_callback (void *data)
 {
   MetaWindow *window;
@@ -1531,23 +1531,23 @@ window_raise_with_delay_callback (void *data)
 
   auto_raise = data;
 
-  meta_topic (META_DEBUG_FOCUS, 
-	      "In autoraise callback for window 0x%lx\n", 
+  meta_topic (META_DEBUG_FOCUS,
+	      "In autoraise callback for window 0x%lx\n",
 	      auto_raise->xwindow);
 
   auto_raise->display->autoraise_timeout_id = 0;
   auto_raise->display->autoraise_window = NULL;
 
-  window  = meta_display_lookup_x_window (auto_raise->display, 
+  window  = meta_display_lookup_x_window (auto_raise->display,
 					  auto_raise->xwindow);
-  
-  if (window == NULL) 
+
+  if (window == NULL)
     return FALSE;
 
   /* If we aren't already on top, check whether the pointer is inside
    * the window and raise the window if so.
-   */      
-  if (meta_stack_get_top (window->screen->stack) != window) 
+   */
+  if (meta_stack_get_top (window->screen->stack) != window)
     {
       int x, y, root_x, root_y;
       Window root, child;
@@ -1562,14 +1562,14 @@ window_raise_with_delay_callback (void *data)
 				   &root_x, &root_y, &x, &y, &mask);
       meta_error_trap_pop (window->display);
 
-      point_in_window = 
+      point_in_window =
         (window->frame && POINT_IN_RECT (root_x, root_y, window->frame->rect)) ||
         (window->frame == NULL && POINT_IN_RECT (root_x, root_y, window->rect));
       if (same_screen && point_in_window)
 	meta_window_raise (window);
       else
-	meta_topic (META_DEBUG_FOCUS, 
-		    "Pointer not inside window, not raising %s\n", 
+	meta_topic (META_DEBUG_FOCUS,
+		    "Pointer not inside window, not raising %s\n",
 		    window->desc);
     }
 
@@ -1582,26 +1582,26 @@ meta_display_queue_autoraise_callback (MetaDisplay *display,
 {
   MetaAutoRaiseData *auto_raise_data;
 
-  meta_topic (META_DEBUG_FOCUS, 
-              "Queuing an autoraise timeout for %s with delay %d\n", 
-              window->desc, 
+  meta_topic (META_DEBUG_FOCUS,
+              "Queuing an autoraise timeout for %s with delay %d\n",
+              window->desc,
               meta_prefs_get_auto_raise_delay ());
-  
+
   auto_raise_data = g_new (MetaAutoRaiseData, 1);
   auto_raise_data->display = window->display;
   auto_raise_data->xwindow = window->xwindow;
-  
+
   if (display->autoraise_timeout_id != 0) {
     g_source_remove (display->autoraise_timeout_id);
     display->autoraise_timeout_id = 0;
   }
 
-  display->autoraise_timeout_id = 
+  display->autoraise_timeout_id =
     g_timeout_add_full (G_PRIORITY_DEFAULT,
                         meta_prefs_get_auto_raise_delay (),
                         window_raise_with_delay_callback,
                         auto_raise_data,
-                        g_free);
+                        free);
   display->autoraise_window = window;
 }
 
@@ -1633,7 +1633,7 @@ event_callback (XEvent   *event,
   gboolean filter_out_event;
 
   display = data;
-  
+
 #ifdef WITH_VERBOSE_MODE
   if (dump_events)
     meta_spew_event (display, event);
@@ -1642,14 +1642,14 @@ event_callback (XEvent   *event,
 #ifdef HAVE_STARTUP_NOTIFICATION
   sn_display_process_event (display->sn_display, event);
 #endif
-  
+
   bypass_compositor = FALSE;
   filter_out_event = FALSE;
   display->current_time = event_get_time (display, event);
   display->monitor_cache_invalidated = TRUE;
-  
+
   modified = event_get_modified_window (display, event);
-  
+
   if (event->type == UnmapNotify)
     {
       if (meta_ui_window_should_not_cause_focus (display->xdisplay,
@@ -1686,7 +1686,7 @@ event_callback (XEvent   *event,
       property_for_window = window;
       window = NULL;
     }
-    
+
 
   frame_was_receiver = FALSE;
   if (window &&
@@ -1720,11 +1720,11 @@ event_callback (XEvent   *event,
 #endif /* HAVE_XSYNC */
 
 #ifdef HAVE_SHAPE
-  if (META_DISPLAY_HAS_SHAPE (display) && 
+  if (META_DISPLAY_HAS_SHAPE (display) &&
       event->type == (display->shape_event_base + ShapeNotify))
     {
       filter_out_event = TRUE; /* GTK doesn't want to see this really */
-      
+
       if (window && !frame_was_receiver)
         {
           XShapeEvent *sev = (XShapeEvent*) event;
@@ -1733,7 +1733,7 @@ event_callback (XEvent   *event,
             {
               if (sev->shaped && !window->has_shape)
                 {
-                  window->has_shape = TRUE;                  
+                  window->has_shape = TRUE;
                   meta_topic (META_DEBUG_SHAPES,
                               "Window %s now has a shape\n",
                               window->desc);
@@ -1785,7 +1785,7 @@ event_callback (XEvent   *event,
           sanity_check_timestamps (display, display->current_time);
         }
     }
-  
+
   switch (event->type)
     {
     case KeyPress:
@@ -1836,14 +1836,14 @@ event_callback (XEvent   *event,
                       "Ending grab op %u on window %s due to button press\n",
                       display->grab_op,
                       (display->grab_window ?
-                       display->grab_window->desc : 
+                       display->grab_window->desc :
                        "none"));
           if (GRAB_OP_IS_WINDOW_SWITCH (display->grab_op))
             {
               MetaScreen *screen;
-              meta_topic (META_DEBUG_WINDOW_OPS, 
+              meta_topic (META_DEBUG_WINDOW_OPS,
                           "Syncing to old stack positions.\n");
-              screen = 
+              screen =
                 meta_display_screen_for_root (display, event->xany.window);
 
               if (screen!=NULL)
@@ -1871,7 +1871,7 @@ event_callback (XEvent   *event,
            * button 1.  So for all such events we focus the window.
            */
           unmodified = (event->xbutton.state & grab_mask) == 0;
-          
+
           if (unmodified ||
               event->xbutton.button == 1)
             {
@@ -1905,7 +1905,7 @@ event_callback (XEvent   *event,
                      */
                     display->allow_terminal_deactivation = TRUE;
                 }
-              
+
               /* you can move on alt-click but not on
                * the click-to-focus
                */
@@ -1946,7 +1946,7 @@ event_callback (XEvent   *event,
                     op = META_GRAB_OP_RESIZING_S;
                   else /* Middle region is no-op to avoid user triggering wrong action */
                     op = META_GRAB_OP_NONE;
-                  
+
                   if (op != META_GRAB_OP_NONE)
                     meta_display_begin_grab_op (display,
                                                 window->screen,
@@ -1978,7 +1978,7 @@ event_callback (XEvent   *event,
                * it has no modifiers and was on the client window
                */
               int mode;
-              
+
               /* When clicking a different app in click-to-focus
                * in application-based mode, and the different
                * app is not a dock or desktop, eat the focus click.
@@ -1998,7 +1998,7 @@ event_callback (XEvent   *event,
               meta_verbose ("Allowing events mode %s time %u\n",
                             mode == AsyncPointer ? "AsyncPointer" : "ReplayPointer",
                             (unsigned int)event->xbutton.time);
-              
+
               XAllowEvents (display->xdisplay,
                             mode, event->xbutton.time);
             }
@@ -2051,11 +2051,11 @@ event_callback (XEvent   *event,
        * actually appear on the right screen.
        */
       {
-        MetaScreen *new_screen = 
+        MetaScreen *new_screen =
           meta_display_screen_for_root (display, event->xcrossing.root);
 
         if (new_screen != NULL && display->active_screen != new_screen)
-          meta_workspace_focus_default_window (new_screen->active_workspace, 
+          meta_workspace_focus_default_window (new_screen->active_workspace,
                                                NULL,
                                                event->xcrossing.time);
       }
@@ -2064,7 +2064,7 @@ event_callback (XEvent   *event,
        * avoid races.
        */
       if (window && !crossing_serial_is_ignored (display, event->xany.serial) &&
-               event->xcrossing.mode != NotifyGrab && 
+               event->xcrossing.mode != NotifyGrab &&
                event->xcrossing.mode != NotifyUngrab &&
                event->xcrossing.detail != NotifyInferior &&
                meta_display_focus_sentinel_clear (display))
@@ -2081,7 +2081,7 @@ event_callback (XEvent   *event,
                               "Focusing %s due to enter notify with serial %lu "
                               "at time %lu, and setting display->mouse_mode to "
                               "TRUE.\n",
-                              window->desc, 
+                              window->desc,
                               event->xany.serial,
                               event->xcrossing.time);
 
@@ -2089,15 +2089,15 @@ event_callback (XEvent   *event,
 
                   /* stop ignoring stuff */
                   reset_ignored_crossing_serials (display);
-                  
-                  if (meta_prefs_get_auto_raise ()) 
+
+                  if (meta_prefs_get_auto_raise ())
                     {
                       meta_display_queue_autoraise_callback (display, window);
                     }
                   else
                     {
                       meta_topic (META_DEBUG_FOCUS,
-                                  "Auto raise is disabled\n");		      
+                                  "Auto raise is disabled\n");
                     }
                 }
               /* In mouse focus mode, we defocus when the mouse *enters*
@@ -2117,7 +2117,7 @@ event_callback (XEvent   *event,
                               "Unsetting focus from %s due to mouse entering "
                               "the DESKTOP window\n",
                               display->expected_focus_window->desc);
-                  meta_display_focus_the_no_focus_window (display, 
+                  meta_display_focus_the_no_focus_window (display,
                                                           window->screen,
                                                           event->xcrossing.time);
                 }
@@ -2125,7 +2125,7 @@ event_callback (XEvent   *event,
             case C_DESKTOP_FOCUS_MODE_CLICK:
               break;
             }
-          
+
           if (window->type == META_WINDOW_DOCK)
             meta_window_raise (window);
         }
@@ -2182,11 +2182,11 @@ event_callback (XEvent   *event,
                       event->xany.window,
                       meta_event_mode_to_string (event->xfocus.mode),
                       meta_event_detail_to_string (event->xfocus.detail));
-          
+
           if (event->type == FocusIn &&
               event->xfocus.detail == NotifyDetailNone)
             {
-              meta_topic (META_DEBUG_FOCUS, 
+              meta_topic (META_DEBUG_FOCUS,
                           "Focus got set to None, probably due to "
                           "brain-damage in the X protocol (see bug "
                           "125492).  Setting the default focus window.\n");
@@ -2230,7 +2230,7 @@ event_callback (XEvent   *event,
                                            &event->xcreatewindow);
       }
       break;
-      
+
     case DestroyNotify:
       {
         MetaScreen *screen;
@@ -2253,7 +2253,7 @@ event_callback (XEvent   *event,
           if (display->grab_op != META_GRAB_OP_NONE &&
               display->grab_window == window)
             meta_display_end_grab_op (display, timestamp);
-          
+
           if (frame_was_receiver)
             {
               meta_warning ("Unexpected destruction of frame 0x%lx, not sure if this should silently fail or be considered a bug\n",
@@ -2284,7 +2284,7 @@ event_callback (XEvent   *event,
               display->grab_window == window &&
               window->frame == NULL)
             meta_display_end_grab_op (display, timestamp);
-      
+
           if (!frame_was_receiver)
             {
               if (window->unmaps_pending == 0)
@@ -2293,7 +2293,7 @@ event_callback (XEvent   *event,
                               "Window %s withdrawn\n",
                               window->desc);
 
-                  /* Unmanage withdrawn window */		  
+                  /* Unmanage withdrawn window */
                   window->withdrawn = TRUE;
                   meta_window_unmanage (window, timestamp);
                   window = NULL;
@@ -2332,7 +2332,7 @@ event_callback (XEvent   *event,
                                     FALSE);
         }
       /* if frame was receiver it's some malicious send event or something */
-      else if (!frame_was_receiver && window)        
+      else if (!frame_was_receiver && window)
         {
           meta_verbose ("MapRequest on %s mapped = %d minimized = %d\n",
                         window->desc, window->mapped, window->minimized);
@@ -2393,8 +2393,8 @@ event_callback (XEvent   *event,
 	      screen->xscreen->width   = event->xconfigure.width;
 	      screen->xscreen->height  = event->xconfigure.height;
 #endif
-	      
-	      meta_screen_resize (screen, 
+
+	      meta_screen_resize (screen,
 				  event->xconfigure.width,
 				  event->xconfigure.height);
 	    }
@@ -2412,7 +2412,7 @@ event_callback (XEvent   *event,
         {
           unsigned int xwcm;
           XWindowChanges xwc;
-          
+
           xwcm = event->xconfigurerequest.value_mask &
             (CWX | CWY | CWWidth | CWHeight | CWBorderWidth);
 
@@ -2447,7 +2447,7 @@ event_callback (XEvent   *event,
       {
         MetaGroup *group;
         MetaScreen *screen;
-        
+
         if (window && !frame_was_receiver)
           meta_window_property_notify (window, event);
         else if (property_for_window && !frame_was_receiver)
@@ -2457,13 +2457,13 @@ event_callback (XEvent   *event,
                                            event->xproperty.window);
         if (group != NULL)
           meta_group_property_notify (group, event);
-        
+
         screen = NULL;
         if (window == NULL &&
             group == NULL) /* window/group != NULL means it wasn't a root window */
           screen = meta_display_screen_for_root (display,
                                                  event->xproperty.window);
-            
+
         if (screen != NULL)
           {
             if (event->xproperty.atom ==
@@ -2526,7 +2526,7 @@ event_callback (XEvent   *event,
 
           screen = meta_display_screen_for_root (display,
                                                  event->xclient.window);
-          
+
           if (screen)
             {
               if (event->xclient.message_type ==
@@ -2535,10 +2535,10 @@ event_callback (XEvent   *event,
                   int space;
                   MetaWorkspace *workspace;
                   guint32 time;
-              
+
                   space = event->xclient.data.l[0];
                   time = event->xclient.data.l[1];
-              
+
                   meta_verbose ("Request to change current workspace to %d with "
                                 "specified timestamp of %u\n",
                                 space, time);
@@ -2565,9 +2565,9 @@ event_callback (XEvent   *event,
                        display->atom__NET_NUMBER_OF_DESKTOPS)
                 {
                   int num_spaces;
-              
+
                   num_spaces = event->xclient.data.l[0];
-              
+
                   meta_verbose ("Request to set number of workspaces to %d\n",
                                 num_spaces);
 
@@ -2578,13 +2578,13 @@ event_callback (XEvent   *event,
                 {
                   gboolean showing_desktop;
                   guint32  timestamp;
-                  
+
                   showing_desktop = event->xclient.data.l[0] != 0;
                   /* FIXME: Braindead protocol doesn't have a timestamp */
                   timestamp = meta_display_get_current_time_roundtrip (display);
                   meta_verbose ("Request to %s desktop\n",
                                 showing_desktop ? "show" : "hide");
-                  
+
                   if (showing_desktop)
                     meta_screen_show_desktop (screen, timestamp);
                   else
@@ -2615,10 +2615,10 @@ event_callback (XEvent   *event,
                   meta_set_verbose (!meta_is_verbose ());
                 }
 	      else if (event->xclient.message_type ==
-		       display->atom_WM_PROTOCOLS) 
+		       display->atom_WM_PROTOCOLS)
 		{
                   meta_verbose ("Received WM_PROTOCOLS message\n");
-                  
+
 		  if ((Atom)event->xclient.data.l[0] == display->atom__NET_WM_PING)
                     {
                       process_pong_message (display, event);
@@ -2645,7 +2645,7 @@ event_callback (XEvent   *event,
         gboolean ignore_current;
 
         ignore_current = FALSE;
-        
+
         /* Check whether the next event is an identical MappingNotify
          * event.  If it is, ignore the current event, we'll update
          * when we get the next one.
@@ -2653,9 +2653,9 @@ event_callback (XEvent   *event,
 	if (XPending (display->xdisplay))
           {
             XEvent next_event;
-            
+
             XPeekEvent (display->xdisplay, &next_event);
-            
+
             if (next_event.type == MappingNotify &&
                 next_event.xmapping.request == event->xmapping.request)
               ignore_current = TRUE;
@@ -2672,10 +2672,10 @@ event_callback (XEvent   *event,
       break;
     default:
 #ifdef HAVE_XKB
-      if (event->type == display->xkb_base_event_type) 
+      if (event->type == display->xkb_base_event_type)
 	{
 	  XkbAnyEvent *xkb_ev = (XkbAnyEvent *) event;
-	  
+
 	  switch (xkb_ev->xkb_type)
 	    {
 	    case XkbBellNotify:
@@ -2703,7 +2703,7 @@ event_callback (XEvent   *event,
                                          window))
         filter_out_event = TRUE;
     }
-  
+
   display->current_time = CurrentTime;
   return filter_out_event;
 }
@@ -2740,10 +2740,10 @@ event_get_modified_window (MetaDisplay *display,
     case EnterNotify:
     case LeaveNotify:
       return event->xany.window;
-      
+
     case CreateNotify:
       return event->xcreatewindow.window;
-      
+
     case DestroyNotify:
       return event->xdestroywindow.window;
 
@@ -2758,10 +2758,10 @@ event_get_modified_window (MetaDisplay *display,
 
     case ReparentNotify:
      return event->xreparent.window;
-      
+
     case ConfigureNotify:
       return event->xconfigure.window;
-      
+
     case ConfigureRequest:
       return event->xconfigurerequest.window;
 
@@ -2779,7 +2779,7 @@ event_get_modified_window (MetaDisplay *display,
 
     default:
 #ifdef HAVE_SHAPE
-      if (META_DISPLAY_HAS_SHAPE (display) && 
+      if (META_DISPLAY_HAS_SHAPE (display) &&
           event->type == (display->shape_event_base + ShapeNotify))
         {
           XShapeEvent *sev = (XShapeEvent*) event;
@@ -2800,11 +2800,11 @@ event_get_time (MetaDisplay *display,
     case KeyPress:
     case KeyRelease:
       return event->xkey.time;
-      
+
     case ButtonPress:
     case ButtonRelease:
       return event->xbutton.time;
-      
+
     case MotionNotify:
       return event->xmotion.time;
 
@@ -2822,7 +2822,7 @@ event_get_time (MetaDisplay *display,
 
     case FocusIn:
     case FocusOut:
-    case KeymapNotify:      
+    case KeymapNotify:
     case Expose:
     case GraphicsExpose:
     case NoExpose:
@@ -2931,7 +2931,7 @@ stack_mode_to_string (int mode)
     case BottomIf:
       return "BottomIf";
     case Opposite:
-      return "Opposite";      
+      return "Opposite";
     }
 
   return "Unknown";
@@ -2945,12 +2945,12 @@ key_event_description (Display *xdisplay,
 {
   KeySym keysym;
   const char *str;
-  
-  keysym = XkbKeycodeToKeysym (xdisplay, event->xkey.keycode, 0, 0);  
+
+  keysym = XkbKeycodeToKeysym (xdisplay, event->xkey.keycode, 0, 0);
 
   str = XKeysymToString (keysym);
-  
-  return g_strdup_printf ("Key '%s' state 0x%x", 
+
+  return g_strdup_printf ("Key '%s' state 0x%x",
                           str ? str : "none", event->xkey.state);
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -2964,7 +2964,7 @@ sync_value_to_64 (const XSyncValue *value)
 
   v = XSyncValueLow32 (*value);
   v |= (((gint64)XSyncValueHigh32 (*value)) << 32);
-  
+
   return v;
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -3001,12 +3001,12 @@ meta_spew_event (MetaDisplay *display,
 
   if (!meta_is_verbose())
     return;
-  
+
   /* filter overnumerous events */
   if (event->type == Expose || event->type == MotionNotify ||
       event->type == NoExpose)
     return;
-      
+
   switch (event->type)
     {
     case KeyPress:
@@ -3190,9 +3190,9 @@ meta_spew_event (MetaDisplay *display,
       {
         char *str;
         const char *state;
-            
+
         name = "PropertyNotify";
-            
+
         meta_error_trap_push (display);
         str = XGetAtomName (display->xdisplay,
                             event->xproperty.atom);
@@ -3204,7 +3204,7 @@ meta_spew_event (MetaDisplay *display,
           state = "PropertyDelete";
         else
           state = "???";
-            
+
         extra = g_strdup_printf ("atom: %s state: %s",
                                  str ? str : "(unknown atom)",
                                  state);
@@ -3242,11 +3242,11 @@ meta_spew_event (MetaDisplay *display,
       break;
     default:
 #ifdef HAVE_XSYNC
-      if (META_DISPLAY_HAS_XSYNC (display) && 
+      if (META_DISPLAY_HAS_XSYNC (display) &&
           event->type == (display->xsync_event_base + XSyncAlarmNotify))
         {
           XSyncAlarmNotifyEvent *aevent = (XSyncAlarmNotifyEvent*) event;
-          
+
           name = "XSyncAlarmNotify";
           extra =
             g_strdup_printf ("alarm: 0x%lx"
@@ -3262,7 +3262,7 @@ meta_spew_event (MetaDisplay *display,
       else
 #endif /* HAVE_XSYNC */
 #ifdef HAVE_SHAPE
-        if (META_DISPLAY_HAS_SHAPE (display) && 
+        if (META_DISPLAY_HAS_SHAPE (display) &&
             event->type == (display->shape_event_base + ShapeNotify))
           {
             XShapeEvent *sev = (XShapeEvent*) event;
@@ -3281,7 +3281,7 @@ meta_spew_event (MetaDisplay *display,
                                sev->shaped);
           }
         else
-#endif /* HAVE_SHAPE */      
+#endif /* HAVE_SHAPE */
         {
           name = "(Unknown event)";
           extra = g_strdup_printf ("type: %d", event->xany.type);
@@ -3290,22 +3290,22 @@ meta_spew_event (MetaDisplay *display,
     }
 
   screen = meta_display_screen_for_root (display, event->xany.window);
-      
+
   if (screen)
     winname = g_strdup_printf ("root %d", screen->number);
   else
     winname = g_strdup_printf ("0x%lx", event->xany.window);
-      
+
   meta_topic (META_DEBUG_EVENTS,
               "%s on %s%s %s %sserial %lu\n", name, winname,
               extra ? ":" : "", extra ? extra : "",
               event->xany.send_event ? "SEND " : "",
               event->xany.serial);
 
-  g_free (winname);
+  free (winname);
 
   if (extra)
-    g_free (extra);
+    free (extra);
 }
 #endif /* WITH_VERBOSE_MODE */
 
@@ -3322,7 +3322,7 @@ meta_display_register_x_window (MetaDisplay *display,
                                 MetaWindow  *window)
 {
   g_return_if_fail (g_hash_table_lookup (display->window_ids, xwindowp) == NULL);
-  
+
   g_hash_table_insert (display->window_ids, xwindowp, window);
 }
 
@@ -3414,13 +3414,13 @@ meta_display_create_x_cursor (MetaDisplay *display,
     case META_CURSOR_BUSY:
       glyph = XC_watch;
       break;
-      
+
     default:
       g_assert_not_reached ();
       glyph = 0; /* silence compiler */
       break;
     }
-  
+
   xcursor = XCreateFontCursor (display->xdisplay, glyph);
 
   return xcursor;
@@ -3431,7 +3431,7 @@ xcursor_for_op (MetaDisplay *display,
                 MetaGrabOp   op)
 {
   MetaCursor cursor = META_CURSOR_DEFAULT;
-  
+
   switch (op)
     {
     case META_GRAB_OP_RESIZING_SE:
@@ -3471,7 +3471,7 @@ xcursor_for_op (MetaDisplay *display,
     case META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN:
       cursor = META_CURSOR_MOVE_OR_RESIZE_WINDOW;
       break;
-      
+
     default:
       break;
     }
@@ -3545,7 +3545,7 @@ meta_display_set_grab_op_cursor (MetaDisplay *display,
     }
 
 #undef GRAB_MASK
-  
+
   if (cursor != None)
     XFreeCursor (display->xdisplay, cursor);
 }
@@ -3565,12 +3565,12 @@ meta_display_begin_grab_op (MetaDisplay *display,
 {
   MetaWindow *grab_window = NULL;
   Window grab_xwindow;
-  
+
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Doing grab op %u on window %s button %d pointer already grabbed: %d pointer pos %d,%d\n",
               op, window ? window->desc : "none", button, pointer_already_grabbed,
               root_x, root_y);
-  
+
   if (display->grab_op != META_GRAB_OP_NONE)
     {
       if (window)
@@ -3615,10 +3615,10 @@ meta_display_begin_grab_op (MetaDisplay *display,
     grab_xwindow = screen->xroot;
 
   display->grab_have_pointer = FALSE;
-  
+
   if (pointer_already_grabbed)
     display->grab_have_pointer = TRUE;
-  
+
   meta_display_set_grab_op_cursor (display, screen, op, FALSE, grab_xwindow,
                                    timestamp);
 
@@ -3639,7 +3639,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       else
         display->grab_have_keyboard =
                      meta_screen_grab_all_keys (screen, timestamp);
-      
+
       if (!display->grab_have_keyboard)
         {
           meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3649,7 +3649,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
           return FALSE;
         }
     }
-  
+
   display->grab_op = op;
   display->grab_window = grab_window;
   display->grab_screen = screen;
@@ -3685,7 +3685,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       g_source_remove (display->grab_resize_timeout_id);
       display->grab_resize_timeout_id = 0;
     }
-	
+
   if (display->grab_window)
     {
       meta_window_get_client_root_coords (display->grab_window,
@@ -3700,7 +3700,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
         }
 #endif
     }
-  
+
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Grab op %u on window %s successful\n",
               display->grab_op, window ? window->desc : "(null)");
@@ -3714,7 +3714,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_topic (META_DEBUG_WINDOW_OPS,
                   "Saving old stack positions; old pointer was %p.\n",
                   display->grab_old_window_stacking);
-      display->grab_old_window_stacking = 
+      display->grab_old_window_stacking =
         meta_stack_get_positions (screen->stack);
     }
 
@@ -3727,7 +3727,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
 
   g_signal_emit (display, display_signals[GRAB_OP_BEGIN], 0,
                  screen, display->grab_window, display->grab_op);
-  
+
   return TRUE;
 }
 
@@ -3782,7 +3782,7 @@ meta_display_end_grab_op (MetaDisplay *display,
 
   if (display->grab_window != NULL)
     display->grab_window->shaken_loose = FALSE;
-  
+
   if (display->grab_window != NULL &&
       !meta_prefs_get_raise_on_click () &&
       (meta_grab_op_is_moving (display->grab_op) ||
@@ -3806,9 +3806,9 @@ meta_display_end_grab_op (MetaDisplay *display,
        */
       display->ungrab_should_not_cause_focus_window = display->grab_xwindow;
     }
-  
+
   /* If this was a move or resize clear out the edge cache */
-  if (meta_grab_op_is_resizing (display->grab_op) || 
+  if (meta_grab_op_is_resizing (display->grab_op) ||
       meta_grab_op_is_moving (display->grab_op))
     {
       meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3916,9 +3916,9 @@ meta_change_button_grab (MetaDisplay *display,
                 grab ? "Grabbing" : "Ungrabbing",
                 xwindow,
                 sync, button, modmask);
-  
+
   meta_error_trap_push (display);
-  
+
   ignored_mask = 0;
   while (ignored_mask <= display->ignored_modifier_mask)
     {
@@ -3935,11 +3935,11 @@ meta_change_button_grab (MetaDisplay *display,
         meta_error_trap_push_with_return (display);
 
       /* GrabModeSync means freeze until XAllowEvents */
-      
+
       if (grab)
         XGrabButton (display->xdisplay, button, modmask | ignored_mask,
                      xwindow, False,
-                     ButtonPressMask | ButtonReleaseMask |    
+                     ButtonPressMask | ButtonReleaseMask |
                      PointerMotionMask | PointerMotionHintMask,
                      sync ? GrabModeSync : GrabModeAsync,
                      GrabModeAsync,
@@ -3951,15 +3951,15 @@ meta_change_button_grab (MetaDisplay *display,
       if (meta_is_debugging ())
         {
           int result;
-          
+
           result = meta_error_trap_pop_with_return (display);
-          
+
           if (result != Success)
             meta_verbose ("Failed to %s button %d with mask 0x%x for window 0x%lx error code %d\n",
                           grab ? "grab" : "ungrab",
                           button, modmask | ignored_mask, xwindow, result);
         }
-      
+
       ++ignored_mask;
     }
 
@@ -3969,7 +3969,7 @@ meta_change_button_grab (MetaDisplay *display,
 LOCAL_SYMBOL void
 meta_display_grab_window_buttons (MetaDisplay *display,
                                   Window       xwindow)
-{  
+{
   /* Grab Alt + button1 for moving window.
    * Grab Alt + button2 for resizing window.
    * Grab Alt + button3 for popping up window menu.
@@ -3978,7 +3978,7 @@ meta_display_grab_window_buttons (MetaDisplay *display,
    * Grab Alt + button5 for scrolling out
    */
   meta_verbose ("Grabbing window buttons for 0x%lx\n", xwindow);
-  
+
   /* FIXME If we ignored errors here instead of spewing, we could
    * put one big error trap around the loop and avoid a bunch of
    * XSync()
@@ -3993,8 +3993,8 @@ meta_display_grab_window_buttons (MetaDisplay *display,
           meta_change_button_grab (display, xwindow,
                                    TRUE,
                                    FALSE,
-                                   i, display->window_grab_modifiers);  
-          
+                                   i, display->window_grab_modifiers);
+
           /* This is for debugging, since I end up moving the Xnest
            * otherwise ;-)
            */
@@ -4056,11 +4056,11 @@ meta_display_ungrab_window_buttons  (MetaDisplay *display,
       meta_change_button_grab (display, xwindow,
                                FALSE, FALSE, i,
                                display->window_grab_modifiers);
-      
+
       if (debug)
         meta_change_button_grab (display, xwindow,
                                  FALSE, FALSE, i, ControlMask);
-      
+
       ++i;
     }
 
@@ -4105,18 +4105,18 @@ meta_display_grab_focus_window_button (MetaDisplay *display,
       return;
     }
 #endif
-  
+
   if (window->have_focus_click_grab)
     {
       meta_verbose (" (well, not grabbing since we already have the grab)\n");
       return;
     }
-  
+
   /* FIXME If we ignored errors here instead of spewing, we could
    * put one big error trap around the loop and avoid a bunch of
    * XSync()
    */
-  
+
   {
     int i = 1;
     while (i < MAX_FOCUS_BUTTON)
@@ -4125,7 +4125,7 @@ meta_display_grab_focus_window_button (MetaDisplay *display,
                                  window->xwindow,
                                  TRUE, TRUE,
                                  i, 0);
-        
+
         ++i;
       }
 
@@ -4141,14 +4141,14 @@ meta_display_ungrab_focus_window_button (MetaDisplay *display,
 
   if (!window->have_focus_click_grab)
     return;
-  
+
   {
     int i = 1;
     while (i < MAX_FOCUS_BUTTON)
       {
         meta_change_button_grab (display, window->xwindow,
                                  FALSE, FALSE, i, 0);
-        
+
         ++i;
       }
 
@@ -4168,7 +4168,7 @@ LOCAL_SYMBOL void
 meta_display_update_active_window_hint (MetaDisplay *display)
 {
   GSList *tmp;
-  
+
   gulong data[1];
 
   if (display->closing)
@@ -4178,12 +4178,12 @@ meta_display_update_active_window_hint (MetaDisplay *display)
     data[0] = display->focus_window->xwindow;
   else
     data[0] = None;
-  
+
   tmp = display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-      
+
       meta_error_trap_push (display);
       XChangeProperty (display->xdisplay, screen->xroot,
                        display->atom__NET_ACTIVE_WINDOW,
@@ -4207,14 +4207,14 @@ meta_display_queue_retheme_all_windows (MetaDisplay *display)
   while (tmp != NULL)
     {
       MetaWindow *window = tmp->data;
-      
+
       meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
       meta_window_frame_size_changed (window);
       if (window->frame)
         {
           meta_frame_queue_draw (window->frame);
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -4227,11 +4227,11 @@ meta_display_retheme_all (void)
   meta_display_queue_retheme_all_windows (meta_get_display ());
 }
 
-LOCAL_SYMBOL void 
-meta_display_set_cursor_theme (const char *theme, 
+LOCAL_SYMBOL void
+meta_display_set_cursor_theme (const char *theme,
 			       int         size)
 {
-#ifdef HAVE_XCURSOR     
+#ifdef HAVE_XCURSOR
   GSList *tmp;
 
   MetaDisplay *display = meta_get_display ();
@@ -4243,7 +4243,7 @@ meta_display_set_cursor_theme (const char *theme,
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-	  	  
+
       meta_screen_update_cursor (screen);
 
       tmp = tmp->next;
@@ -4324,7 +4324,7 @@ meta_display_ping_timeout (gpointer data)
   meta_topic (META_DEBUG_PING,
               "Ping %u on window %lx timed out\n",
               ping_data->timestamp, ping_data->xwindow);
-  
+
   (* ping_data->ping_timeout_func) (ping_data->display, ping_data->xwindow,
                                     ping_data->timestamp, ping_data->user_data);
 
@@ -4332,7 +4332,7 @@ meta_display_ping_timeout (gpointer data)
     g_slist_remove (ping_data->display->pending_pings,
                     ping_data);
   ping_data_free (ping_data);
-  
+
   return FALSE;
 }
 
@@ -4384,7 +4384,7 @@ meta_display_ping_window (MetaDisplay       *display,
 
       return;
     }
-  
+
   ping_data = g_new (MetaPingData, 1);
   ping_data->display = display;
   ping_data->xwindow = window->xwindow;
@@ -4395,7 +4395,7 @@ meta_display_ping_window (MetaDisplay       *display,
   ping_data->ping_timeout_id = g_timeout_add (PING_TIMEOUT_DELAY,
 					      meta_display_ping_timeout,
 					      ping_data);
-  
+
   display->pending_pings = g_slist_prepend (display->pending_pings, ping_data);
 
   meta_topic (META_DEBUG_PING,
@@ -4487,15 +4487,15 @@ process_pong_message (MetaDisplay    *display,
 
   meta_topic (META_DEBUG_PING, "Received a pong with timestamp %u\n",
               timestamp);
-  
+
   for (tmp = display->pending_pings; tmp; tmp = tmp->next)
     {
       MetaPingData *ping_data = tmp->data;
-			  
+
       if (timestamp == ping_data->timestamp)
         {
           meta_topic (META_DEBUG_PING,
-                      "Matching ping found for pong %u\n", 
+                      "Matching ping found for pong %u\n",
                       ping_data->timestamp);
 
           /* Remove the ping data from the list */
@@ -4508,13 +4508,13 @@ process_pong_message (MetaDisplay    *display,
               g_source_remove (ping_data->ping_timeout_id);
               ping_data->ping_timeout_id = 0;
             }
-          
+
           /* Call callback */
-          (* ping_data->ping_reply_func) (display, 
+          (* ping_data->ping_reply_func) (display,
                                           ping_data->xwindow,
-                                          ping_data->timestamp, 
+                                          ping_data->timestamp,
                                           ping_data->user_data);
-			      
+
           ping_data_free (ping_data);
 
           break;
@@ -4546,7 +4546,7 @@ meta_display_window_has_pending_pings (MetaDisplay *display,
     {
       MetaPingData *ping_data = tmp->data;
 
-      if (ping_data->xwindow == window->xwindow) 
+      if (ping_data->xwindow == window->xwindow)
         return TRUE;
     }
 
@@ -4570,7 +4570,7 @@ get_focussed_group (MetaDisplay *display)
 static MetaWindow*
 find_tab_forward (MetaDisplay   *display,
                   MetaTabList    type,
-                  MetaScreen    *screen, 
+                  MetaScreen    *screen,
                   MetaWorkspace *workspace,
                   GList         *start,
                   gboolean       skip_first)
@@ -4604,7 +4604,7 @@ find_tab_forward (MetaDisplay   *display,
         return window;
 
       tmp = tmp->next;
-    }  
+    }
 
   return NULL;
 }
@@ -4612,7 +4612,7 @@ find_tab_forward (MetaDisplay   *display,
 static MetaWindow*
 find_tab_backward (MetaDisplay   *display,
                    MetaTabList    type,
-                   MetaScreen    *screen, 
+                   MetaScreen    *screen,
                    MetaWorkspace *workspace,
                    GList         *start,
                    gboolean       skip_last)
@@ -4623,7 +4623,7 @@ find_tab_backward (MetaDisplay   *display,
   g_return_val_if_fail (workspace != NULL, NULL);
 
   tmp = start;
-  if (skip_last)  
+  if (skip_last)
     tmp = tmp->prev;
   while (tmp != NULL)
     {
@@ -4677,35 +4677,35 @@ meta_display_get_tab_list (MetaDisplay   *display,
    */
   {
     GList *tmp;
-    
+
     tab_list = NULL;
     tmp = workspace->mru_list;
     while (tmp != NULL)
       {
         MetaWindow *window = tmp->data;
-        
+
         if (!window->minimized &&
             window->screen == screen &&
             IN_TAB_CHAIN (window, type))
           tab_list = g_list_prepend (tab_list, window);
-        
+
         tmp = tmp->next;
       }
   }
 
   {
     GList *tmp;
-    
+
     tmp = workspace->mru_list;
     while (tmp != NULL)
       {
         MetaWindow *window = tmp->data;
-        
+
         if (window->minimized &&
             window->screen == screen &&
             IN_TAB_CHAIN (window, type))
           tab_list = g_list_prepend (tab_list, window);
-        
+
         tmp = tmp->next;
       }
   }
@@ -4725,9 +4725,9 @@ meta_display_get_tab_list (MetaDisplay   *display,
         l_window=tmp->data;
 
         /* Check to see if it demands attention */
-        if (l_window->wm_state_demands_attention && 
+        if (l_window->wm_state_demands_attention &&
             l_window->workspace!=workspace &&
-            IN_TAB_CHAIN (l_window, type)) 
+            IN_TAB_CHAIN (l_window, type))
           {
             /* if it does, add it to the popup */
             tab_list = g_list_prepend (tab_list, l_window);
@@ -4738,7 +4738,7 @@ meta_display_get_tab_list (MetaDisplay   *display,
 
     g_slist_free (windows);
   }
-  
+
   return tab_list;
 }
 
@@ -4748,8 +4748,8 @@ meta_display_get_tab_list (MetaDisplay   *display,
  * @type: type of tab list
  * @screen: a #MetaScreen
  * @workspace: origin workspace
- * @window: (allow-none): starting window 
- * @backward: If %TRUE, look for the previous window.  
+ * @window: (allow-none): starting window
+ * @backward: If %TRUE, look for the previous window.
  *
  * Determine the next window that should be displayed for Alt-TAB
  * functionality.
@@ -4775,11 +4775,11 @@ meta_display_get_tab_next (MetaDisplay   *display,
 
   if (tab_list == NULL)
     return NULL;
-  
+
   if (window != NULL)
     {
       g_assert (window->display == display);
-      
+
       if (backward)
         ret = find_tab_backward (display, type, screen, workspace,
                                  g_list_find (tab_list,
@@ -4793,7 +4793,7 @@ meta_display_get_tab_next (MetaDisplay   *display,
     }
   else
     {
-      skip = display->focus_window != NULL && 
+      skip = display->focus_window != NULL &&
              tab_list->data == display->focus_window;
       if (backward)
         ret = find_tab_backward (display, type, screen, workspace,
@@ -4828,7 +4828,7 @@ meta_display_get_tab_current (MetaDisplay   *display,
   MetaWindow *window;
 
   window = display->focus_window;
-  
+
   if (window != NULL &&
       window->screen == screen &&
       IN_TAB_CHAIN (window, type) &&
@@ -4843,7 +4843,7 @@ LOCAL_SYMBOL int
 meta_resize_gravity_from_grab_op (MetaGrabOp op)
 {
   int gravity;
-  
+
   gravity = -1;
   switch (op)
     {
@@ -4893,7 +4893,7 @@ LOCAL_SYMBOL int
 meta_resize_gravity_from_tile_mode (MetaTileMode mode)
 {
   int gravity;
-  
+
   gravity = -1;
   switch (mode)
     {
@@ -4935,18 +4935,18 @@ static MetaScreen*
 find_screen_for_selection (MetaDisplay *display,
                            Window       owner,
                            Atom         selection)
-{  
-  GSList *tmp;  
-  
+{
+  GSList *tmp;
+
   tmp = display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-      
+
       if (screen->wm_sn_selection_window == owner &&
           screen->wm_sn_atom == selection)
         return screen;
-  
+
       tmp = tmp->next;
     }
 
@@ -4988,7 +4988,7 @@ convert_property (MetaDisplay *display,
       meta_error_trap_pop_with_return (display);
       return FALSE;
     }
-  
+
   if (meta_error_trap_pop_with_return (display) != Success)
     return FALSE;
 
@@ -5017,20 +5017,20 @@ process_selection_request (MetaDisplay   *display,
   if (screen == NULL)
     {
       char *str;
-      
+
       meta_error_trap_push (display);
       str = XGetAtomName (display->xdisplay,
                           event->xselectionrequest.selection);
       meta_error_trap_pop (display);
-      
+
       meta_verbose ("Selection request with selection %s window 0x%lx not a WM_Sn selection we recognize\n",
                     str ? str : "(bad atom)", event->xselectionrequest.owner);
-      
+
       meta_XFree (str);
 
       return;
     }
-  
+
   reply.type = SelectionNotify;
   reply.display = display->xdisplay;
   reply.requestor = event->xselectionrequest.requestor;
@@ -5058,9 +5058,9 @@ process_selection_request (MetaDisplay   *display,
               meta_error_trap_pop_with_return (display);
               return;
             }
-          
+
           if (meta_error_trap_pop_with_return (display) == Success)
-            {              
+            {
               /* FIXME: to be 100% correct, should deal with rest > 0,
                * but since we have 4 possible targets, we will hardly ever
                * meet multiple requests with a length > 8
@@ -5091,7 +5091,7 @@ process_selection_request (MetaDisplay   *display,
     {
       if (event->xselectionrequest.property == None)
         event->xselectionrequest.property = event->xselectionrequest.target;
-      
+
       if (convert_property (display, screen,
                             event->xselectionrequest.requestor,
                             event->xselectionrequest.target,
@@ -5116,25 +5116,25 @@ process_selection_clear (MetaDisplay   *display,
   screen = find_screen_for_selection (display,
                                       event->xselectionclear.window,
                                       event->xselectionclear.selection);
-  
+
 
   if (screen != NULL)
     {
       meta_verbose ("Got selection clear for screen %d on display %s\n",
                     screen->number, display->name);
-      
-      meta_display_unmanage_screen (display, 
+
+      meta_display_unmanage_screen (display,
                                     screen,
                                     event->xselectionclear.time);
 
       /* display and screen may both be invalid memory... */
-      
+
       return;
     }
 
   {
     char *str;
-            
+
     meta_error_trap_push (display);
     str = XGetAtomName (display->xdisplay,
                         event->xselectionclear.selection);
@@ -5154,9 +5154,9 @@ meta_display_unmanage_screen (MetaDisplay *display,
 {
   meta_verbose ("Unmanaging screen %d on display %s\n",
                 screen->number, display->name);
-  
+
   g_return_if_fail (g_slist_find (display->screens, screen) != NULL);
-  
+
   meta_screen_free (screen, timestamp);
   display->screens = g_slist_remove (display->screens, screen);
 
@@ -5190,7 +5190,7 @@ meta_display_unmanage_windows_for_screen (MetaDisplay *display,
       if (!window->unmanaging)
         meta_window_unmanage (window, timestamp);
       g_object_unref (window);
-      
+
       tmp = tmp->next;
     }
   g_slist_free (winlist);
@@ -5248,7 +5248,7 @@ meta_display_devirtualize_modifiers (MetaDisplay        *display,
                                      unsigned int       *mask)
 {
   *mask = 0;
-  
+
   if (modifiers & META_VIRTUAL_SHIFT_MASK)
     *mask |= ShiftMask;
   if (modifiers & META_VIRTUAL_CONTROL_MASK)
@@ -5268,20 +5268,20 @@ meta_display_devirtualize_modifiers (MetaDisplay        *display,
   if (modifiers & META_VIRTUAL_MOD4_MASK)
     *mask |= Mod4Mask;
   if (modifiers & META_VIRTUAL_MOD5_MASK)
-    *mask |= Mod5Mask;  
+    *mask |= Mod5Mask;
 }
 
 static void
 update_window_grab_modifiers (MetaDisplay *display)
-     
+
 {
   MetaVirtualModifier virtual_mods;
   unsigned int mods;
-    
+
   virtual_mods = meta_prefs_get_mouse_button_mods ();
   meta_display_devirtualize_modifiers (display, virtual_mods,
                                        &mods);
-    
+
   display->window_grab_modifiers = mods;
 }
 
@@ -5314,9 +5314,9 @@ prefs_changed_callback (MetaPreference pref,
       MetaDisplay *display = data;
       GSList *windows;
       GSList *tmp;
-      
+
       windows = meta_display_list_windows (display, META_LIST_DEFAULT);
-      
+
       /* Ungrab all */
       tmp = windows;
       while (tmp != NULL)
@@ -5370,13 +5370,13 @@ meta_display_increment_focus_sentinel (MetaDisplay *display)
   unsigned long data[1];
 
   data[0] = meta_display_get_current_time (display);
-  
+
   XChangeProperty (display->xdisplay,
                    ((MetaScreen*) display->screens->data)->xroot,
                    display->atom__MUFFIN_SENTINEL,
                    XA_CARDINAL,
                    32, PropModeReplace, (guchar*) data, 1);
-  
+
   display->sentinel_counter += 1;
 }
 
@@ -5425,7 +5425,7 @@ sanity_check_timestamps (MetaDisplay *display,
       while (tmp != NULL)
         {
           MetaWindow *window = tmp->data;
-          
+
           if (XSERVER_TIME_IS_BEFORE (timestamp, window->net_wm_user_time))
             {
               meta_warning ("%s appears to be one of the offending windows "
@@ -5448,7 +5448,7 @@ timestamp_too_old (MetaDisplay *display,
 {
   /* FIXME: If Soeren's suggestion in bug 151984 is implemented, it will allow
    * us to sanity check the timestamp here and ensure it doesn't correspond to
-   * a future time (though we would want to rename to 
+   * a future time (though we would want to rename to
    * timestamp_too_old_or_in_future).
    */
 
@@ -5558,7 +5558,7 @@ meta_display_get_window_pointer (MetaDisplay  *display,
 }
 
 void
-meta_display_set_input_focus_window (MetaDisplay *display, 
+meta_display_set_input_focus_window (MetaDisplay *display,
                                      MetaWindow  *window,
                                      gboolean     focus_frame,
                                      guint32      timestamp)
@@ -5582,7 +5582,7 @@ meta_display_set_input_focus_window (MetaDisplay *display,
 }
 
 void
-meta_display_focus_the_no_focus_window (MetaDisplay *display, 
+meta_display_focus_the_no_focus_window (MetaDisplay *display,
                                         MetaScreen  *screen,
                                         guint32      timestamp)
 {
@@ -5676,7 +5676,7 @@ meta_display_get_focus_window (MetaDisplay *display)
   return display->focus_window;
 }
 
-int 
+int
 meta_display_get_damage_event_base (MetaDisplay *display)
 {
   return display->damage_event_base;
@@ -5759,7 +5759,7 @@ meta_display_restart_internal (MetaDisplay *display)
   execvp (arr->pdata[0], (char**)arr->pdata);
   g_warning ("Failed to reexec: %s", g_strerror (errno));
   g_ptr_array_free (arr, TRUE);
-  g_free (buf);
+  free (buf);
   return FALSE;
 }
 

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -2,9 +2,9 @@
 
 /* Edge resistance for move/resize operations */
 
-/* 
+/*
  * Copyright (C) 2005, 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -246,8 +246,8 @@ find_nearest_position (const GArray        *edges,
     {
       edge = g_array_index (edges, MetaEdge*, i);
       compare = horizontal ? edge->rect.x : edge->rect.y;
-  
-      edges_align = horizontal ? 
+
+      edges_align = horizontal ?
         meta_rectangle_vert_overlap (&edge->rect, new_rect) :
         meta_rectangle_horiz_overlap (&edge->rect, new_rect);
 
@@ -270,8 +270,8 @@ find_nearest_position (const GArray        *edges,
     {
       edge = g_array_index (edges, MetaEdge*, i);
       compare = horizontal ? edge->rect.x : edge->rect.y;
-  
-      edges_align = horizontal ? 
+
+      edges_align = horizontal ?
         meta_rectangle_vert_overlap (&edge->rect, new_rect) :
         meta_rectangle_horiz_overlap (&edge->rect, new_rect);
 
@@ -437,7 +437,7 @@ apply_edge_resistance (MetaWindow                *window,
               if (!resistance_data->timeout_setup &&
                   timeout_length_ms != 0)
                 {
-                  resistance_data->timeout_id = 
+                  resistance_data->timeout_id =
                     g_timeout_add (timeout_length_ms,
                                    edge_resistance_timeout,
                                    resistance_data);
@@ -538,7 +538,7 @@ apply_edge_snapping (int                  old_pos,
  * display->grab_edge_resistance_data MUST already be setup or calling this
  * function will cause a crash.
  */
-static gboolean 
+static gboolean
 apply_edge_resistance_to_each_side (MetaDisplay         *display,
                                     MetaWindow          *window,
                                     const MetaRectangle *old_outer,
@@ -660,7 +660,7 @@ apply_edge_resistance_to_each_side (MetaDisplay         *display,
     }
 
   /* Determine whether anything changed, and save the changes */
-  modified_rect = meta_rect (new_left, 
+  modified_rect = meta_rect (new_left,
                              new_top,
                              new_right - new_left,
                              new_bottom - new_top);
@@ -681,7 +681,7 @@ meta_display_cleanup_edges (MetaDisplay *display)
 
   /* We first need to clean out any window edges */
   edges_to_be_freed = g_hash_table_new_full (g_direct_hash, g_direct_equal,
-                                             g_free, NULL);
+                                             free, NULL);
   for (i = 0; i < 4; i++)
     {
       GArray *tmp = NULL;
@@ -724,7 +724,7 @@ meta_display_cleanup_edges (MetaDisplay *display)
         }
     }
 
-  /* Now free all the window edges (the key destroy function is g_free) */
+  /* Now free all the window edges (the key destroy function is free) */
   g_hash_table_destroy (edges_to_be_freed);
 
   /* Now free the arrays and data */
@@ -755,12 +755,12 @@ meta_display_cleanup_edges (MetaDisplay *display)
     edge_data->bottom_data.timeout_id = 0;
   }
 
-  g_free (display->grab_edge_resistance_data);
+  free (display->grab_edge_resistance_data);
   display->grab_edge_resistance_data = NULL;
 }
 
 static int
-stupid_sort_requiring_extra_pointer_dereference (gconstpointer a, 
+stupid_sort_requiring_extra_pointer_dereference (gconstpointer a,
                                                  gconstpointer b)
 {
   const MetaEdge * const *a_edge = a;
@@ -785,7 +785,7 @@ cache_edges (MetaDisplay *display,
 #ifdef WITH_VERBOSE_MODE
   if (meta_is_verbose())
     {
-      int max_edges = MAX (MAX( g_list_length (window_edges), 
+      int max_edges = MAX (MAX( g_list_length (window_edges),
                                 g_list_length (monitor_edges)),
                            g_list_length (screen_edges));
       char big_buffer[(EDGE_LENGTH+2)*max_edges];
@@ -922,13 +922,13 @@ cache_edges (MetaDisplay *display,
    * avoided this sort by sticking them into the array with some simple
    * merging of the lists).
    */
-  g_array_sort (display->grab_edge_resistance_data->left_edges, 
+  g_array_sort (display->grab_edge_resistance_data->left_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->right_edges, 
+  g_array_sort (display->grab_edge_resistance_data->right_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->top_edges, 
+  g_array_sort (display->grab_edge_resistance_data->top_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->bottom_edges, 
+  g_array_sort (display->grab_edge_resistance_data->bottom_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
 }
 
@@ -970,7 +970,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
   /*
    * 1st: Get the list of relevant windows, from bottom to top
    */
-  stacked_windows = 
+  stacked_windows =
     meta_stack_list_windows (display->grab_screen->stack,
                              display->grab_screen->active_workspace);
 
@@ -1084,7 +1084,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
           /* Update the remaining windows to only those at a higher
            * stacking position than this one.
            */
-          while (rem_win_stacking && 
+          while (rem_win_stacking &&
                  stack_position >= GPOINTER_TO_INT (rem_win_stacking->data))
             {
               rem_windows      = rem_windows->next;
@@ -1092,7 +1092,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
             }
 
           /* Remove edge portions overlapped by rem_windows and rem_docks */
-          new_edges = 
+          new_edges =
             meta_rectangle_remove_intersections_with_boxes_from_edges (
               new_edges,
               rem_windows);
@@ -1114,8 +1114,8 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
   /* FIXME: Shouldn't there be a helper function to make this one line of code
    * to free a list instead of four ugly ones?
    */
-  g_slist_foreach (obscuring_windows, 
-                   (void (*)(gpointer,gpointer))&g_free, /* ew, for ugly */
+  g_slist_foreach (obscuring_windows,
+                   (void (*)(gpointer,gpointer))&free, /* ew, for ugly */
                    NULL);
   g_slist_free (obscuring_windows);
 
@@ -1212,7 +1212,7 @@ meta_window_edge_resistance_for_move (MetaWindow  *window,
       else
         smaller_y_change = bottom_change;
 
-      *new_x = old_x + smaller_x_change + 
+      *new_x = old_x + smaller_x_change +
               (BOX_LEFT (*reference) - BOX_LEFT (old_outer));
       *new_y = old_y + smaller_y_change +
               (BOX_TOP (*reference) - BOX_TOP (old_outer));
@@ -1246,7 +1246,7 @@ meta_window_edge_resistance_for_resize (MetaWindow  *window,
   old_outer = window->outer_rect;
   proposed_outer_width  = old_outer.width  + (*new_width  - old_width);
   proposed_outer_height = old_outer.height + (*new_height - old_height);
-  meta_rectangle_resize_with_gravity (&old_outer, 
+  meta_rectangle_resize_with_gravity (&old_outer,
                                       &new_outer,
                                       gravity,
                                       proposed_outer_width,

--- a/src/core/eventqueue.c
+++ b/src/core/eventqueue.c
@@ -2,10 +2,10 @@
 
 /* Muffin X event source for main loop */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington (based on GDK code (C) Owen
  * Taylor, Red Hat Inc.)
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -61,7 +61,7 @@ meta_event_queue_new (Display *display, MetaEventQueueFunc func, gpointer data)
 
   source = g_source_new (&eq_funcs, sizeof (MetaEventQueue));
   eq = (MetaEventQueue*) source;
-  
+
   eq->connection_fd = ConnectionNumber (display);
   eq->poll_fd.fd = eq->connection_fd;
   eq->poll_fd.events = G_IO_IN;
@@ -69,13 +69,13 @@ meta_event_queue_new (Display *display, MetaEventQueueFunc func, gpointer data)
   eq->events = g_queue_new ();
 
   eq->display = display;
-  
+
   g_source_set_priority (source, G_PRIORITY_DEFAULT);
   g_source_add_poll (source, &eq->poll_fd);
   g_source_set_can_recurse (source, TRUE);
 
   g_source_set_callback (source, (GSourceFunc) func, data, NULL);
-  
+
   g_source_attach (source, NULL);
   g_source_unref (source);
 
@@ -88,7 +88,7 @@ meta_event_queue_free (MetaEventQueue *eq)
   GSource *source;
 
   source = (GSource*) eq;
-  
+
   g_source_destroy (source);
 }
 
@@ -106,7 +106,7 @@ eq_queue_events (MetaEventQueue *eq)
   while (XPending (eq->display))
     {
       XEvent *copy;
-      
+
       XNextEvent (eq->display, &xevent);
 
       copy = g_new (XEvent, 1);
@@ -116,20 +116,20 @@ eq_queue_events (MetaEventQueue *eq)
     }
 }
 
-static gboolean  
+static gboolean
 eq_prepare (GSource *source, gint *timeout)
 {
   MetaEventQueue *eq;
 
   eq = (MetaEventQueue*) source;
-  
+
   *timeout = -1;
 
   return eq_events_pending (eq);
 }
 
-static gboolean  
-eq_check (GSource  *source) 
+static gboolean
+eq_check (GSource  *source)
 {
   MetaEventQueue *eq;
 
@@ -141,13 +141,13 @@ eq_check (GSource  *source)
     return FALSE;
 }
 
-static gboolean  
+static gboolean
 eq_dispatch (GSource *source, GSourceFunc callback, gpointer user_data)
 {
   MetaEventQueue *eq;
 
   eq = (MetaEventQueue*) source;
-  
+
   eq_queue_events (eq);
 
   if (eq->events->length > 0)
@@ -157,12 +157,12 @@ eq_dispatch (GSource *source, GSourceFunc callback, gpointer user_data)
 
       event = g_queue_pop_head (eq->events);
       func = (MetaEventQueueFunc) callback;
-      
+
       (* func) (event, user_data);
 
-      g_free (event);
+      free (event);
     }
-  
+
   return TRUE;
 }
 
@@ -176,10 +176,10 @@ eq_destroy (GSource *source)
   while (eq->events->length > 0)
     {
       XEvent *event;
-      
+
       event = g_queue_pop_head (eq->events);
 
-      g_free (event);
+      free (event);
     }
 
   g_queue_free (eq->events);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -2,11 +2,11 @@
 
 /* Muffin X window decorations */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003, 2004 Red Hat, Inc.
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -46,13 +46,13 @@ meta_window_ensure_frame (MetaWindow *window)
   XSetWindowAttributes attrs;
   Visual *visual;
   gulong create_serial;
-  
+
   if (window->frame)
     return;
-  
+
   /* See comment below for why this is required. */
   meta_display_grab (window->display);
-  
+
   frame = g_new (MetaFrame, 1);
 
   frame->window = window;
@@ -67,7 +67,7 @@ meta_window_ensure_frame (MetaWindow *window)
 
   frame->is_flashing = FALSE;
   frame->borders_cached = FALSE;
-  
+
   meta_verbose ("Framing window %s: visual %s default, depth %d default depth %d\n",
                 window->desc,
                 XVisualIDFromVisual (window->xvisual) ==
@@ -77,7 +77,7 @@ meta_window_ensure_frame (MetaWindow *window)
   meta_verbose ("Frame geometry %d,%d  %dx%d\n",
                 frame->rect.x, frame->rect.y,
                 frame->rect.width, frame->rect.height);
-  
+
   /* Default depth/visual handles clients with weird visuals; they can
    * always be children of the root depth/visual obviously, but
    * e.g. DRI games can't be children of a parent that has the same
@@ -86,7 +86,7 @@ meta_window_ensure_frame (MetaWindow *window)
    * We look for an ARGB visual if we can find one, otherwise use
    * the default of NULL.
    */
-  
+
   /* Special case for depth 32 windows (assumed to be ARGB),
    * we use the window's visual. Otherwise we just use the system visual.
    */
@@ -94,7 +94,7 @@ meta_window_ensure_frame (MetaWindow *window)
     visual = window->xvisual;
   else
     visual = NULL;
-  
+
   frame->xwindow = meta_ui_create_frame_window (window->screen->ui,
                                                 window->display->xdisplay,
                                                 frame->window,
@@ -113,7 +113,7 @@ meta_window_ensure_frame (MetaWindow *window)
   attrs.event_mask = EVENT_MASK;
   XChangeWindowAttributes (window->display->xdisplay,
 			   frame->xwindow, CWEventMask, &attrs);
-  
+
   meta_display_register_x_window (window->display, &frame->xwindow, window);
 
   /* Reparent the client window; it may be destroyed,
@@ -148,7 +148,7 @@ meta_window_ensure_frame (MetaWindow *window)
                    window->rect.y);
   /* FIXME handle this error */
   meta_error_trap_pop (window->display);
-  
+
   /* stick frame to the window */
   window->frame = frame;
 
@@ -156,7 +156,7 @@ meta_window_ensure_frame (MetaWindow *window)
    * style and background.
    */
   meta_ui_update_frame_style (window->screen->ui, frame->xwindow);
-  
+
   if (window->title)
     meta_ui_set_frame_title (window->screen->ui,
                              window->frame->xwindow,
@@ -175,12 +175,12 @@ meta_window_destroy_frame (MetaWindow *window)
 {
   MetaFrame *frame;
   MetaFrameBorders borders;
-  
+
   if (window->frame == NULL)
     return;
 
   meta_verbose ("Unframing window %s\n", window->desc);
-  
+
   frame = window->frame;
 
   meta_frame_calc_borders (frame, &borders);
@@ -217,7 +217,7 @@ meta_window_destroy_frame (MetaWindow *window)
 
   meta_display_unregister_x_window (window->display,
                                     frame->xwindow);
-  
+
   window->frame = NULL;
   if (window->frame_bounds)
     {
@@ -227,9 +227,9 @@ meta_window_destroy_frame (MetaWindow *window)
 
   /* Move keybindings to window instead of frame */
   meta_window_grab_keys (window);
-  
-  g_free (frame);
-  
+
+  free (frame);
+
   /* Put our state back where it should be */
   meta_window_queue (window, META_QUEUE_CALC_SHOWING);
   meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
@@ -252,20 +252,20 @@ meta_frame_get_flags (MetaFrame *frame)
   else
     {
       flags |= META_FRAME_ALLOWS_MENU;
-      
+
       if (frame->window->has_close_func)
         flags |= META_FRAME_ALLOWS_DELETE;
-      
+
       if (frame->window->has_maximize_func)
         flags |= META_FRAME_ALLOWS_MAXIMIZE;
-      
+
       if (frame->window->has_minimize_func)
         flags |= META_FRAME_ALLOWS_MINIMIZE;
-      
+
       if (frame->window->has_shade_func)
         flags |= META_FRAME_ALLOWS_SHADE;
-    }  
-  
+    }
+
   if (META_WINDOW_ALLOWS_MOVE (frame->window))
     flags |= META_FRAME_ALLOWS_MOVE;
 
@@ -274,7 +274,7 @@ meta_frame_get_flags (MetaFrame *frame)
 
   if (META_WINDOW_ALLOWS_VERTICAL_RESIZE (frame->window))
     flags |= META_FRAME_ALLOWS_VERTICAL_RESIZE;
-  
+
   if (META_WINDOW_ALLOWS_TOP_RESIZE (frame->window))
     flags |= META_FRAME_ALLOWS_TOP_RESIZE;
 
@@ -440,7 +440,7 @@ meta_frame_set_screen_cursor (MetaFrame	*frame,
   if (cursor == META_CURSOR_DEFAULT)
     XUndefineCursor (frame->window->display->xdisplay, frame->xwindow);
   else
-    { 
+    {
       xcursor = meta_display_create_x_cursor (frame->window->display, cursor);
       XDefineCursor (frame->window->display->xdisplay, frame->xwindow, xcursor);
       XFlush (frame->window->display->xdisplay);

--- a/src/core/group-props.c
+++ b/src/core/group-props.c
@@ -2,9 +2,9 @@
 
 /* MetaGroup property handling */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -67,16 +67,16 @@ meta_group_reload_properties (MetaGroup  *group,
 
   g_return_if_fail (properties != NULL);
   g_return_if_fail (n_properties > 0);
-  
+
   values = g_new0 (MetaPropValue, n_properties);
-  
+
   i = 0;
   while (i < n_properties)
     {
       init_prop_value (group->display, properties[i], &values[i]);
       ++i;
     }
-  
+
   meta_prop_get_values (group->display, group->group_leader,
                         values, n_properties);
 
@@ -84,13 +84,13 @@ meta_group_reload_properties (MetaGroup  *group,
   while (i < n_properties)
     {
       reload_prop_value (group, &values[i]);
-      
+
       ++i;
     }
 
   meta_prop_free_values (values, n_properties);
-  
-  g_free (values);
+
+  free (values);
 }
 
 /* Fill in the MetaPropValue used to get the value of "property" */
@@ -99,11 +99,11 @@ init_prop_value (MetaDisplay   *display,
                  Atom           property,
                  MetaPropValue *value)
 {
-  MetaGroupPropHooks *hooks;  
+  MetaGroupPropHooks *hooks;
 
   value->type = META_PROP_VALUE_INVALID;
   value->atom = None;
-  
+
   hooks = find_hooks (display, property);
   if (hooks && hooks->init_func != NULL)
     (* hooks->init_func) (display, property, value);
@@ -113,8 +113,8 @@ static void
 reload_prop_value (MetaGroup    *group,
                    MetaPropValue *value)
 {
-  MetaGroupPropHooks *hooks;  
-  
+  MetaGroupPropHooks *hooks;
+
   hooks = find_hooks (group->display, value->atom);
   if (hooks && hooks->reload_func != NULL)
     (* hooks->reload_func) (group, value);
@@ -133,9 +133,9 @@ static void
 reload_wm_client_machine (MetaGroup     *group,
                           MetaPropValue *value)
 {
-  g_free (group->wm_client_machine);
+  free (group->wm_client_machine);
   group->wm_client_machine = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     group->wm_client_machine = g_strdup (value->v.str);
 
@@ -156,12 +156,12 @@ static void
 reload_net_startup_id (MetaGroup     *group,
                        MetaPropValue *value)
 {
-  g_free (group->startup_id);
+  free (group->startup_id);
   group->startup_id = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     group->startup_id = g_strdup (value->v.str);
-  
+
   meta_verbose ("Group has startup id \"%s\"\n",
                 group->startup_id ? group->startup_id : "unset");
 }
@@ -173,12 +173,12 @@ meta_display_init_group_prop_hooks (MetaDisplay *display)
 {
   int i;
   MetaGroupPropHooks *hooks;
-  
+
   g_assert (display->group_prop_hooks == NULL);
 
-  display->group_prop_hooks = g_new0 (MetaGroupPropHooks, N_HOOKS); 
+  display->group_prop_hooks = g_new0 (MetaGroupPropHooks, N_HOOKS);
   hooks = display->group_prop_hooks;
-  
+
   i = 0;
 
   hooks[i].property = display->atom_WM_CLIENT_MACHINE;
@@ -195,7 +195,7 @@ meta_display_init_group_prop_hooks (MetaDisplay *display)
   hooks[i].init_func = init_net_startup_id;
   hooks[i].reload_func = reload_net_startup_id;
   ++i;
-  
+
   if (i != N_HOOKS)
     {
       g_error ("Initialized %d group hooks should have been %d\n", i, N_HOOKS);
@@ -206,8 +206,8 @@ LOCAL_SYMBOL void
 meta_display_free_group_prop_hooks (MetaDisplay *display)
 {
   g_assert (display->group_prop_hooks != NULL);
-  
-  g_free (display->group_prop_hooks);
+
+  free (display->group_prop_hooks);
   display->group_prop_hooks = NULL;
 }
 
@@ -220,13 +220,13 @@ find_hooks (MetaDisplay *display,
   /* FIXME we could sort the array and do binary search or
    * something
    */
-  
+
   i = 0;
   while (i < N_HOOKS)
     {
       if (display->group_prop_hooks[i].property == property)
         return &display->group_prop_hooks[i];
-      
+
       ++i;
     }
 

--- a/src/core/group.c
+++ b/src/core/group.c
@@ -1,9 +1,9 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2003 Rob Adams
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -13,7 +13,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -43,16 +43,16 @@ meta_group_new (MetaDisplay *display,
 #define N_INITIAL_PROPS 3
   Atom initial_props[N_INITIAL_PROPS];
   int i;
-  
+
   g_assert (N_INITIAL_PROPS == (int) G_N_ELEMENTS (initial_props));
-  
+
   group = g_new0 (MetaGroup, 1);
 
   group->display = display;
   group->windows = NULL;
   group->group_leader = group_leader;
   group->refcount = 1; /* owned by caller, hash table has only weak ref */
-  
+
   if (display->groups_by_leader == NULL)
     display->groups_by_leader = g_hash_table_new (meta_unsigned_long_hash,
                                                   meta_unsigned_long_equal);
@@ -69,13 +69,13 @@ meta_group_new (MetaDisplay *display,
   initial_props[i++] = display->atom__NET_WM_PID;
   initial_props[i++] = display->atom__NET_STARTUP_ID;
   g_assert (N_INITIAL_PROPS == i);
-  
+
   meta_group_reload_properties (group, initial_props, N_INITIAL_PROPS);
 
   meta_topic (META_DEBUG_GROUPS,
               "Created new group with leader 0x%lx\n",
               group->group_leader);
-  
+
   return group;
 }
 
@@ -89,10 +89,10 @@ meta_group_unref (MetaGroup *group)
     {
       meta_topic (META_DEBUG_GROUPS,
                   "Destroying group with leader 0x%lx\n",
-                  group->group_leader);      
-      
+                  group->group_leader);
+
       g_assert (group->display->groups_by_leader != NULL);
-      
+
       g_hash_table_remove (group->display->groups_by_leader,
                            &group->group_leader);
 
@@ -103,10 +103,10 @@ meta_group_unref (MetaGroup *group)
           group->display->groups_by_leader = NULL;
         }
 
-      g_free (group->wm_client_machine);
-      g_free (group->startup_id);
-      
-      g_free (group);
+      free (group->wm_client_machine);
+      free (group->startup_id);
+
+      free (group);
     }
 }
 
@@ -130,9 +130,9 @@ meta_window_compute_group (MetaWindow* window)
   MetaWindow *ancestor;
 
   /* use window->xwindow if no window->xgroup_leader */
-      
+
   group = NULL;
-      
+
   /* Determine the ancestor of the window; its group setting will override the
    * normal grouping rules; see bug 328211.
    */
@@ -149,7 +149,7 @@ meta_window_compute_group (MetaWindow* window)
         group = g_hash_table_lookup (window->display->groups_by_leader,
                                      &window->xwindow);
     }
-      
+
   if (group != NULL)
     {
       window->group = group;
@@ -166,7 +166,7 @@ meta_window_compute_group (MetaWindow* window)
       else
         group = meta_group_new (window->display,
                                 window->xwindow);
-          
+
       window->group = group;
     }
 
@@ -186,7 +186,7 @@ remove_window_from_group (MetaWindow *window)
       meta_topic (META_DEBUG_GROUPS,
                   "Removing %s from group with leader 0x%lx\n",
                   window->desc, window->group->group_leader);
-      
+
       window->group->windows =
         g_slist_remove (window->group->windows,
                         window);
@@ -217,9 +217,9 @@ meta_display_lookup_group (MetaDisplay *display,
                            Window       group_leader)
 {
   MetaGroup *group;
-  
+
   group = NULL;
-  
+
   if (display->groups_by_leader)
     group = g_hash_table_lookup (display->groups_by_leader,
                                  &group_leader);
@@ -244,7 +244,7 @@ meta_group_update_layers (MetaGroup *group)
 {
   GSList *tmp;
   GSList *frozen_stacks;
-  
+
   if (group->windows == NULL)
     return;
 
@@ -263,7 +263,7 @@ meta_group_update_layers (MetaGroup *group)
 
       meta_stack_update_layer (window->screen->stack,
                                window);
-      
+
       tmp = tmp->next;
     }
 

--- a/src/core/iconcache.c
+++ b/src/core/iconcache.c
@@ -253,7 +253,7 @@ read_rgb_icon (MetaDisplay   *display,
 static void
 free_pixels (guchar *pixels, gpointer data)
 {
-  g_free (pixels);
+  free (pixels);
 }
 
 static void
@@ -517,7 +517,7 @@ clear_icon_cache (MetaIconCache *icon_cache,
     g_object_unref (G_OBJECT (icon_cache->mini_icon));
   icon_cache->mini_icon = NULL;
 #endif
-  
+
   icon_cache->origin = USING_NO_ICON;
 
   if (dirty_all)
@@ -590,13 +590,13 @@ scaled_from_pixdata (guchar *pixdata,
 {
   GdkPixbuf *src;
   GdkPixbuf *dest;
-  
+
   src = gdk_pixbuf_new_from_data (pixdata,
                                   GDK_COLORSPACE_RGB,
                                   TRUE,
                                   8,
                                   w, h, w * 4,
-                                  free_pixels, 
+                                  free_pixels,
                                   NULL);
 
   if (src == NULL)
@@ -608,7 +608,7 @@ scaled_from_pixdata (guchar *pixdata,
       int size;
 
       size = MAX (w, h);
-      
+
       tmp = gdk_pixbuf_new (GDK_COLORSPACE_RGB, TRUE, 8, size, size);
 
       if (tmp)
@@ -617,16 +617,16 @@ scaled_from_pixdata (guchar *pixdata,
 	  gdk_pixbuf_copy_area (src, 0, 0, w, h,
 				tmp,
 				(size - w) / 2, (size - h) / 2);
-	  
+
 	  g_object_unref (src);
 	  src = tmp;
 	}
     }
-  
+
   if (w != new_w || h != new_h)
     {
       dest = gdk_pixbuf_scale_simple (src, new_w, new_h, GDK_INTERP_BILINEAR);
-      
+
       g_object_unref (G_OBJECT (src));
     }
   else

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1,12 +1,12 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
 /* Muffin Keybindings */
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -176,10 +176,10 @@ static GHashTable *key_handlers;
 static void
 key_handler_free (MetaKeyHandler *handler)
 {
-  g_free (handler->name);
+  free (handler->name);
   if (handler->user_data_free_func && handler->user_data)
     handler->user_data_free_func (handler->user_data);
-  g_free (handler);
+  free (handler);
 }
 
 static void
@@ -196,7 +196,7 @@ reload_keymap (MetaDisplay *display)
                                          display->min_keycode,
                                          display->max_keycode -
                                          display->min_keycode + 1,
-                                         &display->keysyms_per_keycode);  
+                                         &display->keysyms_per_keycode);
 }
 
 static void
@@ -205,7 +205,7 @@ reload_modmap (MetaDisplay *display)
   XModifierKeymap *modmap;
   int map_size;
   int i;
-  
+
   if (display->modmap)
     XFreeModifiermap (display->modmap);
 
@@ -220,7 +220,7 @@ reload_modmap (MetaDisplay *display)
   display->meta_mask = 0;
   display->hyper_mask = 0;
   display->super_mask = 0;
-  
+
   /* there are 8 modifiers, and the first 3 are shift, shift lock,
    * and control
    */
@@ -232,7 +232,7 @@ reload_modmap (MetaDisplay *display)
        * see if its keysym is one we're interested in
        */
       int keycode = modmap->modifiermap[i];
-      
+
       if (keycode >= display->min_keycode &&
           keycode <= display->max_keycode)
         {
@@ -245,21 +245,21 @@ reload_modmap (MetaDisplay *display)
               if (syms[j] != 0)
                 {
                   const char *str;
-                  
+
                   str = XKeysymToString (syms[j]);
                   meta_topic (META_DEBUG_KEYBINDINGS,
                               "Keysym %s bound to modifier 0x%x\n",
                               str ? str : "none",
                               (1 << ( i / modmap->max_keypermod)));
                 }
-              
+
               if (syms[j] == XK_Num_Lock)
                 {
                   /* Mod1Mask is 1 << 3 for example, i.e. the
                    * fourth modifier, i / keyspermod is the modifier
                    * index
                    */
-                  
+
                   display->num_lock_mask |= (1 << ( i / modmap->max_keypermod));
                 }
               else if (syms[j] == XK_Scroll_Lock)
@@ -275,17 +275,17 @@ reload_modmap (MetaDisplay *display)
                        syms[j] == XK_Hyper_R)
                 {
                   display->hyper_mask |= (1 << ( i / modmap->max_keypermod));
-                }              
+                }
               else if (syms[j] == XK_Meta_L ||
                        syms[j] == XK_Meta_R)
                 {
                   display->meta_mask |= (1 << ( i / modmap->max_keypermod));
                 }
-              
+
               ++j;
             }
         }
-      
+
       ++i;
     }
 
@@ -322,7 +322,7 @@ reload_keycodes (MetaDisplay *display)
   if (display->key_bindings)
     {
       int i;
-      
+
       i = 0;
       while (i < display->n_key_bindings)
         {
@@ -331,7 +331,7 @@ reload_keycodes (MetaDisplay *display)
               display->key_bindings[i].keycode =
                 keysym_to_keycode (display, display->key_bindings[i].keysym);
             }
-          
+
           ++i;
         }
     }
@@ -342,11 +342,11 @@ reload_modifiers (MetaDisplay *display)
 {
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Reloading keycodes for binding tables\n");
-  
+
   if (display->key_bindings)
     {
       int i;
-      
+
       i = 0;
       while (i < display->n_key_bindings)
         {
@@ -358,8 +358,8 @@ reload_modifiers (MetaDisplay *display)
                       " Devirtualized mods 0x%x -> 0x%x (%s)\n",
                       display->key_bindings[i].modifiers,
                       display->key_bindings[i].mask,
-                      display->key_bindings[i].name);          
-          
+                      display->key_bindings[i].name);
+
           ++i;
         }
     }
@@ -410,9 +410,9 @@ rebuild_binding_table (MetaDisplay     *display,
   GList *p;
   int n_bindings;
   int i;
-  
+
   n_bindings = count_bindings (prefs);
-  g_free (*bindings_p);
+  free (*bindings_p);
   *bindings_p = g_new0 (MetaKeyBinding, n_bindings);
 
   i = 0;
@@ -436,7 +436,7 @@ rebuild_binding_table (MetaDisplay     *display,
               (*bindings_p)[i].keycode = combo->keycode;
               (*bindings_p)[i].modifiers = combo->modifiers;
               (*bindings_p)[i].mask = 0;
-          
+
               ++i;
 
               if (pref->add_shift &&
@@ -445,7 +445,7 @@ rebuild_binding_table (MetaDisplay     *display,
                   meta_topic (META_DEBUG_KEYBINDINGS,
                               "Binding %s also needs Shift grabbed\n",
                                pref->name);
-              
+
                   (*bindings_p)[i].name = pref->name;
                   (*bindings_p)[i].handler = handler;
                   (*bindings_p)[i].keysym = combo->keysym;
@@ -453,19 +453,19 @@ rebuild_binding_table (MetaDisplay     *display,
                   (*bindings_p)[i].modifiers = combo->modifiers |
                     META_VIRTUAL_SHIFT_MASK;
                   (*bindings_p)[i].mask = 0;
-              
+
                   ++i;
                 }
             }
-            
+
           tmp = tmp->next;
         }
-      
+
       p = p->next;
     }
 
   g_assert (i == n_bindings);
-  
+
   *n_bindings_p = i;
 
   meta_topic (META_DEBUG_KEYBINDINGS,
@@ -496,7 +496,7 @@ regrab_key_bindings (MetaDisplay *display)
   GSList *windows;
 
   meta_error_trap_push (display); /* for efficiency push outer trap */
-  
+
   tmp = display->screens;
   while (tmp != NULL)
     {
@@ -513,10 +513,10 @@ regrab_key_bindings (MetaDisplay *display)
   while (tmp != NULL)
     {
       MetaWindow *w = tmp->data;
-      
+
       meta_window_ungrab_keys (w);
       meta_window_grab_keys (w);
-      
+
       tmp = tmp->next;
     }
   meta_error_trap_pop (display);
@@ -541,7 +541,7 @@ display_get_keybinding (MetaDisplay  *display,
         {
           return &display->key_bindings[i];
         }
-      
+
       --i;
     }
 
@@ -799,7 +799,7 @@ meta_display_keybinding_action_invoke_by_code (MetaDisplay  *display,
 LOCAL_SYMBOL void
 meta_display_process_mapping_event (MetaDisplay *display,
                                     XEvent      *event)
-{ 
+{
   gboolean keymap_changed = FALSE;
   gboolean modmap_changed = FALSE;
 
@@ -884,7 +884,7 @@ bindings_changed_callback (MetaPreference pref,
   MetaDisplay *display;
 
   display = data;
-  
+
   switch (pref)
     {
     case META_PREF_KEYBINDINGS:
@@ -914,22 +914,22 @@ LOCAL_SYMBOL void
 meta_display_shutdown_keys (MetaDisplay *display)
 {
   /* Note that display->xdisplay is invalid in this function */
-  
+
   meta_prefs_remove_listener (bindings_changed_callback, display);
 
   if (display->keymap)
     meta_XFree (display->keymap);
-  
+
   if (display->modmap)
     XFreeModifiermap (display->modmap);
-  g_free (display->key_bindings);
+  free (display->key_bindings);
 }
 
 static const char*
 keysym_name (int keysym)
 {
   const char *name;
-  
+
   name = XKeysymToString (keysym);
   if (name == NULL)
     name = "(unknown)";
@@ -961,7 +961,7 @@ meta_change_keygrab (MetaDisplay *display,
 
   /* efficiency, avoid so many XSync() */
   meta_error_trap_push (display);
-  
+
   ignored_mask = 0;
   while (ignored_mask <= display->ignored_modifier_mask)
     {
@@ -990,11 +990,11 @@ meta_change_keygrab (MetaDisplay *display,
       if (meta_is_debugging ())
         {
           int result;
-          
+
           result = meta_error_trap_pop_with_return (display);
-          
+
           if (grab && result != Success)
-            {      
+            {
               if (result == BadAccess)
                 meta_warning (_("Some other program is already using the key %s with modifiers %x as a binding\n"), keysym_name (keysym), modmask | ignored_mask);
               else
@@ -1032,7 +1032,7 @@ grab_keys (MetaKeyBinding *bindings,
   g_assert (n_bindings == 0 || bindings != NULL);
 
   meta_error_trap_push (display);
-  
+
   i = 0;
   while (i < n_bindings)
     {
@@ -1045,7 +1045,7 @@ grab_keys (MetaKeyBinding *bindings,
                          bindings[i].keycode,
                          bindings[i].mask);
         }
-      
+
       ++i;
     }
 
@@ -1067,10 +1067,10 @@ ungrab_all_keys (MetaDisplay *display,
   if (meta_is_debugging ())
     {
       int result;
-      
+
       result = meta_error_trap_pop_with_return (display);
-      
-      if (result != Success)    
+
+      if (result != Success)
         meta_topic (META_DEBUG_KEYBINDINGS,
                     "Ungrabbing all keys on 0x%lx failed\n", xwindow);
     }
@@ -1119,7 +1119,7 @@ meta_window_grab_keys (MetaWindow  *window)
       window->keys_grabbed = FALSE;
       return;
     }
-  
+
   if (window->keys_grabbed)
     {
       if (window->frame && !window->grab_on_frame)
@@ -1130,7 +1130,7 @@ meta_window_grab_keys (MetaWindow  *window)
       else
         return; /* already all good */
     }
-  
+
   grab_keys (window->display->key_bindings,
              window->display->n_key_bindings,
              window->display,
@@ -1187,7 +1187,7 @@ grab_keyboard (MetaDisplay *display,
 {
   int result;
   int grab_status;
-  
+
   /* Grab the keyboard, so we get key releases and all key
    * presses
    */
@@ -1197,7 +1197,7 @@ grab_keyboard (MetaDisplay *display,
                                xwindow, True,
                                GrabModeAsync, GrabModeAsync,
                                timestamp);
-  
+
   if (grab_status != GrabSuccess)
     {
       meta_error_trap_pop_with_return (display);
@@ -1217,9 +1217,9 @@ grab_keyboard (MetaDisplay *display,
           return FALSE;
         }
     }
-       
+
   meta_topic (META_DEBUG_KEYBINDINGS, "Grabbed all keys\n");
-       
+
   return TRUE;
 }
 
@@ -1242,7 +1242,7 @@ meta_screen_grab_all_keys (MetaScreen *screen, guint32 timestamp)
 
   if (screen->all_keys_grabbed)
     return FALSE;
-  
+
   if (screen->keys_grabbed)
     meta_screen_ungrab_keys (screen);
 
@@ -1282,10 +1282,10 @@ meta_window_grab_all_keys (MetaWindow  *window,
 {
   Window grabwindow;
   gboolean retval;
-  
+
   if (window->all_keys_grabbed)
     return FALSE;
-  
+
   if (window->keys_grabbed)
     meta_window_ungrab_keys (window);
 
@@ -1296,7 +1296,7 @@ meta_window_grab_all_keys (MetaWindow  *window,
               "Focusing %s because we're grabbing all its keys\n",
               window->desc);
   meta_window_focus (window, timestamp);
-  
+
   grabwindow = window->frame ? window->frame->xwindow : window->xwindow;
 
   meta_topic (META_DEBUG_KEYBINDINGS,
@@ -1369,16 +1369,16 @@ meta_window_resize_or_move_allowed (MetaWindow *window,
 }
 
 
-static gboolean 
+static gboolean
 is_modifier (MetaDisplay *display,
              unsigned int keycode)
 {
   int i;
   int map_size;
-  gboolean retval = FALSE;  
+  gboolean retval = FALSE;
 
   g_assert (display->modmap);
-  
+
   map_size = 8 * display->modmap->max_keypermod;
   i = 0;
   while (i < map_size)
@@ -1390,7 +1390,7 @@ is_modifier (MetaDisplay *display,
         }
       ++i;
     }
-  
+
   return retval;
 }
 
@@ -1485,7 +1485,7 @@ strip_self_mod (KeySym keysym, unsigned long *mask)
         mod = 0;
         break;
     }
-  
+
   *mask = *mask & ~mod;
 }
 
@@ -1699,7 +1699,7 @@ meta_display_process_key_event (MetaDisplay *display,
 
   /* if key event was on root window, we have a shortcut */
   screen = meta_display_screen_for_root (display, event->xkey.window);
-  
+
   /* else round-trip to server */
   if (screen == NULL)
     screen = meta_display_screen_for_xwindow (display,
@@ -1707,17 +1707,17 @@ meta_display_process_key_event (MetaDisplay *display,
 
   if (screen == NULL)
     return FALSE; /* event window is destroyed */
-  
+
   /* ignore key events on popup menus and such. */
   if (meta_ui_window_is_widget (screen->ui, event->xany.window))
     return FALSE;
-  
+
   /* window may be NULL */
-  
+
   keysym = XkbKeycodeToKeysym (display->xdisplay, event->xkey.keycode, 0, 0);
 
   str = XKeysymToString (keysym);
-  
+
   /* was topic */
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Processing key %s event, keysym: %s state: 0x%x window: %s\n",
@@ -1755,8 +1755,8 @@ meta_display_process_key_event (MetaDisplay *display,
               mouse_grab_move = TRUE;
               /* Fall through - this is just a flag for if we make it to process_event */
             case META_GRAB_OP_RESIZING_SE:
-            case META_GRAB_OP_RESIZING_S:      
-            case META_GRAB_OP_RESIZING_SW:      
+            case META_GRAB_OP_RESIZING_S:
+            case META_GRAB_OP_RESIZING_SW:
             case META_GRAB_OP_RESIZING_N:
             case META_GRAB_OP_RESIZING_NE:
             case META_GRAB_OP_RESIZING_NW:
@@ -1768,7 +1768,7 @@ meta_display_process_key_event (MetaDisplay *display,
               keep_grab = process_mouse_move_resize_grab (display, screen,
                                                           window, event, keysym);
               break;
- 
+
             case META_GRAB_OP_KEYBOARD_MOVING:
               meta_topic (META_DEBUG_KEYBINDINGS,
                           "Processing event for keyboard move\n");
@@ -1776,7 +1776,7 @@ meta_display_process_key_event (MetaDisplay *display,
               keep_grab = process_keyboard_move_grab (display, screen,
                                                       window, event, keysym);
               break;
-              
+
             case META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN:
             case META_GRAB_OP_KEYBOARD_RESIZING_S:
             case META_GRAB_OP_KEYBOARD_RESIZING_N:
@@ -1785,14 +1785,14 @@ meta_display_process_key_event (MetaDisplay *display,
             case META_GRAB_OP_KEYBOARD_RESIZING_SE:
             case META_GRAB_OP_KEYBOARD_RESIZING_NE:
             case META_GRAB_OP_KEYBOARD_RESIZING_SW:
-            case META_GRAB_OP_KEYBOARD_RESIZING_NW:          
+            case META_GRAB_OP_KEYBOARD_RESIZING_NW:
               meta_topic (META_DEBUG_KEYBINDINGS,
                           "Processing event for keyboard resize\n");
               g_assert (window != NULL);
               keep_grab = process_keyboard_resize_grab (display, screen,
                                                         window, event, keysym);
               break;
- 
+
             default:
               break;
             }
@@ -1814,7 +1814,7 @@ meta_display_process_key_event (MetaDisplay *display,
           return TRUE;
         }
     }
-  
+
   /* Do the normal keybindings */
   return process_event (display->key_bindings,
                         display->n_key_bindings,
@@ -2034,7 +2034,7 @@ process_keyboard_move_grab (MetaDisplay *display,
   int x, y;
   int incr;
   gboolean smart_snap;
-  
+
   handled = FALSE;
 
   /* don't care about releases, but eat them, don't end grab */
@@ -2048,7 +2048,7 @@ process_keyboard_move_grab (MetaDisplay *display,
   meta_window_get_position (window, &x, &y);
 
   smart_snap = (event->xkey.state & ShiftMask) != 0;
-  
+
 #define SMALL_INCREMENT 1
 #define NORMAL_INCREMENT 10
 
@@ -2066,7 +2066,7 @@ process_keyboard_move_grab (MetaDisplay *display,
        * remaximize it.  In normal cases, we need to do a moveresize
        * now to get the position back to the original.
        */
-      if (window->shaken_loose) 
+      if (window->shaken_loose)
         {
           meta_window_maximize (window,
                                 META_MAXIMIZE_HORIZONTAL |
@@ -2087,7 +2087,7 @@ process_keyboard_move_grab (MetaDisplay *display,
                                    display->grab_initial_window_pos.height);
         }
     }
-  
+
   /* When moving by increments, we still snap to edges if the move
    * to the edge is smaller than the increment. This is because
    * Shift + arrow to snap is sort of a hidden feature. This way
@@ -2110,7 +2110,7 @@ process_keyboard_move_grab (MetaDisplay *display,
       handled = TRUE;
       break;
     }
-  
+
   switch (keysym)
     {
     case XK_KP_Home:
@@ -2140,7 +2140,7 @@ process_keyboard_move_grab (MetaDisplay *display,
 
       meta_window_get_client_root_coords (window, &old_rect);
 
-      meta_window_edge_resistance_for_move (window, 
+      meta_window_edge_resistance_for_move (window,
                                             old_rect.x,
                                             old_rect.y,
                                             &x,
@@ -2201,7 +2201,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_S:
       switch (keysym)
         {
@@ -2241,7 +2241,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_W:
       switch (keysym)
         {
@@ -2268,7 +2268,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
         case XK_Up:
         case XK_KP_Up:
           if (meta_window_resize_or_move_allowed (window, META_DIRECTION_UP)) {
-            display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N; 
+            display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
           }
           handled = TRUE;
           break;
@@ -2281,7 +2281,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_SE:
     case META_GRAB_OP_KEYBOARD_RESIZING_NE:
     case META_GRAB_OP_KEYBOARD_RESIZING_SW:
@@ -2296,7 +2296,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
   if (handled)
     {
       meta_window_update_keyboard_resize (window, TRUE);
-      return TRUE; 
+      return TRUE;
     }
 
   return FALSE;
@@ -2315,7 +2315,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
   int width, height;
   gboolean smart_snap;
   int gravity;
-  
+
   handled = FALSE;
 
   /* don't care about releases, but eat them, don't end grab */
@@ -2339,7 +2339,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
       return FALSE;
     }
 
-  if (process_keyboard_resize_grab_op_change (display, screen, window, 
+  if (process_keyboard_resize_grab_op_change (display, screen, window,
                                               event, keysym))
     return TRUE;
 
@@ -2352,7 +2352,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     gravity = meta_resize_gravity_from_grab_op (display->grab_op);
 
   smart_snap = (event->xkey.state & ShiftMask) != 0;
-  
+
 #define SMALL_INCREMENT 1
 #define NORMAL_INCREMENT 10
 
@@ -2365,7 +2365,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     {
       width_inc = SMALL_INCREMENT;
       height_inc = SMALL_INCREMENT;
-    }  
+    }
   else
     {
       width_inc = NORMAL_INCREMENT;
@@ -2379,7 +2379,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     width_inc = window->size_hints.width_inc;
   if (window->size_hints.height_inc > 1)
     height_inc = window->size_hints.height_inc;
-  
+
   switch (keysym)
     {
     case XK_Up:
@@ -2406,7 +2406,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
 
@@ -2434,10 +2434,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-      
+
     case XK_Left:
     case XK_KP_Left:
       switch (gravity)
@@ -2462,10 +2462,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-      
+
     case XK_Right:
     case XK_KP_Right:
       switch (gravity)
@@ -2490,10 +2490,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-          
+
     default:
       break;
     }
@@ -2503,7 +2503,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     height = 1;
   if (width < 1)
     width = 1;
-  
+
   if (handled)
     {
       MetaRectangle old_rect;
@@ -2511,7 +2511,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
                   "Computed new window size due to keypress: "
                   "%dx%d, gravity %s\n",
                   width, height, meta_gravity_to_string (gravity));
-      
+
       old_rect = window->rect;  /* Don't actually care about x,y */
 
       /* Do any edge resistance/snapping */
@@ -2529,7 +2529,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
        * are actually different from what we had before.
        */
       if (window->rect.width != width || window->rect.height != height)
-        meta_window_resize_with_gravity (window, 
+        meta_window_resize_with_gravity (window,
                                          TRUE,
                                          width,
                                          height,
@@ -2551,9 +2551,9 @@ handle_switch_to_workspace (MetaDisplay    *display,
 {
   gint which = binding->handler->data;
   MetaWorkspace *workspace;
-  
+
   workspace = meta_screen_get_workspace_by_index (screen, which);
-  
+
   if (workspace)
       meta_workspace_activate (workspace, event->xkey.time);
 }
@@ -2717,7 +2717,7 @@ handle_activate_window_menu (MetaDisplay    *display,
 
       meta_window_get_position (display->focus_window,
                                 &x, &y);
-      
+
       if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
 	  x += display->focus_window->rect.width;
 
@@ -3046,7 +3046,7 @@ handle_move_to_workspace  (MetaDisplay    *display,
   gboolean flip = (which < 0);
   gboolean new = (which == META_MOTION_NOT_EXIST_YET);
   MetaWorkspace *workspace;
-  
+
   /* If which is zero or positive, it's a workspace number, and the window
    * should move to the workspace with that number.
    *
@@ -3057,11 +3057,11 @@ handle_move_to_workspace  (MetaDisplay    *display,
 
   if (window->always_sticky)
     return;
-  
+
   workspace = NULL;
   if (!new) {
     if (flip)
-      {      
+      {
         workspace = meta_workspace_get_neighbor (screen->active_workspace,
                                                  which);
       }
@@ -3070,7 +3070,7 @@ handle_move_to_workspace  (MetaDisplay    *display,
         workspace = meta_screen_get_workspace_by_index (screen, which);
       }
   }
-  
+
   if (workspace)
     {
       /* Activate second, so the window is never unmapped */
@@ -3117,7 +3117,7 @@ handle_move_to_monitor (MetaDisplay    *display,
   meta_window_move_to_monitor (window, new->number);
 }
 
-static void 
+static void
 handle_raise_or_lower (MetaDisplay    *display,
                        MetaScreen     *screen,
 		       MetaWindow     *window,
@@ -3126,19 +3126,19 @@ handle_raise_or_lower (MetaDisplay    *display,
                        gpointer        dummy)
 {
   /* Get window at pointer */
-  
+
   MetaWindow *above = NULL;
-      
+
   /* Check if top */
   if (meta_stack_get_top (window->screen->stack) == window)
     {
       meta_window_lower (window);
       return;
     }
-      
+
   /* else check if windows in same layer are intersecting it */
-  
-  above = meta_stack_get_above (window->screen->stack, window, TRUE); 
+
+  above = meta_stack_get_above (window->screen->stack, window, TRUE);
 
   while (above)
     {
@@ -3153,8 +3153,8 @@ handle_raise_or_lower (MetaDisplay    *display,
               return;
             }
         }
-	  
-      above = meta_stack_get_above (window->screen->stack, above, TRUE); 
+
+      above = meta_stack_get_above (window->screen->stack, above, TRUE);
     }
 
   /* window is not obscured */
@@ -3851,7 +3851,7 @@ meta_display_init_keys (MetaDisplay *display)
   reload_keymap (display);
   reload_modmap (display);
 
-  key_handlers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+  key_handlers = g_hash_table_new_full (g_str_hash, g_str_equal, free,
                                         (GDestroyNotify) key_handler_free);
   init_builtin_key_bindings (display);
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2,10 +2,10 @@
 
 /* Muffin main() */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -26,12 +26,12 @@
  * SECTION:main
  * @title: Main
  * @short_description: Program startup.
- * 
+ *
  * Functions which parse the command-line arguments, create the display,
  * kick everything off and then close down Muffin when it's time to go.
  *
- * 
- * 
+ *
+ *
  * Muffin - a boring window manager for the adult in you
  *
  * Many window managers are like Marshmallow Froot Loops; Muffin
@@ -185,7 +185,7 @@ meta_print_self_identity (void)
   g_date_strftime (buf, sizeof (buf), "%x", &d);
   meta_verbose ("Muffin version %s running on %s\n",
     VERSION, buf);
-  
+
   /* Locale and encoding. */
   g_get_charset (&charset);
   meta_verbose ("Running in locale \"%s\" with encoding \"%s\"\n",
@@ -282,7 +282,7 @@ meta_get_option_context (void)
  * of the queue and dispatching them before we block for new events.
  */
 
-static gboolean 
+static gboolean
 event_prepare (GSource    *source,
                gint       *timeout_)
 {
@@ -291,7 +291,7 @@ event_prepare (GSource    *source,
   return clutter_events_pending ();
 }
 
-static gboolean 
+static gboolean
 event_check (GSource *source)
 {
   return clutter_events_pending ();
@@ -462,7 +462,7 @@ meta_init (void)
                     g_get_home_dir ());
 
   meta_print_self_identity ();
-  
+
 #ifdef HAVE_INTROSPECTION
   g_irepository_prepend_search_path (MUFFIN_PKGLIBDIR);
 #endif
@@ -470,15 +470,15 @@ meta_init (void)
   meta_set_syncing (opt_sync || (g_getenv ("MUFFIN_SYNC") != NULL));
 
   meta_select_display (opt_display_name);
-  
+
   if (opt_replace_wm)
     meta_set_replace_current_wm (TRUE);
 
   if (opt_save_file && opt_client_id)
     meta_fatal ("Can't specify both SM save file and SM client id\n");
-  
+
   meta_main_loop = g_main_loop_new (NULL, FALSE);
-  
+
   meta_ui_init ();
 
   /*
@@ -498,7 +498,7 @@ meta_init (void)
    * Clutter can only be initialized after the UI.
    */
   meta_clutter_init ();
-  
+
   const char *renderer = (const char *) glGetString (GL_RENDERER);
   if (strstr (renderer, "llvmpipe") ||
       strstr (renderer, "Rasterizer") ||
@@ -536,7 +536,7 @@ meta_run (void)
 
   if (g_getenv ("MUFFIN_G_FATAL_WARNINGS") != NULL)
     g_log_set_always_fatal (G_LOG_LEVEL_MASK);
-  
+
   meta_ui_set_current_theme (meta_prefs_get_theme (), FALSE);
 
   if (!meta_ui_have_a_theme ())
@@ -544,8 +544,8 @@ meta_run (void)
       meta_ui_set_current_theme ("Default", FALSE);
       meta_warning (_("Could not find theme %s. Falling back to default theme."), meta_prefs_get_theme ());
     }
- 
- 
+
+
   /* Connect to SM as late as possible - but before managing display,
    * or we might try to manage a window before we have the session
    * info
@@ -555,9 +555,9 @@ meta_run (void)
       if (opt_client_id == NULL)
         {
           const gchar *desktop_autostart_id;
-  
+
           desktop_autostart_id = g_getenv ("DESKTOP_AUTOSTART_ID");
- 
+
           if (desktop_autostart_id != NULL)
             opt_client_id = g_strdup (desktop_autostart_id);
         }
@@ -571,13 +571,13 @@ meta_run (void)
   /* Free memory possibly allocated by the argument parsing which are
    * no longer needed.
    */
-  g_free (opt_save_file);
-  g_free (opt_display_name);
-  g_free (opt_client_id);
+  free (opt_save_file);
+  free (opt_display_name);
+  free (opt_client_id);
 
   if (!meta_display_open ())
     meta_exit (META_EXIT_ERROR);
-  
+
   g_main_loop_run (meta_main_loop);
 
   meta_finalize ();

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -2060,7 +2060,7 @@ update_binding (MetaKeyPref *binding,
           continue;
         }
 
-      combo = g_malloc0 (sizeof (MetaKeyCombo));
+      combo = calloc (1, sizeof (MetaKeyCombo));
       combo->keysym = keysym;
       combo->keycode = keycode;
       combo->modifiers = mods;

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -2,7 +2,7 @@
 
 /* Muffin preferences */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2006 Elijah Newren
  * Copyright (C) 2008 Thomas Thurman
@@ -17,7 +17,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -646,7 +646,7 @@ handle_preference_init_string (void)
           if (!cursor->target)
             meta_bug ("%s must have handler or target\n", cursor->base.key);
 
-          g_free (*(cursor->target));
+          free (*(cursor->target));
 
           value = g_settings_get_string (SETTINGS (cursor->base.schema),
                                          cursor->base.key);
@@ -663,7 +663,7 @@ handle_preference_init_int (void)
 {
   MetaIntPreference *cursor = preferences_int;
 
-  
+
   while (cursor->base.key != NULL)
     {
       if (cursor->target)
@@ -719,7 +719,7 @@ handle_preference_update_bool (GSettings *settings,
    * store the current value away.
    */
   old_value = *((gboolean *) cursor->target);
-  
+
   /* Now look it up... */
   *((gboolean *) cursor->target) =
     g_settings_get_boolean (SETTINGS (cursor->base.schema), key);
@@ -766,7 +766,7 @@ handle_preference_update_string (GSettings *settings,
 
       inform_listeners = (g_strcmp0 (value, *(cursor->target)) != 0);
 
-      g_free(*(cursor->target));
+      free(*(cursor->target));
 
       *(cursor->target) = value;
     }
@@ -839,12 +839,12 @@ meta_prefs_remove_listener (MetaPrefsChangedFunc func,
       if (l->func == func &&
           l->data == data)
         {
-          g_free (l);
+          free (l);
           listeners = g_list_delete_link (listeners, tmp);
 
           return;
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -859,9 +859,9 @@ emit_changed (MetaPreference pref)
 
   meta_topic (META_DEBUG_PREFS, "Notifying listeners that pref %s changed\n",
               meta_preference_to_string (pref));
-  
+
   copy = g_list_copy (listeners);
-  
+
   tmp = copy;
 
   while (tmp != NULL)
@@ -883,24 +883,24 @@ changed_idle_handler (gpointer data)
   GList *copy;
 
   changed_idle = 0;
-  
+
   copy = g_list_copy (changes); /* reentrancy paranoia */
 
   g_list_free (changes);
   changes = NULL;
-  
+
   tmp = copy;
   while (tmp != NULL)
     {
       MetaPreference pref = GPOINTER_TO_INT (tmp->data);
 
       emit_changed (pref);
-      
+
       tmp = tmp->next;
     }
 
   g_list_free (copy);
-  
+
   return FALSE;
 }
 
@@ -908,7 +908,7 @@ static void
 queue_changed (MetaPreference pref)
 {
   meta_topic (META_DEBUG_PREFS, "Queueing change of pref %s\n",
-              meta_preference_to_string (pref));  
+              meta_preference_to_string (pref));
 
   if (g_list_find (changes, GINT_TO_POINTER (pref)) == NULL)
     changes = g_list_prepend (changes, GINT_TO_POINTER (pref));
@@ -944,7 +944,7 @@ meta_prefs_init (void)
   GSList *tmp;
 
   settings_schemas = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                            g_free, g_object_unref);
+                                            free, g_object_unref);
 
   settings = g_settings_new (SCHEMA_GENERAL);
   g_signal_connect (settings, "changed", G_CALLBACK (settings_changed), NULL);
@@ -1063,7 +1063,7 @@ do_override (char *key,
   detailed_signal = g_strdup_printf ("changed::%s", key);
   handler_id = g_signal_connect (settings, detailed_signal,
                                  G_CALLBACK (settings_changed), NULL);
-  g_free (detailed_signal);
+  free (detailed_signal);
 
   g_object_set_data (G_OBJECT (settings), key, GUINT_TO_POINTER (handler_id));
 
@@ -1109,7 +1109,7 @@ meta_prefs_override_preference_schema (const char *key, const char *schema)
 
   if (overridden)
     {
-      g_free (overridden->new_schema);
+      free (overridden->new_schema);
       overridden->new_schema = g_strdup (schema);
     }
   else
@@ -1141,7 +1141,7 @@ settings_changed (GSettings *settings,
   MetaEnumPreference *cursor;
   gboolean found_enum;
   gchar *schema;
-  
+
   g_object_get(settings, "schema", &schema, NULL);
 
   /* String array, handled separately */
@@ -1151,7 +1151,7 @@ settings_changed (GSettings *settings,
         queue_changed (META_PREF_WORKSPACE_NAMES);
       return;
     }
-  
+
   if (strcmp (key, KEY_MIN_WINDOW_OPACITY) == 0)
     {
       update_min_win_opacity ();
@@ -1220,7 +1220,7 @@ static void
 maybe_give_disable_workarounds_warning (void)
 {
   static gboolean first_disable = TRUE;
-    
+
   if (first_disable && disable_workarounds)
     {
       first_disable = FALSE;
@@ -1358,7 +1358,7 @@ theme_name_handler (GVariant *value,
 
   if (g_strcmp0 (current_theme, string_value) != 0)
     {
-      g_free (current_theme);
+      free (current_theme);
       current_theme = g_strdup (string_value);
       queue_changed (META_PREF_THEME);
     }
@@ -1381,7 +1381,7 @@ mouse_button_mods_handler (GVariant *value,
     {
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Failed to parse new GSettings value\n");
-          
+
       meta_warning (_("\"%s\" found in configuration database is "
                       "not a valid value for mouse button modifier\n"),
                     string_value);
@@ -1479,7 +1479,7 @@ snap_modifier_handler (GVariant *value,
 static gboolean
 button_layout_equal (const MetaButtonLayout *a,
                      const MetaButtonLayout *b)
-{  
+{
   int i;
 
   i = 0;
@@ -1520,7 +1520,7 @@ button_function_from_string (const char *str)
     return META_BUTTON_FUNCTION_ABOVE;
   else if (strcmp (str, "stick") == 0)
     return META_BUTTON_FUNCTION_STICK;
-  else 
+  else
     /* don't know; give up */
     return META_BUTTON_FUNCTION_LAST;
 }
@@ -1645,7 +1645,7 @@ button_layout_handler (GVariant *value,
           new_layout.right_buttons_has_spacer[i] = FALSE;
           ++i;
         }
-      
+
       buttons = g_strsplit (sides[1], ",", -1);
       i = 0;
       b = 0;
@@ -1681,7 +1681,7 @@ button_layout_handler (GVariant *value,
                               buttons[b]);
                 }
             }
-          
+
           ++b;
         }
 
@@ -1695,13 +1695,13 @@ button_layout_handler (GVariant *value,
     }
 
   g_strfreev (sides);
-  
+
   /* Invert the button layout for RTL languages */
   if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
   {
     MetaButtonLayout rtl_layout;
     int j;
-    
+
     for (i = 0; new_layout.left_buttons[i] != META_BUTTON_FUNCTION_LAST; i++);
     for (j = 0; j < i; j++)
       {
@@ -1713,7 +1713,7 @@ button_layout_handler (GVariant *value,
       }
     rtl_layout.right_buttons[j] = META_BUTTON_FUNCTION_LAST;
     rtl_layout.right_buttons_has_spacer[j] = FALSE;
-      
+
     for (i = 0; new_layout.right_buttons[i] != META_BUTTON_FUNCTION_LAST; i++);
     for (j = 0; j < i; j++)
       {
@@ -1799,7 +1799,7 @@ gboolean
 meta_prefs_get_application_based (void)
 {
   return FALSE; /* For now, we never want this to do anything */
-  
+
   return application_based;
 }
 
@@ -1836,7 +1836,7 @@ meta_preference_to_string (MetaPreference pref)
 
     case META_PREF_RAISE_ON_CLICK:
       return "RAISE_ON_CLICK";
-      
+
     case META_PREF_THEME:
       return "THEME";
 
@@ -1869,7 +1869,7 @@ meta_preference_to_string (MetaPreference pref)
 
     case META_PREF_AUTO_RAISE:
       return "AUTO_RAISE";
-      
+
     case META_PREF_AUTO_RAISE_DELAY:
       return "AUTO_RAISE_DELAY";
 
@@ -1985,16 +1985,16 @@ meta_key_pref_free (MetaKeyPref *pref)
 {
   update_binding (pref, NULL);
 
-  g_free (pref->name);
-  g_free (pref->schema);
+  free (pref->name);
+  free (pref->schema);
 
-  g_free (pref);
+  free (pref);
 }
 
 static void
 init_bindings (void)
 {
-  key_bindings = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+  key_bindings = g_hash_table_new_full (g_str_hash, g_str_equal, free,
                                         (GDestroyNotify)meta_key_pref_free);
 }
 
@@ -2021,10 +2021,10 @@ update_binding (MetaKeyPref *binding,
   /* Okay, so, we're about to provide a new list of key combos for this
    * action. Delete any pre-existing list.
    */
-  g_slist_foreach (binding->bindings, (GFunc) g_free, NULL);
+  g_slist_foreach (binding->bindings, (GFunc) free, NULL);
   g_slist_free (binding->bindings);
   binding->bindings = NULL;
-  
+
   for (i = 0; strokes && strokes[i]; i++)
     {
       keysym = 0;
@@ -2143,7 +2143,7 @@ meta_prefs_get_workspace_name (int i)
     {
       char *generated_name = g_strdup_printf (_("Workspace %d"), i + 1);
       name = g_intern_string (generated_name);
-      g_free (generated_name);
+      free (generated_name);
     }
   else
     name = workspace_names[i];
@@ -2160,7 +2160,7 @@ meta_prefs_change_workspace_name (int         num,
 {
   GVariantBuilder builder;
   int n_workspace_names, i;
-  
+
   g_return_if_fail (num >= 0);
 
   meta_topic (META_DEBUG_PREFS,
@@ -2261,7 +2261,7 @@ meta_prefs_add_keybinding (const char           *name,
       char *changed_signal = g_strdup_printf ("changed::%s", name);
       id = g_signal_connect (settings, changed_signal,
                              G_CALLBACK (bindings_changed), NULL);
-      g_free (changed_signal);
+      free (changed_signal);
 
       g_object_set_data (G_OBJECT (settings), name, GUINT_TO_POINTER (id));
 
@@ -2354,7 +2354,7 @@ meta_prefs_remove_custom_keybinding (const char *name)
 
 /**
  * meta_prefs_get_keybindings:
- * 
+ *
  * Returns: (element-type MetaKeyPref) (transfer container):
  */
 GList *

--- a/src/core/restart.c
+++ b/src/core/restart.c
@@ -71,7 +71,7 @@ restart_helper_read_line_callback (GObject      *source_object,
                     error ? error->message : NULL);
     }
   else
-    g_free (line); /* We don't actually care what the restart helper outputs */
+    free (line); /* We don't actually care what the restart helper outputs */
 
   g_object_unref (source_object);
 

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1,13 +1,13 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2001, 2002 Havoc Pennington
  * Copyright (C) 2002, 2003 Red Hat Inc.
  * Some ICCCM manager selection code derived from fvwm2,
  * Copyright (C) 2001 Dominik Vogt, Matthias Clasen, and fvwm2 team
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -17,7 +17,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -168,7 +168,7 @@ static void
 meta_screen_finalize (GObject *object)
 {
   /* Actual freeing done in meta_screen_free() for now */
-  
+
   G_OBJECT_CLASS (meta_screen_parent_class)->finalize (object);
 }
 
@@ -387,7 +387,7 @@ set_wm_check_hint (MetaScreen *screen)
   unsigned long data[1];
 
   g_return_val_if_fail (screen->display->leader_window != None, 0);
-  
+
   data[0] = screen->display->leader_window;
 
   XChangeProperty (screen->display->xdisplay, screen->xroot,
@@ -401,7 +401,7 @@ set_wm_check_hint (MetaScreen *screen)
 static void
 unset_wm_check_hint (MetaScreen *screen)
 {
-  XDeleteProperty (screen->display->xdisplay, screen->xroot, 
+  XDeleteProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_SUPPORTING_WM_CHECK);
 }
 
@@ -530,7 +530,7 @@ reload_monitor_infos (MetaScreen *screen)
         MetaWorkspace *space = tmp->data;
 
         meta_workspace_invalidate_work_area (space);
-        
+
         tmp = tmp->next;
       }
   }
@@ -596,7 +596,7 @@ reload_monitor_infos (MetaScreen *screen)
         {
           screen->monitor_infos = g_new0 (MetaMonitorInfo, n_infos);
           screen->n_monitor_infos = n_infos;
-          
+
           i = 0;
           while (i < n_infos)
             {
@@ -614,11 +614,11 @@ reload_monitor_infos (MetaScreen *screen)
                           screen->monitor_infos[i].rect.y,
                           screen->monitor_infos[i].rect.width,
                           screen->monitor_infos[i].rect.height);
-              
+
               ++i;
             }
         }
-      
+
       meta_XFree (infos);
 
 #ifdef HAVE_RANDR
@@ -680,16 +680,16 @@ reload_monitor_infos (MetaScreen *screen)
                                 screen->number,
 				monitors, hints,
                                 &n_monitors);
-      /* Yes I know it should be Success but the current implementation 
+      /* Yes I know it should be Success but the current implementation
        * returns the num of monitor
        */
       if (result > 0)
 	{
           g_assert (n_monitors > 0);
-          
+
           screen->monitor_infos = g_new0 (MetaMonitorInfo, n_monitors);
           screen->n_monitor_infos = n_monitors;
-          
+
           i = 0;
           while (i < n_monitors)
             {
@@ -705,8 +705,8 @@ reload_monitor_infos (MetaScreen *screen)
                           screen->monitor_infos[i].rect.x,
                           screen->monitor_infos[i].rect.y,
                           screen->monitor_infos[i].rect.width,
-                          screen->monitor_infos[i].rect.height);              
-              
+                          screen->monitor_infos[i].rect.height);
+
               ++i;
             }
 	}
@@ -722,7 +722,7 @@ reload_monitor_infos (MetaScreen *screen)
               "Muffin compiled without Solaris Xinerama support\n");
 #endif /* HAVE_SOLARIS_XINERAMA */
 
-  
+
   /* If no Xinerama, fill in the single screen info so
    * we can use the field unconditionally
    */
@@ -730,10 +730,10 @@ reload_monitor_infos (MetaScreen *screen)
     {
       meta_topic (META_DEBUG_XINERAMA,
                   "No Xinerama screens, using default screen info\n");
-          
+
       screen->monitor_infos = g_new0 (MetaMonitorInfo, 1);
       screen->n_monitor_infos = 1;
-          
+
       screen->monitor_infos[0].number = 0;
       screen->monitor_infos[0].rect = screen->rect;
       screen->monitor_infos[0].in_fullscreen = -1;
@@ -757,7 +757,7 @@ create_guard_window (Display *xdisplay, MetaScreen *screen)
   XSetWindowAttributes attributes;
   Window guard_window;
   gulong create_serial;
-  
+
   attributes.event_mask = NoEventMask;
   attributes.override_redirect = True;
   attributes.background_pixel = BlackPixel (xdisplay, screen->number);
@@ -807,14 +807,14 @@ meta_screen_new (MetaDisplay *display,
   guint32 manager_timestamp;
 
   replace_current_wm = meta_get_replace_current_wm ();
-  
+
   /* Only display->name, display->xdisplay, and display->error_traps
    * can really be used in this function, since normally screens are
    * created from the MetaDisplay constructor
    */
-  
+
   xdisplay = display->xdisplay;
-  
+
   meta_verbose ("Trying screen %d on display '%s'\n",
                 number, display->name);
 
@@ -831,14 +831,14 @@ meta_screen_new (MetaDisplay *display,
     }
 
   sprintf (buf, "WM_S%d", number);
-  wm_sn_atom = XInternAtom (xdisplay, buf, False);  
-  
+  wm_sn_atom = XInternAtom (xdisplay, buf, False);
+
   current_wm_sn_owner = XGetSelectionOwner (xdisplay, wm_sn_atom);
 
   if (current_wm_sn_owner != None)
     {
       XSetWindowAttributes attrs;
-      
+
       if (!replace_current_wm)
         {
           meta_warning (_("Screen %d on display \"%s\" already has a window manager; try using the --replace option to replace the current window manager.\n"),
@@ -862,7 +862,7 @@ meta_screen_new (MetaDisplay *display,
   new_wm_sn_owner = meta_create_offscreen_window (xdisplay, xroot, NoEventMask);
 
   manager_timestamp = timestamp;
-  
+
   XSetSelectionOwner (xdisplay, wm_sn_atom, new_wm_sn_owner,
                       manager_timestamp);
 
@@ -872,14 +872,14 @@ meta_screen_new (MetaDisplay *display,
                     number, display->name);
 
       XDestroyWindow (xdisplay, new_wm_sn_owner);
-      
+
       return NULL;
     }
-  
+
   {
     /* Send client message indicating that we are now the WM */
     XClientMessageEvent ev;
-    
+
     ev.type = ClientMessage;
     ev.window = xroot;
     ev.message_type = display->atom_MANAGER;
@@ -896,7 +896,7 @@ meta_screen_new (MetaDisplay *display,
       XEvent event;
 
       /* We sort of block infinitely here which is probably lame. */
-      
+
       meta_verbose ("Waiting for old window manager to exit\n");
       do
         {
@@ -905,7 +905,7 @@ meta_screen_new (MetaDisplay *display,
         }
       while (event.type != DestroyNotify);
     }
-  
+
   /* select our root window events */
   meta_error_trap_push_with_return (display);
 
@@ -927,13 +927,13 @@ meta_screen_new (MetaDisplay *display,
                     number, display->name);
 
       XDestroyWindow (xdisplay, new_wm_sn_owner);
-      
+
       return NULL;
     }
-  
+
   screen = g_object_new (META_TYPE_SCREEN, NULL);
   screen->closing = 0;
-  
+
   screen->display = display;
   screen->number = number;
   screen->screen_name = get_screen_name (display, number);
@@ -951,8 +951,8 @@ meta_screen_new (MetaDisplay *display,
   screen->wm_sn_atom = wm_sn_atom;
   screen->wm_sn_timestamp = manager_timestamp;
 
-  screen->wm_cm_selection_window = meta_create_offscreen_window (xdisplay, 
-                                                                 xroot, 
+  screen->wm_cm_selection_window = meta_create_offscreen_window (xdisplay,
+                                                                 xroot,
                                                                  NoEventMask);
   screen->work_area_later = 0;
   screen->check_fullscreen_later = 0;
@@ -969,13 +969,13 @@ meta_screen_new (MetaDisplay *display,
 
   screen->monitor_infos = NULL;
   screen->n_monitor_infos = 0;
-  screen->last_monitor_index = 0;  
-  
+  screen->last_monitor_index = 0;
+
   reload_monitor_infos (screen);
-  
+
   meta_screen_set_cursor (screen, META_CURSOR_DEFAULT);
 
-  /* Handle creating a no_focus_window for this screen */  
+  /* Handle creating a no_focus_window for this screen */
   screen->no_focus_window =
     meta_create_offscreen_window (display->xdisplay,
                                   screen->xroot,
@@ -984,7 +984,7 @@ meta_screen_new (MetaDisplay *display,
   /* Done with no_focus_window stuff */
 
   set_supported_hint (screen);
-  
+
   set_wm_check_hint (screen);
 
   set_desktop_viewport_hint (screen);
@@ -998,7 +998,7 @@ meta_screen_new (MetaDisplay *display,
    */
   meta_workspace_activate (meta_workspace_new (screen), timestamp);
   update_num_workspaces (screen, timestamp);
-  
+
   set_workspace_names (screen);
 
   screen->all_keys_grabbed = FALSE;
@@ -1034,7 +1034,7 @@ meta_screen_new (MetaDisplay *display,
 
   meta_verbose ("Added screen %d ('%s') root 0x%lx\n",
                 screen->number, screen->screen_name, screen->xroot);
-  
+
   return screen;
 }
 
@@ -1047,16 +1047,16 @@ meta_screen_free (MetaScreen *screen,
   display = screen->display;
 
   screen->closing += 1;
-  
+
   meta_display_grab (display);
 
   meta_compositor_unmanage_screen (screen->display->compositor,
                                    screen);
 
   meta_display_unmanage_windows_for_screen (display, screen, timestamp);
-  
+
   meta_prefs_remove_listener (prefs_changed_callback, screen);
-  
+
   meta_screen_ungrab_keys (screen);
 
 #ifdef HAVE_STARTUP_NOTIFICATION
@@ -1076,7 +1076,7 @@ meta_screen_free (MetaScreen *screen,
       screen->sn_context = NULL;
     }
 #endif
-  
+
   meta_ui_free (screen->ui);
 
   meta_stack_free (screen->stack);
@@ -1092,7 +1092,7 @@ meta_screen_free (MetaScreen *screen,
 
   XDestroyWindow (screen->display->xdisplay,
                   screen->wm_sn_selection_window);
-  
+
   if (screen->work_area_later != 0) {
     g_source_remove (screen->work_area_later);
     screen->work_area_later = 0;
@@ -1101,7 +1101,7 @@ meta_screen_free (MetaScreen *screen,
   if (screen->check_fullscreen_later != 0)
     g_source_remove (screen->check_fullscreen_later);
 
-  g_free (screen->monitor_infos);
+  free (screen->monitor_infos);
 
   if (screen->tile_preview_timeout_id) {
     g_source_remove (screen->tile_preview_timeout_id);
@@ -1118,7 +1118,7 @@ meta_screen_free (MetaScreen *screen,
     screen->snap_osd_timeout_id = 0;
   }
 
-  g_free (screen->screen_name);
+  free (screen->screen_name);
 
   g_object_unref (screen);
 
@@ -1150,7 +1150,7 @@ list_windows (MetaScreen *screen)
       WindowInfo *info = g_new0 (WindowInfo, 1);
 
       meta_error_trap_push_with_return (screen->display);
-      
+
       XGetWindowAttributes (screen->display->xdisplay,
                             children[i], &info->attrs);
 
@@ -1158,7 +1158,7 @@ list_windows (MetaScreen *screen)
 	{
           meta_verbose ("Failed to get attributes for window 0x%lx\n",
                         children[i]);
-	  g_free (info);
+	  free (info);
         }
       else
         {
@@ -1199,7 +1199,7 @@ meta_screen_manage_all_windows (MetaScreen *screen)
     }
   meta_stack_thaw (screen->stack);
 
-  g_list_foreach (windows, (GFunc)g_free, NULL);
+  g_list_foreach (windows, (GFunc)free, NULL);
   g_list_free (windows);
 
   meta_display_ungrab (screen->display);
@@ -1227,7 +1227,7 @@ meta_screen_composite_all_windows (MetaScreen *screen)
     }
 
   g_slist_free (windows);
-  
+
   /* initialize the compositor's view of the stacking order */
   meta_stack_tracker_sync_stack (screen->stack_tracker);
 }
@@ -1245,12 +1245,12 @@ MetaScreen*
 meta_screen_for_x_screen (Screen *xscreen)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (DisplayOfScreen (xscreen));
 
   if (display == NULL)
     return NULL;
-  
+
   return meta_display_screen_for_x_screen (display, xscreen);
 }
 
@@ -1259,7 +1259,7 @@ prefs_changed_callback (MetaPreference pref,
                         gpointer       data)
 {
   MetaScreen *screen = data;
-  
+
   if ((pref == META_PREF_NUM_WORKSPACES ||
        pref == META_PREF_DYNAMIC_WORKSPACES) &&
       !meta_prefs_get_dynamic_workspaces ())
@@ -1267,7 +1267,7 @@ prefs_changed_callback (MetaPreference pref,
       /* GSettings doesn't provide timestamps, but luckily update_num_workspaces
        * often doesn't need it...
        */
-      guint32 timestamp = 
+      guint32 timestamp =
         meta_display_get_current_time_roundtrip (screen->display);
       update_num_workspaces (screen, timestamp);
     }
@@ -1289,7 +1289,7 @@ get_screen_name (MetaDisplay *display,
   char *p;
   char *dname;
   char *scr;
-  
+
   /* DisplayString gives us a sort of canonical display,
    * vs. the user-entered name from XDisplayName()
    */
@@ -1304,10 +1304,10 @@ get_screen_name (MetaDisplay *display,
       if (p)
         *p = '\0';
     }
-  
+
   scr = g_strdup_printf ("%s.%d", dname, number);
 
-  g_free (dname);
+  free (dname);
 
   return scr;
 }
@@ -1327,7 +1327,7 @@ static void
 listify_func (gpointer key, gpointer value, gpointer data)
 {
   GSList **listp;
-  
+
   listp = data;
 
   *listp = g_slist_prepend (*listp, value);
@@ -1353,14 +1353,14 @@ meta_screen_foreach_window (MetaScreen *screen,
   /* If we end up doing this often, just keeping a list
    * of windows might be sensible.
    */
-  
+
   winlist = NULL;
   g_hash_table_foreach (screen->display->window_ids,
                         listify_func,
                         &winlist);
-  
+
   winlist = g_slist_sort (winlist, ptrcmp);
-  
+
   tmp = winlist;
   while (tmp != NULL)
     {
@@ -1375,7 +1375,7 @@ meta_screen_foreach_window (MetaScreen *screen,
           if (window->screen == screen && !window->override_redirect)
             (* func) (screen, window, data);
         }
-      
+
       tmp = tmp->next;
     }
   g_slist_free (winlist);
@@ -1434,7 +1434,7 @@ meta_screen_get_workspace_by_index (MetaScreen  *screen,
   /* should be robust, idx is maybe from an app */
   if (idx < 0)
     return NULL;
-  
+
   i = 0;
   tmp = screen->workspaces;
   while (tmp != NULL)
@@ -1693,7 +1693,7 @@ update_num_workspaces (MetaScreen *screen,
   GList *extras;
   MetaWorkspace *last_remaining;
   gboolean need_change_space;
-  
+
   new_num = meta_prefs_get_num_workspaces ();
 
   g_assert (new_num > 0);
@@ -1713,14 +1713,14 @@ update_num_workspaces (MetaScreen *screen,
         extras = g_list_prepend (extras, w);
       else
         last_remaining = w;
-          
+
       ++i;
       tmp = tmp->next;
     }
   old_num = i;
 
   g_assert (last_remaining);
-  
+
   /* Get rid of the extra workspaces by moving all their windows
    * to last_remaining, then activating last_remaining if
    * one of the removed workspaces was active. This will be a bit
@@ -1733,11 +1733,11 @@ update_num_workspaces (MetaScreen *screen,
     {
       MetaWorkspace *w = tmp->data;
 
-      meta_workspace_relocate_windows (w, last_remaining);      
+      meta_workspace_relocate_windows (w, last_remaining);
 
       if (w == screen->active_workspace)
         need_change_space = TRUE;
-      
+
       tmp = tmp->next;
     }
 
@@ -1789,7 +1789,7 @@ meta_screen_set_cursor (MetaScreen *screen,
     return;
 
   screen->current_cursor = cursor;
-  
+
   xcursor = meta_display_create_x_cursor (screen->display, cursor);
   XDefineCursor (screen->display->xdisplay, screen->xroot, xcursor);
   XFlush (screen->display->xdisplay);
@@ -1801,7 +1801,7 @@ meta_screen_update_cursor (MetaScreen *screen)
 {
   Cursor xcursor;
 
-  xcursor = meta_display_create_x_cursor (screen->display, 
+  xcursor = meta_display_create_x_cursor (screen->display,
 					  screen->current_cursor);
   XDefineCursor (screen->display->xdisplay, screen->xroot, xcursor);
   XFlush (screen->display->xdisplay);
@@ -1815,7 +1815,7 @@ snap_osd_timeout (void *data)
   int monitor;
 
   monitor = meta_screen_get_current_monitor (screen);
-  
+
   if (meta_screen_tile_preview_get_visible (screen) ||
       meta_screen_tile_hud_get_visible (screen))
       g_signal_emit (screen, screen_signals[SNAP_OSD_SHOW], 0, monitor);
@@ -2085,9 +2085,9 @@ meta_screen_get_mouse_window (MetaScreen  *screen,
   int root_x_return, root_y_return;
   int win_x_return, win_y_return;
   unsigned int mask_return;
-  
+
   window = NULL;
-  
+
   if (not_this_one)
     meta_topic (META_DEBUG_FOCUS,
                 "Focusing mouse window excluding %s\n", not_this_one->desc);
@@ -2181,7 +2181,7 @@ meta_screen_get_monitor_index_for_rect (MetaScreen    *screen,
   return monitor->number;
 }
 
-LOCAL_SYMBOL const MetaMonitorInfo* 
+LOCAL_SYMBOL const MetaMonitorInfo*
 meta_screen_get_monitor_neighbor (MetaScreen         *screen,
                                   int                 which_monitor,
                                   MetaScreenDirection direction)
@@ -2194,23 +2194,23 @@ meta_screen_get_monitor_neighbor (MetaScreen         *screen,
     {
       current = screen->monitor_infos + i;
 
-      if ((direction == META_SCREEN_RIGHT && 
+      if ((direction == META_SCREEN_RIGHT &&
            current->rect.x == input->rect.x + input->rect.width &&
            meta_rectangle_vert_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_LEFT && 
+          (direction == META_SCREEN_LEFT &&
            input->rect.x == current->rect.x + current->rect.width &&
            meta_rectangle_vert_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_UP && 
+          (direction == META_SCREEN_UP &&
            input->rect.y == current->rect.y + current->rect.height &&
            meta_rectangle_horiz_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_DOWN && 
+          (direction == META_SCREEN_DOWN &&
            current->rect.y == input->rect.y + input->rect.height &&
            meta_rectangle_horiz_overlap(&current->rect, &input->rect)))
         {
           return current;
         }
     }
-  
+
   return NULL;
 }
 
@@ -2250,7 +2250,7 @@ meta_screen_get_natural_monitor_list (MetaScreen *screen,
 
   while (!g_queue_is_empty (monitor_queue))
     {
-      current = (const MetaMonitorInfo*) 
+      current = (const MetaMonitorInfo*)
         g_queue_pop_head (monitor_queue);
 
       (*monitors_list)[cur++] = current->number;
@@ -2305,7 +2305,7 @@ meta_screen_get_natural_monitor_list (MetaScreen *screen,
         }
     }
 
-  g_free (visited);
+  free (visited);
   g_queue_free (monitor_queue);
 }
 
@@ -2330,10 +2330,10 @@ meta_screen_get_current_monitor (MetaScreen *screen)
 {
   if (screen->n_monitor_infos == 1)
     return 0;
-  
+
   /* Sadly, we have to do it this way. Yuck.
    */
-  
+
   if (screen->display->monitor_cache_invalidated)
     {
       Window root_return, child_return;
@@ -2341,9 +2341,9 @@ meta_screen_get_current_monitor (MetaScreen *screen)
       unsigned int mask_return;
       int i;
       MetaRectangle pointer_position;
-      
+
       screen->display->monitor_cache_invalidated = FALSE;
-      
+
       pointer_position.width = pointer_position.height = 1;
       XQueryPointer (screen->display->xdisplay,
                      screen->xroot,
@@ -2365,7 +2365,7 @@ meta_screen_get_current_monitor (MetaScreen *screen)
               break;
             }
         }
-      
+
       meta_topic (META_DEBUG_XINERAMA,
                   "Rechecked current monitor, now %d\n",
                   screen->last_monitor_index);
@@ -2434,7 +2434,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
 
   if (screen->workspace_layout_overridden)
     return;
-  
+
   list = NULL;
   n_items = 0;
 
@@ -2446,7 +2446,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
       if (n_items == 3 || n_items == 4)
         {
           int cols, rows;
-          
+
           switch (list[0])
             {
             case _NET_WM_ORIENTATION_HORZ:
@@ -2473,7 +2473,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
                 screen->rows_of_workspaces = rows;
               else
                 screen->rows_of_workspaces = -1;
-              
+
               if (cols > 0)
                 screen->columns_of_workspaces = cols;
               else
@@ -2577,10 +2577,10 @@ set_workspace_names (MetaScreen *screen)
                              strlen (name) + 1);
       else
         g_string_append_len (flattened, "", 1);
-      
+
       ++i;
     }
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay,
                    screen->xroot,
@@ -2589,7 +2589,7 @@ set_workspace_names (MetaScreen *screen)
                    8, PropModeReplace,
 		   (unsigned char *)flattened->str, flattened->len);
   meta_error_trap_pop (screen->display);
-  
+
   g_string_free (flattened, TRUE);
 }
 
@@ -2603,7 +2603,7 @@ meta_screen_update_workspace_names (MetaScreen *screen)
   /* this updates names in prefs when the root window property changes,
    * iff the new property contents don't match what's already in prefs
    */
-  
+
   names = NULL;
   n_names = 0;
   if (!meta_prop_get_utf8_list (screen->display,
@@ -2623,10 +2623,10 @@ meta_screen_update_workspace_names (MetaScreen *screen)
                   "Setting workspace %d name to \"%s\" due to _NET_DESKTOP_NAMES change\n",
                   i, names[i] ? names[i] : "null");
       meta_prefs_change_workspace_name (i, names[i]);
-      
+
       ++i;
     }
-  
+
   g_strfreev (names);
 }
 
@@ -2643,7 +2643,7 @@ meta_create_offscreen_window (Display *xdisplay,
    */
   attrs.override_redirect = True;
   attrs.event_mask = valuemask;
-  
+
   return XCreateWindow (xdisplay,
                         parent,
                         -100, -100, 1, 1,
@@ -2662,12 +2662,12 @@ set_work_area_hint (MetaScreen *screen)
   GList *tmp_list;
   unsigned long *data, *tmp;
   MetaRectangle area;
-  
+
   num_workspaces = meta_screen_get_n_workspaces (screen);
   data = g_new (unsigned long, num_workspaces * 4);
   tmp_list = screen->workspaces;
   tmp = data;
-  
+
   while (tmp_list != NULL)
     {
       MetaWorkspace *workspace = tmp_list->data;
@@ -2682,16 +2682,16 @@ set_work_area_hint (MetaScreen *screen)
 
 	  tmp += 4;
         }
-      
+
       tmp_list = tmp_list->next;
     }
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
 		   screen->display->atom__NET_WORKAREA,
 		   XA_CARDINAL, 32, PropModeReplace,
 		   (guchar*) data, num_workspaces*4);
-  g_free (data);
+  free (data);
   meta_error_trap_pop (screen->display);
 
   g_signal_emit (screen, screen_signals[WORKAREAS_CHANGED], 0);
@@ -2702,11 +2702,11 @@ set_work_area_later_func (MetaScreen *screen)
 {
   meta_topic (META_DEBUG_WORKAREA,
               "Running work area hint computation function\n");
-  
+
   screen->work_area_later = 0;
-  
+
   set_work_area_hint (screen);
-  
+
   return FALSE;
 }
 
@@ -2758,7 +2758,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
   int *grid;
   int i, r, c;
   int current_row, current_col;
-  
+
   rows = screen->rows_of_workspaces;
   cols = screen->columns_of_workspaces;
   if (rows <= 0 && cols <= 0)
@@ -2776,56 +2776,56 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
     cols = 1;
 
   g_assert (rows != 0 && cols != 0);
-  
+
   grid_area = rows * cols;
-  
+
   meta_verbose ("Getting layout rows = %d cols = %d current = %d "
                 "num_spaces = %d vertical = %s corner = %s\n",
                 rows, cols, current_space, num_workspaces,
                 screen->vertical_workspaces ? "(true)" : "(false)",
                 meta_screen_corner_to_string (screen->starting_corner));
-  
-  /* ok, we want to setup the distances in the workspace array to go     
-   * in each direction. Remember, there are many ways that a workspace   
-   * array can be setup.                                                 
-   * see http://www.freedesktop.org/standards/wm-spec/1.2/html/x109.html 
-   * and look at the _NET_DESKTOP_LAYOUT section for details.            
+
+  /* ok, we want to setup the distances in the workspace array to go
+   * in each direction. Remember, there are many ways that a workspace
+   * array can be setup.
+   * see http://www.freedesktop.org/standards/wm-spec/1.2/html/x109.html
+   * and look at the _NET_DESKTOP_LAYOUT section for details.
    * For instance:
    */
-  /* starting_corner = META_SCREEN_TOPLEFT                         
+  /* starting_corner = META_SCREEN_TOPLEFT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       1234                                    1357            
-   *       5678                                    2468            
-   *                                                               
-   * starting_corner = META_SCREEN_TOPRIGHT                        
+   *       1234                                    1357
+   *       5678                                    2468
+   *
+   * starting_corner = META_SCREEN_TOPRIGHT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       4321                                    7531            
-   *       8765                                    8642            
-   *                                                               
-   * starting_corner = META_SCREEN_BOTTOMLEFT                      
+   *       4321                                    7531
+   *       8765                                    8642
+   *
+   * starting_corner = META_SCREEN_BOTTOMLEFT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       5678                                    2468            
-   *       1234                                    1357            
-   *                                                               
-   * starting_corner = META_SCREEN_BOTTOMRIGHT                     
+   *       5678                                    2468
+   *       1234                                    1357
+   *
+   * starting_corner = META_SCREEN_BOTTOMRIGHT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       8765                                    8642            
-   *       4321                                    7531            
+   *       8765                                    8642
+   *       4321                                    7531
    *
    */
   /* keep in mind that we could have a ragged layout, e.g. the "8"
    * in the above grids could be missing
    */
 
-  
+
   grid = g_new (int, grid_area);
 
   i = 0;
-  
-  switch (screen->starting_corner) 
+
+  switch (screen->starting_corner)
     {
     case META_SCREEN_TOPLEFT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = 0;
           while (c < cols)
@@ -2857,7 +2857,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_TOPRIGHT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = cols - 1;
           while (c >= 0)
@@ -2889,7 +2889,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_BOTTOMLEFT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = 0;
           while (c < cols)
@@ -2921,7 +2921,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_BOTTOMRIGHT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = cols - 1;
           while (c >= 0)
@@ -2952,12 +2952,12 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
             }
         }
       break;
-    }  
+    }
 
   if (i != grid_area)
     meta_bug ("did not fill in the whole workspace grid in %s (%d filled)\n",
               G_STRFUNC, i);
-  
+
   current_row = 0;
   current_col = 0;
   r = 0;
@@ -3017,7 +3017,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
 LOCAL_SYMBOL void
 meta_screen_free_workspace_layout (MetaWorkspaceLayout *layout)
 {
-  g_free (layout->grid);
+  free (layout->grid);
 }
 
 static void
@@ -3068,7 +3068,7 @@ meta_screen_resize (MetaScreen *screen,
         meta_window_update_for_monitors_changed (window);
     }
 
-  g_free (old_monitor_infos);
+  free (old_monitor_infos);
   g_slist_free (windows);
 
   meta_screen_queue_check_fullscreen (screen);
@@ -3082,7 +3082,7 @@ meta_screen_update_showing_desktop_hint (MetaScreen *screen)
   unsigned long data[1];
 
   data[0] = screen->active_workspace->showing_desktop ? 1 : 0;
-      
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_SHOWING_DESKTOP,
@@ -3110,7 +3110,7 @@ queue_windows_showing (MetaScreen *screen)
 
       if (w->screen == screen)
         meta_window_queue (w, META_QUEUE_CALC_SHOWING);
-      
+
       tmp = tmp->next;
     }
 
@@ -3125,17 +3125,17 @@ meta_screen_minimize_all_on_active_workspace_except (MetaScreen *screen,
   GList *tmp;
 
   windows = screen->active_workspace->windows;
-  
+
   tmp = windows;
   while (tmp != NULL)
     {
       MetaWindow *w = tmp->data;
-      
+
       if (w->screen == screen  &&
           w->has_minimize_func &&
 	  w != keep)
 	meta_window_minimize (w);
-      
+
       tmp = tmp->next;
     }
 }
@@ -3158,16 +3158,16 @@ meta_screen_toggle_desktop (MetaScreen *screen,
 }
 
 void
-meta_screen_show_desktop (MetaScreen *screen, 
+meta_screen_show_desktop (MetaScreen *screen,
                           guint32     timestamp)
 {
   GList *windows;
 
   if (screen->active_workspace->showing_desktop)
     return;
-  
+
   screen->active_workspace->showing_desktop = TRUE;
-  
+
   queue_windows_showing (screen);
 
   /* Focus the most recently used META_WINDOW_DESKTOP window, if there is one;
@@ -3177,18 +3177,18 @@ meta_screen_show_desktop (MetaScreen *screen,
   while (windows != NULL)
     {
       MetaWindow *w = windows->data;
-      
-      if (w->screen == screen  && 
+
+      if (w->screen == screen  &&
           w->type == META_WINDOW_DESKTOP)
         {
           meta_window_focus (w, timestamp);
           break;
         }
-      
+
       windows = windows->next;
     }
 
-  
+
   meta_screen_update_showing_desktop_hint (screen);
 }
 
@@ -3255,7 +3255,7 @@ remove_sequence (MetaScreen        *screen,
   meta_topic (META_DEBUG_STARTUP,
               "Removing sequence %s\n",
               sn_startup_sequence_get_id (sequence));
-  
+
   screen->startup_sequences = g_slist_remove (screen->startup_sequences,
                                               sequence);
 
@@ -3292,7 +3292,7 @@ collect_timed_out_foreach (void *element,
   SnStartupSequence *sequence = element;
   long tv_sec, tv_usec;
   double elapsed;
-  
+
   sn_startup_sequence_get_last_active_time (sequence, &tv_sec, &tv_usec);
 
   elapsed =
@@ -3303,7 +3303,7 @@ collect_timed_out_foreach (void *element,
               "Sequence used %g seconds vs. %g max: %s\n",
               elapsed, (double) STARTUP_TIMEOUT,
               sn_startup_sequence_get_id (sequence));
-  
+
   if (elapsed > STARTUP_TIMEOUT)
     ctod->list = g_slist_prepend (ctod->list, sequence);
 }
@@ -3314,7 +3314,7 @@ startup_sequence_timeout (void *data)
   MetaScreen *screen = data;
   CollectTimedOutData ctod;
   GSList *tmp;
-  
+
   ctod.list = NULL;
   g_get_current_time (&ctod.now);
   g_slist_foreach (screen->startup_sequences,
@@ -3329,14 +3329,14 @@ startup_sequence_timeout (void *data)
       meta_topic (META_DEBUG_STARTUP,
                   "Timed out sequence %s\n",
                   sn_startup_sequence_get_id (sequence));
-      
+
       sn_startup_sequence_complete (sequence);
-      
+
       tmp = tmp->next;
     }
 
   g_slist_free (ctod.list);
-  
+
   if (screen->startup_sequences != NULL)
     {
       return TRUE;
@@ -3355,7 +3355,7 @@ meta_screen_sn_event (SnMonitorEvent *event,
 {
   MetaScreen *screen;
   SnStartupSequence *sequence;
-  
+
   screen = user_data;
 
   sequence = sn_monitor_event_get_startup_sequence (event);
@@ -3369,7 +3369,7 @@ meta_screen_sn_event (SnMonitorEvent *event,
         const char *wmclass;
 
         wmclass = sn_startup_sequence_get_wmclass (sequence);
-        
+
         meta_topic (META_DEBUG_STARTUP,
                     "Received startup initiated for %s wmclass %s\n",
                     sn_startup_sequence_get_id (sequence),
@@ -3435,7 +3435,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   const char *startup_id;
   GSList *tmp;
   SnStartupSequence *sequence;
-  
+
   /* Does the window have a startup ID stored? */
   startup_id = meta_window_get_startup_id (window);
 
@@ -3443,7 +3443,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
               "Applying startup props to %s id \"%s\"\n",
               window->desc,
               startup_id ? startup_id : "(none)");
-  
+
   sequence = NULL;
   if (startup_id == NULL)
     {
@@ -3474,11 +3474,11 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
                           "Ending legacy sequence %s due to window %s\n",
                           sn_startup_sequence_get_id (sequence),
                           window->desc);
-              
+
               sn_startup_sequence_complete (sequence);
               break;
             }
-          
+
           tmp = tmp->next;
         }
     }
@@ -3486,7 +3486,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   /* Still no startup ID? Bail. */
   if (startup_id == NULL)
     return FALSE;
-  
+
   /* We might get this far and not know the sequence ID (if the window
    * already had a startup ID stored), so let's look for one if we don't
    * already know it.
@@ -3497,15 +3497,15 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
       while (tmp != NULL)
         {
           const char *id;
-          
+
           id = sn_startup_sequence_get_id (tmp->data);
-          
+
           if (strcmp (id, startup_id) == 0)
             {
               sequence = tmp->data;
               break;
             }
-          
+
           tmp = tmp->next;
         }
     }
@@ -3513,7 +3513,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   if (sequence != NULL)
     {
       gboolean changed_something = FALSE;
-          
+
       meta_topic (META_DEBUG_STARTUP,
                   "Found startup sequence for window %s ID \"%s\"\n",
                   window->desc, startup_id);
@@ -3526,7 +3526,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
               meta_topic (META_DEBUG_STARTUP,
                           "Setting initial window workspace to %d based on startup info\n",
                           space);
-              
+
               window->initial_workspace_set = TRUE;
               window->initial_workspace = space;
               changed_something = TRUE;
@@ -3539,7 +3539,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
           meta_topic (META_DEBUG_STARTUP,
                       "Setting initial window timestamp to %u based on startup info\n",
                       timestamp);
-              
+
           window->initial_timestamp_set = TRUE;
           window->initial_timestamp = timestamp;
           changed_something = TRUE;
@@ -3553,7 +3553,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
                   "Did not find startup sequence for window %s ID \"%s\"\n",
                   window->desc, startup_id);
     }
-  
+
 #endif /* HAVE_STARTUP_NOTIFICATION */
 
   return FALSE;
@@ -3569,8 +3569,8 @@ meta_screen_get_screen_number (MetaScreen *screen)
  * meta_screen_get_display:
  * Retrieve the display associated with screen.
  * @screen: A #MetaScreen
- * 
- * Returns: (transfer none): Display 
+ *
+ * Returns: (transfer none): Display
  */
 MetaDisplay *
 meta_screen_get_display (MetaScreen *screen)
@@ -3596,7 +3596,7 @@ meta_screen_get_xroot (MetaScreen *screen)
  *
  * Retrieve the size of the screen.
  */
-void 
+void
 meta_screen_get_size (MetaScreen *screen,
                       int        *width,
                       int        *height)
@@ -3617,7 +3617,7 @@ meta_screen_set_cm_selection (MetaScreen *screen)
   g_snprintf (selection, sizeof(selection), "_NET_WM_CM_S%d", screen->number);
   meta_verbose ("Setting selection: %s\n", selection);
   a = XInternAtom (screen->display->xdisplay, selection, FALSE);
-  XSetSelectionOwner (screen->display->xdisplay, a, 
+  XSetSelectionOwner (screen->display->xdisplay, a,
                       screen->wm_cm_selection_window, screen->wm_cm_timestamp);
 }
 
@@ -3697,11 +3697,11 @@ meta_screen_set_active_workspace_hint (MetaScreen *screen)
    */
   if (screen->closing > 0)
     return;
-  
+
   data[0] = meta_workspace_index (screen->active_workspace);
 
   meta_verbose ("Setting _NET_CURRENT_DESKTOP to %lu\n", data[0]);
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_CURRENT_DESKTOP,
@@ -3790,7 +3790,7 @@ check_fullscreen_func (gpointer data)
                 fullscreen_monitors = g_slist_prepend (fullscreen_monitors, monitor_p);
             }
 
-          g_free (monitors);
+          free (monitors);
         }
     }
 

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -2,11 +2,11 @@
 
 /* Muffin Session Management */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington (some code in here from
  * libgnomeui, (C) Tom Tromey, Carsten Schaar)
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -70,7 +70,7 @@ meta_window_release_saved_state (const MetaWindowSessionInfo *info)
 
 static void ice_io_error_handler (IceConn connection);
 
-static void new_ice_connection (IceConn connection, IcePointer client_data, 
+static void new_ice_connection (IceConn connection, IcePointer client_data,
 				Bool opening, IcePointer *watch_data);
 
 static void        save_state         (void);
@@ -100,7 +100,7 @@ process_ice_messages (GIOChannel *channel,
 #if 0
       IcePointer context = IceGetConnectionContext (connection);
 #endif
-      
+
       /* We were disconnected; close our connection to the
        * session manager, this will result in the ICE connection
        * being cleaned up, since it is owned by libSM.
@@ -110,7 +110,7 @@ process_ice_messages (GIOChannel *channel,
 
       return FALSE;
     }
-  
+
   return TRUE;
 }
 
@@ -128,22 +128,22 @@ new_ice_connection (IceConn connection, IcePointer client_data, Bool opening,
        * exec'ed children
        */
       GIOChannel *channel;
-      
+
       fcntl (IceConnectionNumber (connection), F_SETFD,
              fcntl (IceConnectionNumber (connection), F_GETFD, 0) | FD_CLOEXEC);
 
       channel = g_io_channel_unix_new (IceConnectionNumber (connection));
-      
+
       input_id = g_io_add_watch (channel,
                                  G_IO_IN | G_IO_ERR,
                                  process_ice_messages,
                                  connection);
 
       g_io_channel_unref (channel);
-      
+
       *watch_data = (IcePointer) GUINT_TO_POINTER (input_id);
     }
-  else 
+  else
     {
       input_id = GPOINTER_TO_UINT ((gpointer) *watch_data);
       if (input_id) {
@@ -154,14 +154,14 @@ new_ice_connection (IceConn connection, IcePointer client_data, Bool opening,
 
 static IceIOErrorHandler ice_installed_handler;
 
-/* We call any handler installed before (or after) gnome_ice_init but 
+/* We call any handler installed before (or after) gnome_ice_init but
    avoid calling the default libICE handler which does an exit() */
 static void
 ice_io_error_handler (IceConn connection)
 {
     if (ice_installed_handler)
       (*ice_installed_handler) (connection);
-}    
+}
 
 static void
 ice_init (void)
@@ -230,7 +230,7 @@ meta_session_init (const char *previous_client_id,
   unsigned long mask;
   SmcCallbacks callbacks;
   char *saved_client_id;
-  
+
   meta_topic (META_DEBUG_SM, "Initializing session with save file '%s'\n",
               previous_save_file ? previous_save_file : "(none)");
 
@@ -243,30 +243,30 @@ meta_session_init (const char *previous_client_id,
     {
       char *save_file = g_strconcat (previous_client_id, ".ms", NULL);
       saved_client_id = load_state (save_file);
-      g_free (save_file);
+      free (save_file);
     }
   else
     {
       saved_client_id = NULL;
     }
-  
+
   ice_init ();
-  
+
   mask = SmcSaveYourselfProcMask | SmcDieProcMask |
     SmcSaveCompleteProcMask | SmcShutdownCancelledProcMask;
-  
+
   callbacks.save_yourself.callback = save_yourself_callback;
   callbacks.save_yourself.client_data = NULL;
-  
+
   callbacks.die.callback = die_callback;
   callbacks.die.client_data = NULL;
-  
+
   callbacks.save_complete.callback = save_complete_callback;
   callbacks.save_complete.client_data = NULL;
-  
+
   callbacks.shutdown_cancelled.callback = shutdown_cancelled_callback;
   callbacks.shutdown_cancelled.client_data = NULL;
-  
+
   session_connection =
     SmcOpenConnection (NULL, /* use SESSION_MANAGER env */
                        NULL, /* means use existing ICE connection */
@@ -277,10 +277,10 @@ meta_session_init (const char *previous_client_id,
                        (char*) previous_client_id,
                        &client_id,
                        255, buf);
-  
+
   if (session_connection == NULL)
     {
-      meta_topic (META_DEBUG_SM, 
+      meta_topic (META_DEBUG_SM,
                   "Failed to a open connection to a session manager, so window positions will not be saved: %s\n",
                   buf);
 
@@ -297,7 +297,7 @@ meta_session_init (const char *previous_client_id,
     current_state = STATE_IDLE;
   else
     current_state = STATE_REGISTERING;
-  
+
   {
     SmProp prop1, prop2, prop3, prop4, prop5, prop6, *props[6];
     SmPropValue prop1val, prop2val, prop3val, prop4val, prop5val, prop6val;
@@ -329,7 +329,7 @@ meta_session_init (const char *previous_client_id,
     prop2.vals = &prop2val;
     prop2val.value = (char*) g_get_user_name ();
     prop2val.length = strlen (prop2val.value);
-	
+
     prop3.name = SmRestartStyleHint;
     prop3.type = SmCARD8;
     prop3.num_vals = 1;
@@ -343,7 +343,7 @@ meta_session_init (const char *previous_client_id,
     prop4.num_vals = 1;
     prop4.vals = &prop4val;
     prop4val.value = pid;
-    prop4val.length = strlen (prop4val.value);    
+    prop4val.length = strlen (prop4val.value);
 
     /* Always start in home directory */
     prop5.name = SmCurrentDirectory;
@@ -359,19 +359,19 @@ meta_session_init (const char *previous_client_id,
     prop6.vals = &prop6val;
     prop6val.value = &priority;
     prop6val.length = 1;
-    
+
     props[0] = &prop1;
     props[1] = &prop2;
     props[2] = &prop3;
     props[3] = &prop4;
     props[4] = &prop5;
     props[5] = &prop6;
-    
+
     SmcSetProperties (session_connection, 6, props);
   }
 
  out:
-  g_free (saved_client_id);
+  free (saved_client_id);
 }
 
 static void
@@ -389,11 +389,11 @@ save_yourself_possibly_done (gboolean shutdown,
   meta_topic (META_DEBUG_SM,
               "save possibly done shutdown = %d success = %d\n",
               shutdown, successful);
-  
+
   if (current_state == STATE_SAVING_PHASE_1)
     {
       Status status;
-      
+
       status = SmcRequestSaveYourselfPhase2 (session_connection,
                                              save_phase_2_callback,
                                              GINT_TO_POINTER (shutdown));
@@ -424,17 +424,17 @@ save_yourself_possibly_done (gboolean shutdown,
       meta_topic (META_DEBUG_SM,
                   "Requested interact, status = %d\n", status);
     }
-  
+
   if (current_state == STATE_SAVING_PHASE_1 ||
       current_state == STATE_SAVING_PHASE_2 ||
       current_state == STATE_DONE_WITH_INTERACT ||
       current_state == STATE_SKIPPING_GLOBAL_SAVE)
     {
       meta_topic (META_DEBUG_SM, "Sending SaveYourselfDone\n");
-      
+
       SmcSaveYourselfDone (session_connection,
                            successful);
-      
+
       if (shutdown)
         current_state = STATE_FROZEN;
       else
@@ -442,19 +442,19 @@ save_yourself_possibly_done (gboolean shutdown,
     }
 }
 
-static void 
+static void
 save_phase_2_callback (SmcConn smc_conn, SmPointer client_data)
 {
   gboolean shutdown;
 
   meta_topic (META_DEBUG_SM, "Phase 2 save");
-  
+
   shutdown = GPOINTER_TO_INT (client_data);
-  
+
   current_state = STATE_SAVING_PHASE_2;
 
   save_state ();
-  
+
   save_yourself_possibly_done (shutdown, TRUE);
 }
 
@@ -469,9 +469,9 @@ save_yourself_callback (SmcConn   smc_conn,
   gboolean successful;
 
   meta_topic (META_DEBUG_SM, "SaveYourself received");
-  
+
   successful = TRUE;
-  
+
   /* The first SaveYourself after registering for the first time
    * is a special case (SM specs 7.2).
    */
@@ -481,8 +481,8 @@ save_yourself_callback (SmcConn   smc_conn,
     {
       current_state = STATE_IDLE;
       /* Double check that this is a section 7.2 SaveYourself: */
-      
-      if (save_style == SmSaveLocal && 
+
+      if (save_style == SmSaveLocal &&
 	  interact_style == SmInteractStyleNone &&
 	  !shutdown && !fast)
 	{
@@ -494,7 +494,7 @@ save_yourself_callback (SmcConn   smc_conn,
 #endif
 
   /* ignore Global style saves
-   * 
+   *
    * This interpretaion of the Local/Global/Both styles
    * was discussed extensively on the xdg-list. See:
    *
@@ -508,11 +508,11 @@ save_yourself_callback (SmcConn   smc_conn,
     }
 
   interaction_allowed = interact_style != SmInteractStyleNone;
-  
+
   current_state = STATE_SAVING_PHASE_1;
 
   regenerate_save_file ();
-  
+
   set_clone_restart_commands ();
 
   save_yourself_possibly_done (shutdown, successful);
@@ -545,7 +545,7 @@ static void
 shutdown_cancelled_callback (SmcConn smc_conn, SmPointer client_data)
 {
   meta_topic (META_DEBUG_SM, "Shutdown cancelled received\n");
-  
+
   if (session_connection != NULL &&
       (current_state != STATE_IDLE && current_state != STATE_FROZEN))
     {
@@ -554,14 +554,14 @@ shutdown_cancelled_callback (SmcConn smc_conn, SmPointer client_data)
     }
 }
 
-static void 
+static void
 interact_callback (SmcConn smc_conn, SmPointer client_data)
 {
   /* nothing */
   gboolean shutdown;
 
   meta_topic (META_DEBUG_SM, "Interaction permission received\n");
-  
+
   shutdown = GPOINTER_TO_INT (client_data);
 
   current_state = STATE_DONE_WITH_INTERACT;
@@ -580,14 +580,14 @@ set_clone_restart_commands (void)
   const char *prgname;
 
   prgname = g_get_prgname ();
-  
+
   /* Restart (use same client ID) */
-  
+
   prop1.name = SmRestartCommand;
   prop1.type = SmLISTofARRAY8;
-  
+
   g_return_if_fail (client_id);
-  
+
   i = 0;
   restartv[i] = (char *)prgname;
   ++i;
@@ -608,7 +608,7 @@ set_clone_restart_commands (void)
   prop1.num_vals = i;
 
   /* Clone (no client ID) */
-  
+
   i = 0;
   clonev[i] = (char *)prgname;
   ++i;
@@ -616,7 +616,7 @@ set_clone_restart_commands (void)
 
   prop2.name = SmCloneCommand;
   prop2.type = SmLISTofARRAY8;
-  
+
   prop2.vals = g_new (SmPropValue, i);
   i = 0;
   while (clonev[i])
@@ -628,7 +628,7 @@ set_clone_restart_commands (void)
   prop2.num_vals = i;
 
   /* Discard */
-  
+
   i = 0;
   discardv[i] = "rm";
   ++i;
@@ -637,10 +637,10 @@ set_clone_restart_commands (void)
   discardv[i] = (char*) full_save_file ();
   ++i;
   discardv[i] = NULL;
-  
+
   prop3.name = SmDiscardCommand;
   prop3.type = SmLISTofARRAY8;
-  
+
   prop3.vals = g_new (SmPropValue, i);
   i = 0;
   while (discardv[i])
@@ -651,16 +651,16 @@ set_clone_restart_commands (void)
     }
   prop3.num_vals = i;
 
-  
+
   props[0] = &prop1;
   props[1] = &prop2;
   props[2] = &prop3;
-  
+
   SmcSetProperties (session_connection, 3, props);
 
-  g_free (prop1.vals);
-  g_free (prop2.vals);
-  g_free (prop3.vals);
+  free (prop1.vals);
+  free (prop2.vals);
+  free (prop3.vals);
 }
 
 /* The remaining code in this file actually loads/saves the session,
@@ -708,7 +708,7 @@ window_type_to_string (MetaWindowType type)
     }
 
   return "";
-} 
+}
 
 static MetaWindowType
 window_type_from_string (const char *str)
@@ -771,7 +771,7 @@ encode_text_as_utf8_markup (const char *text)
   GString *str;
   const char *p;
   char *escaped;
-  
+
   str = g_string_new ("");
 
   p = text;
@@ -783,7 +783,7 @@ encode_text_as_utf8_markup (const char *text)
 
   escaped = g_markup_escape_text (str->str, str->len);
   g_string_free (str, TRUE);
-  
+
   return escaped;
 }
 
@@ -795,7 +795,7 @@ decode_text_from_utf8 (const char *text)
   const char *p;
 
   str = g_string_new ("");
-  
+
   p = text;
   while (*p)
     {
@@ -817,11 +817,11 @@ save_state (void)
   GSList *windows;
   GSList *tmp;
   int stack_position;
-  
+
   g_assert (client_id);
 
   outfile = NULL;
-  
+
   /*
    * g_get_user_config_dir() is guaranteed to return an existing directory.
    * Eventually, if SM stays with the WM, I'd like to make this
@@ -833,7 +833,7 @@ save_state (void)
   muffin_dir = g_strconcat (g_get_user_config_dir (),
                               G_DIR_SEPARATOR_S "muffin",
                               NULL);
-  
+
   session_dir = g_strconcat (muffin_dir,
                              G_DIR_SEPARATOR_S "sessions",
                              NULL);
@@ -853,7 +853,7 @@ save_state (void)
     }
 
   meta_topic (META_DEBUG_SM, "Saving session to '%s'\n", full_save_file ());
-  
+
   outfile = fopen (full_save_file (), "w");
 
   if (outfile == NULL)
@@ -876,9 +876,9 @@ save_state (void)
    * Note that attributes on <window> are the match info we use to
    * see if the saved state applies to a restored window, and
    * child elements are the saved state to be applied.
-   * 
+   *
    */
-  
+
   fprintf (outfile, "<muffin_session id=\"%s\">\n",
            client_id);
 
@@ -906,7 +906,7 @@ save_state (void)
            * in UTF-8 (I think they are in XPCS which is Latin-1?
            * in practice they are always ascii though.)
            */
-              
+
           sm_client_id = encode_text_as_utf8_markup (window->sm_client_id);
           res_class = window->res_class ?
             encode_text_as_utf8_markup (window->res_class) : NULL;
@@ -918,7 +918,7 @@ save_state (void)
             title = g_markup_escape_text (window->title, -1);
           else
             title = NULL;
-              
+
           meta_topic (META_DEBUG_SM, "Saving session managed window %s, client ID '%s'\n",
                       window->desc, window->sm_client_id);
 
@@ -932,12 +932,12 @@ save_state (void)
                    window_type_to_string (window->type),
                    stack_position);
 
-          g_free (sm_client_id);
-          g_free (res_class);
-          g_free (res_name);
-          g_free (role);
-          g_free (title);
-              
+          free (sm_client_id);
+          free (res_class);
+          free (res_name);
+          free (role);
+          free (title);
+
           /* Sticky */
           if (window->on_all_workspaces_requested)
             fputs ("    <sticky/>\n", outfile);
@@ -950,13 +950,13 @@ save_state (void)
           if (META_WINDOW_MAXIMIZED (window))
             {
               fprintf (outfile,
-                       "    <maximized saved_x=\"%d\" saved_y=\"%d\" saved_width=\"%d\" saved_height=\"%d\"/>\n", 
+                       "    <maximized saved_x=\"%d\" saved_y=\"%d\" saved_width=\"%d\" saved_height=\"%d\"/>\n",
                        window->saved_rect.x,
                        window->saved_rect.y,
                        window->saved_rect.width,
                        window->saved_rect.height);
             }
-              
+
           /* Workspaces we're on */
           {
             int n;
@@ -969,13 +969,13 @@ save_state (void)
           {
             int x, y, w, h;
             meta_window_get_geometry (window, &x, &y, &w, &h);
-            
+
             fprintf (outfile,
                      "    <geometry x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" gravity=\"%s\"/>\n",
                      x, y, w, h,
                      meta_gravity_to_string (window->size_hints.win_gravity));
           }
-              
+
           fputs ("  </window>\n", outfile);
         }
       else
@@ -983,15 +983,15 @@ save_state (void)
           meta_topic (META_DEBUG_SM, "Not saving window '%s', not session managed\n",
                       window->desc);
         }
-          
+
       tmp = tmp->next;
       ++stack_position;
     }
-      
+
   g_slist_free (windows);
 
   fputs ("</muffin_session>\n", outfile);
-  
+
  out:
   if (outfile)
     {
@@ -1007,9 +1007,9 @@ save_state (void)
                         full_save_file (), g_strerror (errno));
         }
     }
-  
-  g_free (muffin_dir);
-  g_free (session_dir);
+
+  free (muffin_dir);
+  free (session_dir);
 }
 
 typedef enum
@@ -1088,7 +1088,7 @@ load_state (const char *previous_save_file)
                                   G_DIR_SEPARATOR_S,
                                   previous_save_file,
                                   NULL);
-      
+
       if (!g_file_get_contents (session_file,
                                 &text,
                                 &length,
@@ -1097,21 +1097,21 @@ load_state (const char *previous_save_file)
           /* oh, just give up */
 
           g_error_free (error);
-          g_free (session_file);
-          g_free (canonical_session_file);
+          free (session_file);
+          free (canonical_session_file);
           return NULL;
         }
 
-      g_free (canonical_session_file);
+      free (canonical_session_file);
     }
 
   meta_topic (META_DEBUG_SM, "Parsing saved session file %s\n", session_file);
-  g_free (session_file);
+  free (session_file);
   session_file = NULL;
-  
+
   parse_data.info = NULL;
   parse_data.previous_id = NULL;
-  
+
   context = g_markup_parse_context_new (&muffin_session_parser,
                                         0, &parse_data, NULL);
 
@@ -1121,8 +1121,8 @@ load_state (const char *previous_save_file)
                                      length,
                                      &error))
     goto error;
-  
-  
+
+
   error = NULL;
   if (!g_markup_parse_context_end_parse (context, &error))
     goto error;
@@ -1132,7 +1132,7 @@ load_state (const char *previous_save_file)
   goto out;
 
  error:
-  
+
   meta_warning (_("Failed to parse saved session file: %s\n"),
                 error->message);
   g_error_free (error);
@@ -1140,12 +1140,12 @@ load_state (const char *previous_save_file)
   if (parse_data.info)
     session_info_free (parse_data.info);
 
-  g_free (parse_data.previous_id);
+  free (parse_data.previous_id);
   parse_data.previous_id = NULL;
-  
+
  out:
-  
-  g_free (text);
+
+  free (text);
 
   return parse_data.previous_id;
 }
@@ -1166,14 +1166,14 @@ start_element_handler  (GMarkupParseContext *context,
   if (strcmp (element_name, "muffin_session") == 0)
     {
       /* Get previous ID */
-      int i;      
+      int i;
 
       i = 0;
       while (attribute_names[i])
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
 
@@ -1185,7 +1185,7 @@ start_element_handler  (GMarkupParseContext *context,
                            _("<muffin_session> attribute seen but we already have the session ID"));
               return;
             }
-          
+
           if (strcmp (name, "id") == 0)
             {
               pd->previous_id = decode_text_from_utf8 (val);
@@ -1199,14 +1199,14 @@ start_element_handler  (GMarkupParseContext *context,
                            name, "muffin_session");
               return;
             }
-          
+
           ++i;
         }
     }
   else if (strcmp (element_name, "window") == 0)
     {
       int i;
-      
+
       if (pd->info)
         {
           g_set_error (error,
@@ -1215,7 +1215,7 @@ start_element_handler  (GMarkupParseContext *context,
                        _("nested <window> tag"));
           return;
         }
-      
+
       pd->info = session_info_new ();
 
       i = 0;
@@ -1223,10 +1223,10 @@ start_element_handler  (GMarkupParseContext *context,
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
-          
+
           if (strcmp (name, "id") == 0)
             {
               if (*val)
@@ -1276,7 +1276,7 @@ start_element_handler  (GMarkupParseContext *context,
               pd->info = NULL;
               return;
             }
-          
+
           ++i;
         }
     }
@@ -1290,7 +1290,7 @@ start_element_handler  (GMarkupParseContext *context,
           const char *name;
 
           name = attribute_names[i];
-          
+
           if (strcmp (name, "index") == 0)
             {
               pd->info->workspace_indices =
@@ -1308,7 +1308,7 @@ start_element_handler  (GMarkupParseContext *context,
               pd->info = NULL;
               return;
             }
-          
+
           ++i;
         }
     }
@@ -1388,22 +1388,22 @@ start_element_handler  (GMarkupParseContext *context,
                     pd->info->saved_rect.y,
                     pd->info->saved_rect.width,
                     pd->info->saved_rect.height);
-    }  
+    }
   else if (strcmp (element_name, "geometry") == 0)
     {
       int i;
 
       pd->info->geometry_set = TRUE;
-      
+
       i = 0;
       while (attribute_names[i])
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
-          
+
           if (strcmp (name, "x") == 0)
             {
               if (*val)
@@ -1438,7 +1438,7 @@ start_element_handler  (GMarkupParseContext *context,
                            name, "geometry");
               return;
             }
-          
+
           ++i;
         }
 
@@ -1476,12 +1476,12 @@ end_element_handler    (GMarkupParseContext *context,
 
       window_info_list = g_slist_prepend (window_info_list,
                                           pd->info);
-      
+
       meta_topic (META_DEBUG_SM, "Loaded window info from session with class: %s name: %s role: %s\n",
                   pd->info->res_class ? pd->info->res_class : "(none)",
                   pd->info->res_name ? pd->info->res_name : "(none)",
                   pd->info->role ? pd->info->role : "(none)");
-      
+
       pd->info = NULL;
     }
 }
@@ -1517,20 +1517,20 @@ get_possible_matches (MetaWindow *window)
   GSList *retval;
   GSList *tmp;
   gboolean ignore_client_id;
-  
+
   retval = NULL;
 
   ignore_client_id = g_getenv ("MUFFIN_DEBUG_SM") != NULL;
-  
+
   tmp = window_info_list;
   while (tmp != NULL)
     {
       MetaWindowSessionInfo *info;
 
       info = tmp->data;
-      
+
       if ((ignore_client_id ||
-           both_null_or_matching (info->id, window->sm_client_id)) && 
+           both_null_or_matching (info->id, window->sm_client_id)) &&
           both_null_or_matching (info->res_class, window->res_class) &&
           both_null_or_matching (info->res_name, window->res_name) &&
           both_null_or_matching (info->role, window->role))
@@ -1557,7 +1557,7 @@ get_possible_matches (MetaWindow *window)
                             window->desc,
                             window->res_class ? window->res_class : "(none)",
                             info->res_class ? info->res_class : "(none)");
-              
+
               else if (!both_null_or_matching (info->res_name, window->res_name))
                 meta_topic (META_DEBUG_SM, "Window %s has name %s doesn't match saved name %s, no match\n",
                             window->desc,
@@ -1573,7 +1573,7 @@ get_possible_matches (MetaWindow *window)
                             window->desc, info->id);
             }
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -1587,10 +1587,10 @@ find_best_match (GSList     *infos,
   GSList *tmp;
   const MetaWindowSessionInfo *matching_title;
   const MetaWindowSessionInfo *matching_type;
-  
+
   matching_title = NULL;
   matching_type = NULL;
-  
+
   tmp = infos;
   while (tmp != NULL)
     {
@@ -1605,7 +1605,7 @@ find_best_match (GSList     *infos,
       if (matching_type == NULL &&
           info->type == window->type)
         matching_type = info;
-      
+
       tmp = tmp->next;
     }
 
@@ -1614,7 +1614,7 @@ find_best_match (GSList     *infos,
    * to e.g. break ties by geometry hint similarity,
    * or other window features.
    */
-  
+
   if (matching_title)
     return matching_title;
   else if (matching_type)
@@ -1628,7 +1628,7 @@ meta_window_lookup_saved_state (MetaWindow *window)
 {
   GSList *possibles;
   const MetaWindowSessionInfo *info;
-  
+
   /* Window is not session managed.
    * I haven't yet figured out how to deal with these
    * in a way that doesn't cause broken side effects in
@@ -1652,9 +1652,9 @@ meta_window_lookup_saved_state (MetaWindow *window)
     }
 
   info = find_best_match (possibles, window);
-  
+
   g_slist_free (possibles);
-  
+
   return info;
 }
 
@@ -1672,15 +1672,15 @@ meta_window_release_saved_state (const MetaWindowSessionInfo *info)
 static void
 session_info_free (MetaWindowSessionInfo *info)
 {
-  g_free (info->id);
-  g_free (info->res_class);
-  g_free (info->res_name);
-  g_free (info->title);
-  g_free (info->role);
+  free (info->id);
+  free (info->res_class);
+  free (info->res_name);
+  free (info->title);
+  free (info->role);
 
   g_slist_free (info->workspace_indices);
-  
-  g_free (info);
+
+  free (info);
 }
 
 static MetaWindowSessionInfo*
@@ -1692,7 +1692,7 @@ session_info_new (void)
 
   info->type = META_WINDOW_NORMAL;
   info->gravity = NorthWestGravity;
-  
+
   return info;
 }
 
@@ -1701,7 +1701,7 @@ static char* full_save_path = NULL;
 static void
 regenerate_save_file (void)
 {
-  g_free (full_save_path);
+  free (full_save_path);
 
   if (client_id)
     full_save_path = g_strconcat (g_get_user_config_dir (),
@@ -1733,7 +1733,7 @@ finish_interact (gboolean shutdown)
   if (current_state == STATE_DONE_WITH_INTERACT) /* paranoia */
     {
       SmcInteractDone (session_connection, False /* don't cancel logout */);
-      
+
       save_yourself_possibly_done (shutdown, TRUE);
     }
 }
@@ -1758,13 +1758,13 @@ warn_about_lame_clients_and_finish_interact (gboolean shutdown)
   GSList *tmp;
   GSList *columns = NULL;
   GPid pid;
-  
+
   windows = meta_display_list_windows (meta_get_display (), META_LIST_DEFAULT);
   tmp = windows;
   while (tmp != NULL)
     {
       MetaWindow *window;
-          
+
       window = tmp->data;
 
       /* only complain about normal windows, the others
@@ -1773,12 +1773,12 @@ warn_about_lame_clients_and_finish_interact (gboolean shutdown)
       if (window->sm_client_id == NULL &&
           window->type == META_WINDOW_NORMAL)
         lame = g_slist_prepend (lame, window);
-          
+
       tmp = tmp->next;
     }
-      
+
   g_slist_free (windows);
-  
+
   if (lame == NULL)
     {
       /* No lame apps. */

--- a/src/core/stack-tracker.c
+++ b/src/core/stack-tracker.c
@@ -395,7 +395,7 @@ meta_stack_tracker_free (MetaStackTracker *tracker)
   g_queue_free (tracker->queued_requests);
   tracker->queued_requests = NULL;
 
-  g_free (tracker);
+  free (tracker);
 }
 
 static void

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -5,12 +5,12 @@
  * @short_description: Which windows cover which other windows
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003 Red Hat, Inc.
  * Copyright (C) 2004 Rob Adams
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -20,7 +20,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -67,7 +67,7 @@ LOCAL_SYMBOL MetaStack*
 meta_stack_new (MetaScreen *screen)
 {
   MetaStack *stack;
-  
+
   stack = g_new (MetaStack, 1);
 
   stack->screen = screen;
@@ -85,7 +85,7 @@ meta_stack_new (MetaScreen *screen)
   stack->need_resort = FALSE;
   stack->need_relayer = FALSE;
   stack->need_constrain = FALSE;
-  
+
   return stack;
 }
 
@@ -100,8 +100,8 @@ meta_stack_free (MetaStack *stack)
 
   if (stack->last_root_children_stacked)
     g_array_free (stack->last_root_children_stacked, TRUE);
-  
-  g_free (stack);
+
+  free (stack);
 }
 
 LOCAL_SYMBOL void
@@ -112,7 +112,7 @@ meta_stack_add (MetaStack  *stack,
 
   if (window->stack_position >= 0)
     meta_bug ("Window %s had stack position already\n", window->desc);
-  
+
   stack->added = g_list_prepend (stack->added, window);
 
   window->stack_position = stack->n_positions;
@@ -120,7 +120,7 @@ meta_stack_add (MetaStack  *stack,
   meta_topic (META_DEBUG_STACK,
               "Window %s has stack_position initialized to %d\n",
               window->desc, window->stack_position);
-  
+
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, window->screen->active_workspace);
 }
@@ -141,7 +141,7 @@ meta_stack_remove (MetaStack  *stack,
   meta_window_set_stack_position_no_sync (window,
                                           stack->n_positions - 1);
   window->stack_position = -1;
-  stack->n_positions -= 1;  
+  stack->n_positions -= 1;
 
   /* We don't know if it's been moved from "added" to "stack" yet */
   stack->added = g_list_remove (stack->added, window);
@@ -156,7 +156,7 @@ meta_stack_remove (MetaStack  *stack,
   if (window->frame)
     stack->removed = g_list_prepend (stack->removed,
                                      GUINT_TO_POINTER (window->frame->xwindow));
-  
+
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, window->screen->active_workspace);
 }
@@ -166,7 +166,7 @@ meta_stack_update_layer (MetaStack  *stack,
                          MetaWindow *window)
 {
   stack->need_relayer = TRUE;
-  
+
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, window->screen->active_workspace);
 }
@@ -176,7 +176,7 @@ meta_stack_update_transient (MetaStack  *stack,
                              MetaWindow *window)
 {
   stack->need_constrain = TRUE;
-  
+
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, window->screen->active_workspace);
 }
@@ -233,7 +233,7 @@ meta_stack_lower (MetaStack  *stack,
     return;
 
   meta_window_set_stack_position_no_sync (window, min_stack_position);
-  
+
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, window->screen->active_workspace);
 }
@@ -248,7 +248,7 @@ LOCAL_SYMBOL void
 meta_stack_thaw (MetaStack *stack)
 {
   g_return_if_fail (stack->freeze_count > 0);
-  
+
   stack->freeze_count -= 1;
   stack_sync_to_server (stack);
   meta_stack_update_window_tile_matches (stack, NULL);
@@ -306,7 +306,7 @@ get_standalone_layer (MetaWindow *window)
     case META_WINDOW_OVERRIDE_OTHER:
       layer = META_LAYER_OVERRIDE_REDIRECT;
       break;
-    default:       
+    default:
       if (window->wm_state_below)
         layer = META_LAYER_BOTTOM;
       else if (window->wm_state_above)
@@ -330,16 +330,16 @@ get_maximum_layer_in_group (MetaWindow *window)
   GSList *tmp;
   MetaStackLayer max;
   MetaStackLayer layer;
-  
+
   max = META_LAYER_DESKTOP;
-  
+
   group = meta_window_get_group (window);
 
   if (group != NULL)
     members = meta_group_list_windows (group);
   else
     members = NULL;
-  
+
   tmp = members;
   while (tmp != NULL)
     {
@@ -351,12 +351,12 @@ get_maximum_layer_in_group (MetaWindow *window)
           if (layer > max)
             max = layer;
         }
-      
+
       tmp = tmp->next;
     }
 
   g_slist_free (members);
-  
+
   return max;
 }
 
@@ -364,7 +364,7 @@ static void
 compute_layer (MetaWindow *window)
 {
   window->layer = get_standalone_layer (window);
-  
+
   /* We can only do promotion-due-to-group for dialogs and other
    * transients, or weird stuff happens like the desktop window and
    * nautilus windows getting in the same layer, or all gnome-terminal
@@ -381,11 +381,11 @@ compute_layer (MetaWindow *window)
        * and a dialog transient for the normal window; you don't want the dialog
        * above the dock if it wouldn't normally be.
        */
-      
+
       MetaStackLayer group_max;
-      
+
       group_max = get_maximum_layer_in_group (window);
-      
+
       if (group_max > window->layer)
         {
           meta_topic (META_DEBUG_STACK,
@@ -422,10 +422,10 @@ compare_window_position (void *a,
   else
     return 0; /* not reached */
 }
-  
+
 /*
  * Stacking constraints
- * 
+ *
  * Assume constraints of the form "AB" meaning "window A must be
  * below window B"
  *
@@ -442,14 +442,14 @@ compare_window_position (void *a,
  *  apply BC: ABC
  *
  * but apply constraints in the wrong order and it breaks:
- * 
+ *
  *  start:    BCA
  *  apply BC: BCA
  *  apply AB: CAB
  *
  * We make a directed graph of the constraints by linking
  * from "above windows" to "below windows as follows:
- * 
+ *
  *   AB -> BC -> CD
  *          \
  *           CE
@@ -474,7 +474,7 @@ struct Constraint
 
   /* used to create the graph. */
   GSList *next_nodes;
-  
+
   /* constraint has been applied, used
    * to detect cycles.
    */
@@ -502,7 +502,7 @@ add_constraint (Constraint **constraints,
   Constraint *c;
 
   g_assert (above->screen == below->screen);
-  
+
   /* check if constraint is a duplicate */
   c = constraints[below->stack_position];
   while (c != NULL)
@@ -529,7 +529,7 @@ create_constraints (Constraint **constraints,
                     GList       *windows)
 {
   GList *tmp;
-  
+
   tmp = windows;
   while (tmp != NULL)
     {
@@ -542,7 +542,7 @@ create_constraints (Constraint **constraints,
           tmp = tmp->next;
           continue;
         }
-      
+
       if (WINDOW_TRANSIENT_FOR_WHOLE_GROUP (w))
         {
           GSList *group_windows;
@@ -555,9 +555,9 @@ create_constraints (Constraint **constraints,
             group_windows = meta_group_list_windows (group);
           else
             group_windows = NULL;
-          
+
           tmp2 = group_windows;
-          
+
           while (tmp2 != NULL)
             {
               MetaWindow *group_window = tmp2->data;
@@ -569,7 +569,7 @@ create_constraints (Constraint **constraints,
                   tmp2 = tmp2->next;
                   continue;
                 }
-              
+
 #if 0
               /* old way of doing it */
               if (!(meta_window_is_ancestor_of_transient (w, group_window)) &&
@@ -585,7 +585,7 @@ create_constraints (Constraint **constraints,
                               w->desc, group_window->desc);
                   add_constraint (constraints, w, group_window);
                 }
-              
+
               tmp2 = tmp2->next;
             }
 
@@ -595,7 +595,7 @@ create_constraints (Constraint **constraints,
                !w->transient_parent_is_root_window)
         {
           MetaWindow *parent;
-          
+
           parent =
             meta_display_lookup_x_window (w->display, w->xtransient_for);
 
@@ -607,7 +607,7 @@ create_constraints (Constraint **constraints,
               add_constraint (constraints, w, parent);
             }
         }
-      
+
       tmp = tmp->next;
     }
 }
@@ -626,12 +626,12 @@ graph_constraints (Constraint **constraints,
       /* If we have "A below B" and "B below C" then AB -> BC so we
        * add BC to next_nodes in AB.
        */
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           Constraint *n;
-            
+
           g_assert (c->below->stack_position == i);
 
           /* Constraints where ->above is below are our
@@ -644,10 +644,10 @@ graph_constraints (Constraint **constraints,
                                                n);
               /* c is a previous node of n */
               n->has_prev = TRUE;
-              
+
               n = n->next;
             }
-          
+
           c = c->next;
         }
 
@@ -665,16 +665,16 @@ free_constraints (Constraint **constraints,
   while (i < n_constraints)
     {
       Constraint *c;
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           Constraint *next = c->next;
-          
+
           g_slist_free (c->next_nodes);
 
-          g_free (c);
-          
+          free (c);
+
           c = next;
         }
 
@@ -685,7 +685,7 @@ free_constraints (Constraint **constraints,
 static void
 ensure_above (MetaWindow *above,
               MetaWindow *below)
-{  
+{
   if (WINDOW_HAS_TRANSIENT_TYPE(above) &&
       above->layer < below->layer)
     {
@@ -713,10 +713,10 @@ traverse_constraint (Constraint *c)
 
   if (c->applied)
     return;
-  
+
   ensure_above (c->above, c->below);
   c->applied = TRUE;
-  
+
   tmp = c->next_nodes;
   while (tmp != NULL)
     {
@@ -740,13 +740,13 @@ apply_constraints (Constraint **constraints,
   while (i < n_constraints)
     {
       Constraint *c;
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           if (!c->has_prev)
             heads = g_slist_prepend (heads, c);
-          
+
           c = c->next;
         }
 
@@ -760,7 +760,7 @@ apply_constraints (Constraint **constraints,
       Constraint *c = tmp->data;
 
       traverse_constraint (c);
-      
+
       tmp = tmp->next;
     }
 
@@ -779,7 +779,7 @@ stack_do_window_deletions (MetaStack *stack)
    */
   GList *tmp;
   int i;
-    
+
   tmp = stack->removed;
   while (tmp != NULL)
     {
@@ -793,7 +793,7 @@ stack_do_window_deletions (MetaStack *stack)
       while (i > 0)
         {
           --i;
-          
+
           /* there's no guarantee we'll actually find windows to
            * remove, e.g. the same xwindow could have been
            * added/removed before we ever synced, and we put
@@ -830,34 +830,34 @@ stack_do_window_additions (MetaStack *stack)
       meta_topic (META_DEBUG_STACK,
                   "Adding %d windows to sorted list\n",
                   n_added);
-      
+
       old_size = stack->windows->len;
       g_array_set_size (stack->windows, old_size + n_added);
-      
+
       end = &g_array_index (stack->windows, Window, old_size);
 
       /* stack->added has the most recent additions at the
        * front of the list, so we need to reverse it
        */
       stack->added = g_list_reverse (stack->added);
-      
+
       i = 0;
       tmp = stack->added;
       while (tmp != NULL)
         {
           MetaWindow *w;
-          
+
           w = tmp->data;
-          
+
           end[i] = w->xwindow;
 
           /* add to the main list */
           stack->sorted = g_list_prepend (stack->sorted, w);
-          
+
           ++i;
           tmp = tmp->next;
         }
-      
+
       stack->need_resort = TRUE; /* may not be needed as we add to top */
       stack->need_constrain = TRUE;
       stack->need_relayer = TRUE;
@@ -874,13 +874,13 @@ static void
 stack_do_relayer (MetaStack *stack)
 {
   GList *tmp;
-    
+
   if (!stack->need_relayer)
       return;
-    
+
   meta_topic (META_DEBUG_STACK,
               "Recomputing layers\n");
-      
+
   tmp = stack->sorted;
 
   while (tmp != NULL)
@@ -905,7 +905,7 @@ stack_do_relayer (MetaStack *stack)
            * not layer
            */
         }
-          
+
       tmp = tmp->next;
     }
 
@@ -922,7 +922,7 @@ stack_do_constrain (MetaStack *stack)
   Constraint **constraints;
 
   /* It'd be nice if this were all faster, probably */
-  
+
   if (!stack->need_constrain)
     return;
 
@@ -937,10 +937,10 @@ stack_do_constrain (MetaStack *stack)
   graph_constraints (constraints, stack->n_positions);
 
   apply_constraints (constraints, stack->n_positions);
-  
+
   free_constraints (constraints, stack->n_positions);
-  g_free (constraints);
-  
+  free (constraints);
+
   stack->need_constrain = FALSE;
 }
 
@@ -952,10 +952,10 @@ stack_do_resort (MetaStack *stack)
 {
   if (!stack->need_resort)
     return;
-  
+
   meta_topic (META_DEBUG_STACK,
               "Sorting stack list\n");
-      
+
   stack->sorted = g_list_sort (stack->sorted,
                                (GCompareFunc) compare_window_position);
 
@@ -1103,12 +1103,12 @@ stack_sync_to_server (MetaStack *stack)
   GArray *all_hidden;
   int n_override_redirect = 0;
   int n_unmanaging = 0;
-  
+
   /* Bail out if frozen */
   if (stack->freeze_count > 0)
     return;
-  
-  meta_topic (META_DEBUG_STACK, "Syncing window stack to server\n");  
+
+  meta_topic (META_DEBUG_STACK, "Syncing window stack to server\n");
 
   stack_ensure_sorted (stack);
 
@@ -1138,7 +1138,7 @@ stack_sync_to_server (MetaStack *stack)
           n_unmanaging ++;
           continue;
         }
-      
+
       meta_topic (META_DEBUG_STACK, "%u:%d - %s ",
 		  w->layer, w->stack_position, w->desc);
 
@@ -1147,7 +1147,7 @@ stack_sync_to_server (MetaStack *stack)
 	n_override_redirect++;
       else
 	g_array_prepend_val (stacked, w->xwindow);
-      
+
       if (w->frame)
 	top_level_window = w->frame->xwindow;
       else
@@ -1173,12 +1173,12 @@ stack_sync_to_server (MetaStack *stack)
   if (stacked->len != stack->windows->len - n_override_redirect - n_unmanaging)
     meta_bug ("%u windows stacked, %u windows exist in stack\n",
               stacked->len, stack->windows->len);
-  
+
   /* Sync to server */
 
   meta_topic (META_DEBUG_STACK, "Restacking %u windows\n",
               root_children_stacked->len);
-  
+
   meta_error_trap_push (stack->screen->display);
 
   if (stack->last_root_children_stacked == NULL)
@@ -1216,7 +1216,7 @@ stack_sync_to_server (MetaStack *stack)
       const Window *old_end = old_stack + old_len;
       const Window *new_end = new_stack + new_len;
       Window last_window = None;
-      
+
       while (oldp != old_end &&
              newp != new_end)
         {
@@ -1251,7 +1251,7 @@ stack_sync_to_server (MetaStack *stack)
                    * *newp, then we fail to restack *newp; but on
                    * unmanaging last_window, we'll fix it up.
                    */
-                  
+
                   XWindowChanges changes;
 
                   changes.sibling = last_window;
@@ -1312,7 +1312,7 @@ stack_sync_to_server (MetaStack *stack)
    * get removed from the stacking list when we unmanage it
    * and we'll fix stacking at that time.
    */
-  
+
   /* Sync _NET_CLIENT_LIST and _NET_CLIENT_LIST_STACKING */
 
   XChangeProperty (stack->screen->display->xdisplay,
@@ -1371,9 +1371,9 @@ meta_stack_get_above (MetaStack      *stack,
 {
   GList *link;
   MetaWindow *above;
-  
+
   stack_ensure_sorted (stack);
-  
+
   link = g_list_find (stack->sorted, window);
   if (link == NULL)
     return NULL;
@@ -1396,7 +1396,7 @@ meta_stack_get_below (MetaStack      *stack,
 {
   GList *link;
   MetaWindow *below;
-  
+
   stack_ensure_sorted (stack);
 
   link = g_list_find (stack->sorted, window);
@@ -1405,7 +1405,7 @@ meta_stack_get_below (MetaStack      *stack,
     return NULL;
   if (link->next == NULL)
     return NULL;
-  
+
   below = link->next->data;
 
   if (only_within_layer &&
@@ -1435,7 +1435,7 @@ get_default_focus_window (MetaStack     *stack,
   MetaWindow *topmost_overall;
   MetaGroup *not_this_one_group;
   GList *link;
-  
+
   topmost_dock = NULL;
   transient_parent = NULL;
   topmost_in_group = NULL;
@@ -1449,7 +1449,7 @@ get_default_focus_window (MetaStack     *stack,
 
   /* top of this layer is at the front of the list */
   link = stack->sorted;
-      
+
   while (link)
     {
       MetaWindow *window = link->data;
@@ -1536,22 +1536,22 @@ meta_stack_list_windows (MetaStack     *stack,
 {
   GList *workspace_windows = NULL;
   GList *link;
-  
+
   stack_ensure_sorted (stack); /* do adds/removes */
-  
+
   link = stack->sorted;
-  
+
   while (link)
     {
       MetaWindow *window = link->data;
-      
+
       if (window &&
           (workspace == NULL || meta_window_located_on_workspace (window, workspace)))
         {
           workspace_windows = g_list_prepend (workspace_windows,
                                               window);
         }
-      
+
       link = link->next;
     }
 
@@ -1568,7 +1568,7 @@ meta_stack_windows_cmp  (MetaStack  *stack,
   /* -1 means a below b */
 
   stack_ensure_sorted (stack); /* update constraints, layers */
-  
+
   if (window_a->layer < window_b->layer)
     return -1;
   else if (window_a->layer > window_b->layer)
@@ -1618,7 +1618,7 @@ compare_pointers (gconstpointer a,
     return 1;
   else if (a < b)
     return -1;
-  else 
+  else
     return 0;
 }
 
@@ -1656,7 +1656,7 @@ meta_stack_set_positions (MetaStack *stack,
 
   /* Make sure any adds or removes aren't in limbo -- is this needed? */
   stack_ensure_sorted (stack);
-  
+
   if (!lists_contain_same_windows (windows, stack->sorted))
     {
       meta_warning ("This list of windows has somehow changed; not resetting "
@@ -1669,7 +1669,7 @@ meta_stack_set_positions (MetaStack *stack,
 
   stack->need_resort = TRUE;
   stack->need_constrain = TRUE;
-   
+
   i = 0;
   tmp = windows;
   while (tmp != NULL)
@@ -1678,7 +1678,7 @@ meta_stack_set_positions (MetaStack *stack,
       w->stack_position = i++;
       tmp = tmp->next;
     }
-  
+
   meta_topic (META_DEBUG_STACK,
               "Reset the stack positions of (nearly) all windows\n");
 
@@ -1692,7 +1692,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 {
   int low, high, delta;
   GList *tmp;
-  
+
   g_return_if_fail (window->screen->stack != NULL);
   g_return_if_fail (window->stack_position >= 0);
   g_return_if_fail (position >= 0);
@@ -1707,7 +1707,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 
   window->screen->stack->need_resort = TRUE;
   window->screen->stack->need_constrain = TRUE;
-  
+
   if (position < window->stack_position)
     {
       low = position;
@@ -1732,7 +1732,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 
       tmp = tmp->next;
     }
-  
+
   window->stack_position = position;
 
   meta_topic (META_DEBUG_STACK,

--- a/src/core/testboxes.c
+++ b/src/core/testboxes.c
@@ -2,9 +2,9 @@
 
 /* Muffin box operation testing program */
 
-/* 
+/*
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -230,7 +230,7 @@ free_strut_list (GSList *struts)
   GSList *tmp = struts;
   while (tmp)
     {
-      g_free (tmp->data);
+      free (tmp->data);
       tmp = tmp->next;
     }
   g_slist_free (struts);
@@ -365,7 +365,7 @@ test_merge_regions ()
    * uniformly distributed location of center of struts (within screen)
    * merge all regions that are possible
    * print stats on problem setup
-   *   number of (non-completely-occluded?) struts 
+   *   number of (non-completely-occluded?) struts
    *   percentage of screen covered
    *   length of resulting non-minimal spanning set
    *   length of resulting minimal spanning set
@@ -496,7 +496,7 @@ test_merge_regions ()
                 }
 
               /* Okay, we can free it now */
-              g_free (delete_me->data);
+              free (delete_me->data);
               region = g_list_delete_link (region, delete_me);
             }
 
@@ -510,11 +510,11 @@ test_merge_regions ()
       compare = compare->next;
     }
 
-  printf ("  Num rectangles contained in others          : %d\n", 
+  printf ("  Num rectangles contained in others          : %d\n",
           num_contains);
-  printf ("  Num rectangles partially contained in others: %d\n", 
+  printf ("  Num rectangles partially contained in others: %d\n",
           num_part_contains);
-  printf ("  Num rectangles adjacent to others           : %d\n", 
+  printf ("  Num rectangles adjacent to others           : %d\n",
           num_adjacent);
   printf ("  Num rectangles merged with others           : %d\n",
           num_merged);
@@ -585,9 +585,9 @@ test_regions_okay ()
   GList* region;
   GList* tmp;
 
-  /*************************************************************/  
+  /*************************************************************/
   /* Make sure test region 0 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (0);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (0, 0, 1600, 1200));
@@ -595,9 +595,9 @@ test_regions_okay ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (region);
 
-  /*************************************************************/  
+  /*************************************************************/
   /* Make sure test region 1 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (0, 20,  400, 1180));
@@ -608,7 +608,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 2 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (   0,   20,  300, 1180));
@@ -622,7 +622,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 3 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (   0,   20,  300, 1180)); /* 354000 */
@@ -642,7 +642,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 4 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect ( 800,   20,  800, 1180));
@@ -652,7 +652,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 5 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   printf ("The next test intentionally causes a warning, "
           "but it can be ignored.\n");
   region = get_screen_region (5);
@@ -1016,9 +1016,9 @@ test_find_onscreen_edges ()
   int top    = META_DIRECTION_TOP;
   int bottom = META_DIRECTION_BOTTOM;
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 0 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (0);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200, 1600, 0, bottom));
@@ -1029,9 +1029,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 1 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200,  400, 0, bottom));
@@ -1044,9 +1044,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 2 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (1200, 1200,  400, 0, bottom));
@@ -1065,9 +1065,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 3 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (1200, 1200,  400, 0, bottom));
@@ -1092,7 +1092,7 @@ test_find_onscreen_edges ()
   char big_buffer1[(EDGE_LENGTH+2)*FUDGE], big_buffer2[(EDGE_LENGTH+2)*FUDGE];
   meta_rectangle_edge_list_to_string (edges, "\n ", big_buffer1);
   meta_rectangle_edge_list_to_string (tmp,   "\n ", big_buffer2);
-  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n", 
+  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n",
          big_buffer1, big_buffer2);
 #endif
 
@@ -1100,9 +1100,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 4 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge ( 800, 1200, 800,  0, bottom));
@@ -1113,18 +1113,18 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 5 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (5);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 6 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (6);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200, 1600,  0, bottom));
@@ -1149,18 +1149,18 @@ test_find_nonintersected_monitor_edges ()
   int top    = META_DIRECTION_TOP;
   int bottom = META_DIRECTION_BOTTOM;
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 0 for with region 0 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (0, 0);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 2 for with region 1 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (2, 1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_monitor_edge (   0,  600, 1600, 0, bottom));
@@ -1169,9 +1169,9 @@ test_find_nonintersected_monitor_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 1 for with region 2 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (1, 2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_monitor_edge ( 800,   20, 0, 1080, right));
@@ -1181,16 +1181,16 @@ test_find_nonintersected_monitor_edges ()
   char big_buffer1[(EDGE_LENGTH+2)*FUDGE], big_buffer2[(EDGE_LENGTH+2)*FUDGE];
   meta_rectangle_edge_list_to_string (edges, "\n ", big_buffer1);
   meta_rectangle_edge_list_to_string (tmp,   "\n ", big_buffer2);
-  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n", 
+  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n",
          big_buffer1, big_buffer2);
 #endif
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 3 for with region 3 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (3, 3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_monitor_edge ( 900,  600,  700, 0, bottom));
@@ -1203,9 +1203,9 @@ test_find_nonintersected_monitor_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 3 for with region 4 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (3, 4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_monitor_edge ( 800,  600,  800, 0, bottom));
@@ -1215,9 +1215,9 @@ test_find_nonintersected_monitor_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test monitor set 3 for with region 5has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_monitor_edges (3, 5);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -2,10 +2,10 @@
 
 /* Muffin utilities */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -70,11 +70,11 @@ meta_print_backtrace (void)
   int bt_size;
   int i;
   char **syms;
-  
+
   bt_size = backtrace (bt, 500);
 
   syms = backtrace_symbols (bt, bt_size);
-  
+
   i = 0;
   while (i < bt_size)
     {
@@ -109,7 +109,7 @@ ensure_logfile (void)
       char *tmpl;
       int fd;
       GError *err;
-      
+
       tmpl = g_strdup_printf ("muffin-%d-debug-log-XXXXXX",
                               (int) getpid ());
 
@@ -118,8 +118,8 @@ ensure_logfile (void)
                             &filename,
                             &err);
 
-      g_free (tmpl);
-      
+      free (tmpl);
+
       if (err != NULL)
         {
           meta_warning (_("Failed to open debug log: %s\n"),
@@ -127,9 +127,9 @@ ensure_logfile (void)
           g_error_free (err);
           return;
         }
-      
+
       logfile = fdopen (fd, "w");
-      
+
       if (logfile == NULL)
         {
           meta_warning (_("Failed to fdopen() log file %s: %s\n"),
@@ -140,8 +140,8 @@ ensure_logfile (void)
         {
           g_printerr (_("Opened log file %s\n"), filename);
         }
-      
-      g_free (filename);
+
+      free (filename);
     }
 }
 #endif
@@ -158,7 +158,7 @@ meta_set_verbose (gboolean setting)
 #ifndef WITH_VERBOSE_MODE
   if (setting)
     meta_fatal (_("Muffin was compiled without support for verbose mode\n"));
-#else 
+#else
   if (setting)
     ensure_logfile ();
 #endif
@@ -255,7 +255,7 @@ utf8_fputs (const char *str,
 {
   char *l;
   int retval;
-  
+
   l = g_locale_from_utf8 (str, -1, NULL, NULL, NULL);
 
   if (l == NULL)
@@ -263,7 +263,7 @@ utf8_fputs (const char *str,
   else
     retval = fputs (l, f);
 
-  g_free (l);
+  free (l);
 
   return retval;
 }
@@ -276,7 +276,7 @@ void
 meta_free_gslist_and_elements (GSList *list_to_deep_free)
 {
   g_slist_foreach (list_to_deep_free,
-                   (void (*)(gpointer,gpointer))&g_free, /* ew, for ugly */
+                   (void (*)(gpointer,gpointer))&free, /* ew, for ugly */
                    NULL);
   g_slist_free (list_to_deep_free);
 }
@@ -288,25 +288,25 @@ meta_debug_spew_real (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
 
   if (!is_debugging)
     return;
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
 
   out = logfile ? logfile : stderr;
-  
+
   if (no_prefix == 0)
     utf8_fputs ("muffin: ", out);
   utf8_fputs (str, out);
 
   fflush (out);
-  
-  g_free (str);
+
+  free (str);
 }
 #endif /* WITH_VERBOSE_MODE */
 
@@ -408,12 +408,12 @@ meta_topic_real_valist (MetaDebugTopic topic,
       ++sync_count;
       fprintf (out, "%d: ", sync_count);
     }
-  
+
   utf8_fputs (str, out);
-  
+
   fflush (out);
-  
-  g_free (str);
+
+  free (str);
 }
 
 void
@@ -437,7 +437,7 @@ meta_bug (const char *format, ...)
   FILE *out;
 
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -453,11 +453,11 @@ meta_bug (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
-  g_free (str);
+
+  free (str);
 
   meta_print_backtrace ();
-  
+
   /* stop us in a debugger */
   abort ();
 }
@@ -468,9 +468,9 @@ meta_warning (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -486,8 +486,8 @@ meta_warning (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
-  g_free (str);
+
+  free (str);
 }
 
 void
@@ -496,9 +496,9 @@ meta_fatal (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -514,8 +514,8 @@ meta_fatal (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
-  g_free (str);
+
+  free (str);
 
   meta_exit (META_EXIT_ERROR);
 }
@@ -537,7 +537,7 @@ meta_pop_no_msg_prefix (void)
 void
 meta_exit (MetaExitCode code)
 {
-  
+
   exit (code);
 }
 
@@ -695,7 +695,7 @@ meta_show_dialog (const char *type,
     {
       gchar *env = g_strdup_printf("%d", transient_for);
       setenv ("WINDOWID", env, 1);
-      g_free (env);
+      free (env);
     }
 
   g_spawn_async (

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -15,11 +15,11 @@
  * together.
  */
 
-/* 
+/*
  * Copyright (C) 2001, 2002, 2003 Red Hat, Inc.
  * Copyright (C) 2004, 2005 Elijah Newren
  * Copyright (C) 2009 Thomas Thurman
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -29,7 +29,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -122,9 +122,9 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
 
   g_return_if_fail (properties != NULL);
   g_return_if_fail (n_properties > 0);
-  
+
   values = g_new0 (MetaPropValue, n_properties);
-  
+
   i = 0;
   while (i < n_properties)
     {
@@ -132,7 +132,7 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
       init_prop_value (window, hooks, &values[i]);
       ++i;
     }
-  
+
   meta_prop_get_values (window->display, xwindow,
                         values, n_properties);
 
@@ -141,13 +141,13 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
     {
       MetaWindowPropHooks *hooks = find_hooks (window->display, properties[i]);
       reload_prop_value (window, hooks, &values[i], initial);
-      
+
       ++i;
     }
 
   meta_prop_free_values (values, n_properties);
-  
-  g_free (values);
+
+  free (values);
 }
 
 LOCAL_SYMBOL void
@@ -192,7 +192,7 @@ meta_window_load_initial_properties (MetaWindow *window)
 
   meta_prop_free_values (values, n_properties);
 
-  g_free (values);
+  free (values);
 }
 
 /* Fill in the MetaPropValue used to get the value of "property" */
@@ -230,9 +230,9 @@ reload_wm_client_machine (MetaWindow    *window,
                           MetaPropValue *value,
                           gboolean       initial)
 {
-  g_free (window->wm_client_machine);
+  free (window->wm_client_machine);
   window->wm_client_machine = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     window->wm_client_machine = g_strdup (value->v.str);
 
@@ -245,7 +245,7 @@ reload_theme_icon_name (MetaWindow    *window,
                         MetaPropValue *value,
                         gboolean       initial)
 {
-  g_free (window->theme_icon_name);
+  free (window->theme_icon_name);
   window->theme_icon_name = NULL;
 
   if (value->type != META_PROP_VALUE_INVALID)
@@ -442,7 +442,7 @@ reload_net_wm_pid (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       gulong cardinal = (int) value->v.cardinal;
-      
+
       if (cardinal <= 0)
         meta_warning (_("Application set a bogus _NET_WM_PID %lu\n"),
                       cardinal);
@@ -552,12 +552,12 @@ set_title_text (MetaWindow  *window,
 {
   char hostname[HOST_NAME_MAX + 1];
   gboolean modified = FALSE;
-  
+
   if (!target)
     return FALSE;
-  
-  g_free (*target);
-  
+
+  free (*target);
+
   if (!title)
     *target = g_strdup ("");
   else if (g_utf8_strlen (title, MAX_TITLE_LENGTH + 1) > MAX_TITLE_LENGTH)
@@ -601,7 +601,7 @@ set_window_title (MetaWindow *window,
                   const char *title)
 {
   char *str;
- 
+
   gboolean modified =
     set_title_text (window,
                     window->using_net_wm_visible_name,
@@ -609,12 +609,12 @@ set_window_title (MetaWindow *window,
                     window->display->atom__NET_WM_VISIBLE_NAME,
                     &window->title);
   window->using_net_wm_visible_name = modified;
-  
+
   /* strndup is a hack since GNU libc has broken %.10s */
   str = g_strndup (window->title, 10);
-  g_free (window->desc);
+  free (window->desc);
   window->desc = g_strdup_printf ("0x%lx (%s)", window->xwindow, str);
-  g_free (str);
+  free (str);
 
   if (window->frame)
     meta_ui_set_frame_title (window->screen->ui,
@@ -657,7 +657,7 @@ reload_wm_name (MetaWindow    *window,
                     value->v.str);
       return;
     }
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     {
       set_window_title (window, value->v.str);
@@ -732,7 +732,7 @@ reload_opaque_region (MetaWindow    *window,
 
       opaque_region = cairo_region_create_rectangles (rects, nrects);
 
-      g_free (rects);
+      free (rects);
     }
 
  out:
@@ -764,7 +764,7 @@ reload_muffin_hints (MetaWindow    *window,
 
       if (changed)
         {
-          g_free (old_hints);
+          free (old_hints);
 
           if (new_hints)
             window->muffin_hints = g_strdup (new_hints);
@@ -776,7 +776,7 @@ reload_muffin_hints (MetaWindow    *window,
     }
   else if (window->muffin_hints)
     {
-      g_free (window->muffin_hints);
+      free (window->muffin_hints);
       window->muffin_hints = NULL;
 
       g_object_notify (G_OBJECT (window), "muffin-hints");
@@ -829,11 +829,11 @@ reload_wm_icon_name (MetaWindow    *window,
                     value->v.str);
       return;
     }
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     {
       set_icon_title (window, value->v.str);
-      
+
       meta_verbose ("Using WM_ICON_NAME for new title of %s: \"%s\"\n",
                     window->desc, window->title);
     }
@@ -1031,7 +1031,7 @@ reload_mwm_hints (MetaWindow    *window,
     meta_verbose ("Functions flag unset\n");
 
   meta_window_recalc_features (window);
-  
+
   /* We do all this anyhow at the end of meta_window_new() */
   if (!window->constructing)
     {
@@ -1039,7 +1039,7 @@ reload_mwm_hints (MetaWindow    *window,
         meta_window_ensure_frame (window);
       else
         meta_window_destroy_frame (window);
-      
+
       meta_window_queue (window,
                          META_QUEUE_MOVE_RESIZE |
                          /* because ensure/destroy frame may unmap: */
@@ -1056,15 +1056,15 @@ reload_wm_class (MetaWindow    *window,
                  gboolean       initial)
 {
   if (window->res_class)
-    g_free (window->res_class);
+    free (window->res_class);
   if (window->res_name)
-    g_free (window->res_name);
+    free (window->res_name);
 
   window->res_class = NULL;
   window->res_name = NULL;
 
   if (value->type != META_PROP_VALUE_INVALID)
-    { 
+    {
       if (value->v.class_hint.res_name)
         window->res_name = g_strdup (value->v.class_hint.res_name);
 
@@ -1102,32 +1102,32 @@ reload_net_startup_id (MetaWindow    *window,
 {
   guint32 timestamp = window->net_wm_user_time;
   MetaWorkspace *workspace = NULL;
-  
-  g_free (window->startup_id);
-  
+
+  free (window->startup_id);
+
   if (value->type != META_PROP_VALUE_INVALID)
     window->startup_id = g_strdup (value->v.str);
   else
     window->startup_id = NULL;
-    
+
   /* Update timestamp and workspace on a running window */
   if (!window->constructing)
   {
-    window->initial_timestamp_set = 0;  
+    window->initial_timestamp_set = 0;
     window->initial_workspace_set = 0;
-    
+
     if (meta_screen_apply_startup_properties (window->screen, window))
       {
-  
+
         if (window->initial_timestamp_set)
           timestamp = window->initial_timestamp;
         if (window->initial_workspace_set)
           workspace = meta_screen_get_workspace_by_index (window->screen, window->initial_workspace);
-    
+
         meta_window_activate_with_workspace (window, timestamp, workspace);
       }
   }
-  
+
   meta_verbose ("New _NET_STARTUP_ID \"%s\" for %s\n",
                 window->startup_id ? window->startup_id : "unset",
                 window->desc);
@@ -1227,7 +1227,7 @@ spew_size_hints_differences (const XSizeHints *old,
   if (FLAG_CHANGED (old, new, PWinGravity))
     meta_topic (META_DEBUG_GEOMETRY, "XSizeHints: PWinGravity now %s  (%d -> %d)\n",
                 FLAG_TOGGLED_ON (old, new, PWinGravity) ? "set" : "unset",
-                old->win_gravity, new->win_gravity);  
+                old->win_gravity, new->win_gravity);
 }
 
 LOCAL_SYMBOL void
@@ -1584,15 +1584,15 @@ reload_normal_hints (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       XSizeHints old_hints;
-  
+
       meta_topic (META_DEBUG_GEOMETRY, "Updating WM_NORMAL_HINTS for %s\n", window->desc);
 
       old_hints = window->size_hints;
-  
+
       meta_set_normal_hints (window, value->v.size_hints.hints);
-      
+
       spew_size_hints_differences (&old_hints, &window->size_hints);
-      
+
       meta_window_recalc_features (window);
 
       if (!initial)
@@ -1606,12 +1606,12 @@ reload_wm_protocols (MetaWindow    *window,
                      gboolean       initial)
 {
   int i;
-  
+
   window->take_focus = FALSE;
   window->delete_window = FALSE;
   window->net_wm_ping = FALSE;
-  
-  if (value->type == META_PROP_VALUE_INVALID)    
+
+  if (value->type == META_PROP_VALUE_INVALID)
     return;
 
   i = 0;
@@ -1628,7 +1628,7 @@ reload_wm_protocols (MetaWindow    *window,
         window->net_wm_ping = TRUE;
       ++i;
     }
-  
+
   meta_verbose ("New _NET_STARTUP_ID \"%s\" for %s\n",
                 window->startup_id ? window->startup_id : "unset",
                 window->desc);
@@ -1644,7 +1644,7 @@ reload_wm_hints (MetaWindow    *window,
 
   old_group_leader = window->xgroup_leader;
   old_urgent = window->wm_hints_urgent;
-  
+
   /* Fill in defaults */
   window->input = TRUE;
   window->initially_iconic = FALSE;
@@ -1656,7 +1656,7 @@ reload_wm_hints (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       const XWMHints *hints = value->v.wm_hints;
-      
+
       if (hints->flags & InputHint)
         window->input = hints->input;
 
@@ -1686,7 +1686,7 @@ reload_wm_hints (MetaWindow    *window,
     {
       meta_verbose ("Window %s changed its group leader to 0x%lx\n",
                     window->desc, window->xgroup_leader);
-      
+
       meta_window_group_leader_changed (window);
     }
 
@@ -1794,7 +1794,7 @@ lookup_parent_by_client_leader (MetaWindow *transient,
       parent = data->window;
     }
 
-    g_free (data);
+    free (data);
 
     return parent;
 }
@@ -1935,7 +1935,7 @@ reload_gtk_theme_variant (MetaWindow    *window,
 
   if (g_strcmp0 (requested_variant, current_variant) != 0)
     {
-      g_free (current_variant);
+      free (current_variant);
 
       window->gtk_theme_variant = g_strdup (requested_variant);
 
@@ -1976,7 +1976,7 @@ reload_bypass_compositor (MetaWindow    *window,
                        MetaPropValue *value,        \
                        gboolean       initial)      \
   {                                                 \
-    g_free (window->var_name);                      \
+    free (window->var_name);                      \
                                                     \
     if (value->type != META_PROP_VALUE_INVALID)     \
       window->var_name = g_strdup (value->v.str);   \
@@ -2053,8 +2053,8 @@ meta_display_init_window_prop_hooks (MetaDisplay *display)
     { display->atom__GTK_APPLICATION_ID,               META_PROP_VALUE_UTF8,         reload_gtk_application_id,               TRUE, FALSE },
     { display->atom__GTK_UNIQUE_BUS_NAME,              META_PROP_VALUE_UTF8,         reload_gtk_unique_bus_name,              TRUE, FALSE },
     { display->atom__GTK_APPLICATION_OBJECT_PATH,      META_PROP_VALUE_UTF8,         reload_gtk_application_object_path,      TRUE, FALSE },
-    { display->atom__GTK_WINDOW_OBJECT_PATH,           META_PROP_VALUE_UTF8,         reload_gtk_window_object_path,           TRUE, FALSE },    
-    { display->atom__GTK_APP_MENU_OBJECT_PATH,         META_PROP_VALUE_UTF8,         reload_gtk_app_menu_object_path,         TRUE, FALSE },    
+    { display->atom__GTK_WINDOW_OBJECT_PATH,           META_PROP_VALUE_UTF8,         reload_gtk_window_object_path,           TRUE, FALSE },
+    { display->atom__GTK_APP_MENU_OBJECT_PATH,         META_PROP_VALUE_UTF8,         reload_gtk_app_menu_object_path,         TRUE, FALSE },
     { display->atom__GTK_MENUBAR_OBJECT_PATH,          META_PROP_VALUE_UTF8,         reload_gtk_menubar_object_path,          TRUE, FALSE },
     { display->atom__GTK_FRAME_EXTENTS,                META_PROP_VALUE_CARDINAL_LIST,reload_gtk_frame_extents,                TRUE, FALSE },
     { display->atom__NET_WM_USER_TIME_WINDOW, META_PROP_VALUE_WINDOW, reload_net_wm_user_time_window, TRUE, FALSE },
@@ -2077,7 +2077,7 @@ meta_display_init_window_prop_hooks (MetaDisplay *display)
 
   MetaWindowPropHooks *table = g_memdup (hooks, sizeof (hooks)),
     *cursor = table;
-  
+
   g_assert (display->prop_hooks == NULL);
 
   display->prop_hooks_table = (gpointer) table;
@@ -2106,7 +2106,7 @@ meta_display_free_window_prop_hooks (MetaDisplay *display)
   g_hash_table_unref (display->prop_hooks);
   display->prop_hooks = NULL;
 
-  g_free (display->prop_hooks_table);
+  free (display->prop_hooks_table);
   display->prop_hooks_table = NULL;
 }
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -249,24 +249,24 @@ meta_window_finalize (GObject *object)
 
   meta_icon_cache_free (&window->icon_cache);
 
-  g_free (window->sm_client_id);
-  g_free (window->wm_client_machine);
-  g_free (window->startup_id);
-  g_free (window->muffin_hints);
-  g_free (window->role);
-  g_free (window->res_class);
-  g_free (window->res_name);
-  g_free (window->title);
-  g_free (window->icon_name);
-  g_free (window->theme_icon_name);
-  g_free (window->desc);
-  g_free (window->gtk_theme_variant);
-  g_free (window->gtk_application_id);
-  g_free (window->gtk_unique_bus_name);
-  g_free (window->gtk_application_object_path);
-  g_free (window->gtk_window_object_path);
-  g_free (window->gtk_app_menu_object_path);
-  g_free (window->gtk_menubar_object_path);
+  free (window->sm_client_id);
+  free (window->wm_client_machine);
+  free (window->startup_id);
+  free (window->muffin_hints);
+  free (window->role);
+  free (window->res_class);
+  free (window->res_name);
+  free (window->title);
+  free (window->icon_name);
+  free (window->theme_icon_name);
+  free (window->desc);
+  free (window->gtk_theme_variant);
+  free (window->gtk_application_id);
+  free (window->gtk_unique_bus_name);
+  free (window->gtk_application_object_path);
+  free (window->gtk_window_object_path);
+  free (window->gtk_app_menu_object_path);
+  free (window->gtk_menubar_object_path);
 
   G_OBJECT_CLASS (meta_window_parent_class)->finalize (object);
 }
@@ -7906,7 +7906,7 @@ meta_window_update_role (MetaWindow *window)
   g_return_if_fail (!window->override_redirect);
 
   if (window->role)
-    g_free (window->role);
+    free (window->role);
   window->role = NULL;
 
   if (meta_prop_get_latin1_string (window->display, window->xwindow,

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -1,10 +1,10 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -79,7 +79,7 @@ static void
 meta_workspace_finalize (GObject *object)
 {
   /* Actual freeing done in meta_workspace_remove() for now */
-  
+
   G_OBJECT_CLASS (meta_workspace_parent_class)->finalize (object);
 }
 
@@ -201,7 +201,7 @@ meta_workspace_new (MetaScreen *screen)
   workspace->all_struts = NULL;
 
   workspace->showing_desktop = FALSE;
-  
+
   return workspace;
 }
 
@@ -209,7 +209,7 @@ meta_workspace_new (MetaScreen *screen)
 static void
 free_this (gpointer candidate, gpointer dummy)
 {
-  g_free (candidate);
+  free (candidate);
 }
 
 /*
@@ -222,7 +222,7 @@ workspace_free_all_struts (MetaWorkspace *workspace)
 {
   if (workspace->all_struts == NULL)
     return;
-    
+
   g_slist_foreach (workspace->all_struts, free_this, NULL);
   g_slist_free (workspace->all_struts);
   workspace->all_struts = NULL;
@@ -238,7 +238,7 @@ workspace_free_builtin_struts (MetaWorkspace *workspace)
 {
   if (workspace->builtin_struts == NULL)
     return;
-    
+
   g_slist_foreach (workspace->builtin_struts, free_this, NULL);
   g_slist_free (workspace->builtin_struts);
   workspace->builtin_struts = NULL;
@@ -256,7 +256,7 @@ meta_workspace_remove (MetaWorkspace *workspace)
   /* Here we assume all the windows are already on another workspace
    * as well, so they won't be "orphaned"
    */
-  
+
   tmp = workspace->windows;
   while (tmp != NULL)
     {
@@ -274,11 +274,11 @@ meta_workspace_remove (MetaWorkspace *workspace)
   g_assert (workspace->windows == NULL);
 
   screen = workspace->screen;
-  
+
   workspace->screen->workspaces =
     g_list_remove (workspace->screen->workspaces, workspace);
-  
-  g_free (workspace->work_area_monitor);
+
+  free (workspace->work_area_monitor);
 
   g_list_free (workspace->mru_list);
   g_list_free (workspace->list_containing_self);
@@ -297,7 +297,7 @@ meta_workspace_remove (MetaWorkspace *workspace)
       workspace_free_all_struts (workspace);
       for (i = 0; i < screen->n_monitor_infos; i++)
         meta_rectangle_free_list_and_elements (workspace->monitor_region[i]);
-      g_free (workspace->monitor_region);
+      free (workspace->monitor_region);
       meta_rectangle_free_list_and_elements (workspace->screen_region);
       meta_rectangle_free_list_and_elements (workspace->screen_edges);
       meta_rectangle_free_list_and_elements (workspace->monitor_edges);
@@ -325,11 +325,11 @@ meta_workspace_add_window (MetaWorkspace *workspace,
                            MetaWindow    *window)
 {
   g_return_if_fail (window->workspace == NULL);
-  
+
   /* If the window is on all workspaces, we want to add it to all mru
    * lists, otherwise just add it to this workspaces mru list
    */
-  if (window->on_all_workspaces) 
+  if (window->on_all_workspaces)
     {
       if (window->workspace == NULL)
         {
@@ -355,7 +355,7 @@ meta_workspace_add_window (MetaWorkspace *workspace,
   window->workspace = workspace;
 
   meta_window_set_current_workspace_hint (window);
-  
+
   if (window->struts)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -383,10 +383,10 @@ meta_workspace_remove_window (MetaWorkspace *workspace,
   window->workspace = NULL;
 
   /* If the window is on all workspaces, we don't want to remove it
-   * from the MRU list unless this causes it to be removed from all 
+   * from the MRU list unless this causes it to be removed from all
    * workspaces
    */
-  if (window->on_all_workspaces) 
+  if (window->on_all_workspaces)
     {
       GList* tmp = window->screen->workspaces;
       while (tmp)
@@ -404,7 +404,7 @@ meta_workspace_remove_window (MetaWorkspace *workspace,
     }
 
   meta_window_set_current_workspace_hint (window);
-  
+
   if (window->struts)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -428,12 +428,12 @@ meta_workspace_relocate_windows (MetaWorkspace *workspace,
 {
   GList *tmp;
   GList *copy;
-  
+
   g_return_if_fail (workspace != new_home);
 
   /* can't modify list we're iterating over */
   copy = g_list_copy (workspace->windows);
-  
+
   tmp = copy;
   while (tmp != NULL)
     {
@@ -441,12 +441,12 @@ meta_workspace_relocate_windows (MetaWorkspace *workspace,
 
       meta_workspace_remove_window (workspace, window);
       meta_workspace_add_window (new_home, window);
-      
+
       tmp = tmp->next;
     }
 
   g_list_free (copy);
-  
+
   g_assert (workspace->windows == NULL);
 }
 
@@ -594,10 +594,10 @@ meta_workspace_activate_internal (MetaWorkspace       *workspace,
   MetaWorkspaceLayout layout1, layout2;
   gint num_workspaces, current_space, new_space;
   MetaMotionDirection direction;
-  
+
   meta_verbose ("Activating workspace %d\n",
                 meta_workspace_index (workspace));
-  
+
   if (workspace->screen->active_workspace == workspace)
     return;
 
@@ -629,7 +629,7 @@ meta_workspace_activate_internal (MetaWorkspace       *workspace,
   if (workspace->screen->display->grab_op == META_GRAB_OP_MOVING ||
       workspace->screen->display->grab_op == META_GRAB_OP_KEYBOARD_MOVING)
     move_window = workspace->screen->display->grab_window;
-      
+
   if (move_window != NULL)
     {
       if (move_window->on_all_workspaces)
@@ -812,7 +812,7 @@ meta_workspace_list_windows (MetaWorkspace *workspace)
   GSList *display_windows;
   GSList *tmp;
   GList *workspace_windows;
-  
+
   display_windows = meta_display_list_windows (workspace->screen->display,
                                                META_LIST_DEFAULT);
 
@@ -840,7 +840,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
   GList *tmp;
   GList *windows;
   int i;
-  
+
   if (workspace->work_areas_invalid)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -858,14 +858,14 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
   if (workspace == workspace->screen->active_workspace)
     meta_display_cleanup_edges (workspace->screen->display);
 
-  g_free (workspace->work_area_monitor);
+  free (workspace->work_area_monitor);
   workspace->work_area_monitor = NULL;
-      
+
   workspace_free_all_struts (workspace);
 
   for (i = 0; i < workspace->screen->n_monitor_infos; i++)
     meta_rectangle_free_list_and_elements (workspace->monitor_region[i]);
-  g_free (workspace->monitor_region);
+  free (workspace->monitor_region);
   meta_rectangle_free_list_and_elements (workspace->screen_region);
   meta_rectangle_free_list_and_elements (workspace->screen_edges);
   meta_rectangle_free_list_and_elements (workspace->monitor_edges);
@@ -873,7 +873,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
   workspace->screen_region = NULL;
   workspace->screen_edges = NULL;
   workspace->monitor_edges = NULL;
-  
+
   workspace->work_areas_invalid = TRUE;
 
   /* redo the size/position constraints on all windows */
@@ -884,7 +884,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
       MetaWindow *w = tmp->data;
 
       meta_window_queue (w, META_QUEUE_MOVE_RESIZE);
-      
+
       tmp = tmp->next;
     }
 
@@ -949,7 +949,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
 
   /* STEP 2: Get the maximal/spanning rects for the onscreen and
    *         on-single-monitor regions
-   */  
+   */
   g_assert (workspace->monitor_region == NULL);
   g_assert (workspace->screen_region   == NULL);
 
@@ -1021,10 +1021,10 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
               workspace->work_area_screen.x,
               workspace->work_area_screen.y,
               workspace->work_area_screen.width,
-              workspace->work_area_screen.height);    
+              workspace->work_area_screen.height);
 
   /* Now find the work areas for each monitor */
-  g_free (workspace->work_area_monitor);
+  free (workspace->work_area_monitor);
   workspace->work_area_monitor = g_new (MetaRectangle,
                                          workspace->screen->n_monitor_infos);
 
@@ -1056,7 +1056,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
 
   /* STEP 4: Make sure the screen_region is nonempty (separate from step 2
    *         since it relies on step 3).
-   */  
+   */
   if (workspace->screen_region == NULL)
     {
       MetaRectangle *nonempty_region;
@@ -1151,7 +1151,7 @@ meta_workspace_set_builtin_struts (MetaWorkspace *workspace,
           break;
         }
     }
-    
+
   /* Reordering doesn't actually matter, so we don't catch all
    * no-impact changes, but this is just a (possibly unnecessary
    * anyways) optimization */
@@ -1227,7 +1227,7 @@ meta_workspace_get_work_area_for_monitor (MetaWorkspace *workspace,
 
   ensure_work_areas_validated (workspace);
   g_assert (which_monitor < workspace->screen->n_monitor_infos);
-  
+
   *area = workspace->work_area_monitor[which_monitor];
 }
 
@@ -1236,7 +1236,7 @@ meta_workspace_get_work_area_all_monitors (MetaWorkspace *workspace,
                                            MetaRectangle *area)
 {
   ensure_work_areas_validated (workspace);
-  
+
   *area = workspace->work_area_screen;
 }
 
@@ -1300,7 +1300,7 @@ MetaWorkspace*
 meta_workspace_get_neighbor (MetaWorkspace      *workspace,
                              MetaMotionDirection direction)
 {
-  MetaWorkspaceLayout layout;  
+  MetaWorkspaceLayout layout;
   int i, current_space, num_workspaces;
   gboolean ltr, cycle;
 
@@ -1312,10 +1312,10 @@ meta_workspace_get_neighbor (MetaWorkspace      *workspace,
 
   meta_verbose ("Getting neighbor of %d in direction %s\n",
                 current_space, meta_motion_direction_to_string (direction));
-  
+
   ltr = meta_ui_get_direction() == META_UI_DIRECTION_LTR;
 
-  switch (direction) 
+  switch (direction)
     {
     case META_MOTION_LEFT:
       layout.current_col -= ltr ? 1 : -1;
@@ -1349,12 +1349,12 @@ meta_workspace_get_neighbor (MetaWorkspace      *workspace,
   if (i >= num_workspaces)
     meta_bug ("calc_workspace_layout left an invalid (too-high) workspace number %d in the grid\n",
               i);
-    
+
   meta_verbose ("Neighbor workspace is %d at row %d col %d\n",
                 i, layout.current_row, layout.current_col);
 
   meta_screen_free_workspace_layout (&layout);
-  
+
   return meta_screen_get_workspace_by_index (workspace->screen, i);
 }
 
@@ -1408,7 +1408,7 @@ meta_workspace_focus_default_window (MetaWorkspace *workspace,
             }
 
           if (workspace->screen->display->autoraise_window != window &&
-              meta_prefs_get_auto_raise ()) 
+              meta_prefs_get_auto_raise ())
             {
               meta_display_queue_autoraise_callback (workspace->screen->display,
                                                      window);
@@ -1453,7 +1453,7 @@ focus_ancestor_or_top_window (MetaWorkspace *workspace,
     meta_topic (META_DEBUG_FOCUS,
                 "Focusing MRU window\n");
 
-  /* First, check to see if we need to focus an ancestor of a window */  
+  /* First, check to see if we need to focus an ancestor of a window */
   if (not_this_one)
     {
       MetaWindow *ancestor;
@@ -1465,9 +1465,9 @@ focus_ancestor_or_top_window (MetaWorkspace *workspace,
           meta_window_showing_on_its_workspace (ancestor))
         {
           meta_topic (META_DEBUG_FOCUS,
-                      "Focusing %s, ancestor of %s\n", 
+                      "Focusing %s, ancestor of %s\n",
                       ancestor->desc, not_this_one->desc);
-      
+
           meta_window_focus (ancestor, timestamp);
 
           /* Also raise the window if in click-to-focus */
@@ -1486,7 +1486,7 @@ focus_ancestor_or_top_window (MetaWorkspace *workspace,
     {
       meta_topic (META_DEBUG_FOCUS,
                   "Focusing workspace MRU window %s\n", window->desc);
-      
+
       meta_window_focus (window, timestamp);
 
       /* Also raise the window if in click-to-focus */

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -441,7 +441,7 @@ meta_prop_get_utf8_string (MetaDisplay *display,
   return utf8_string_from_results (&results, str_p);
 }
 
-/* this one freakishly returns g_malloc memory */
+/* this one freakishly returns malloc memory */
 static gboolean
 utf8_list_from_results (GetPropertyResults *results,
                         char             ***str_p,
@@ -516,7 +516,7 @@ utf8_list_from_results (GetPropertyResults *results,
   return TRUE;
 }
 
-/* returns g_malloc not Xmalloc memory */
+/* returns malloc not Xmalloc memory */
 LOCAL_SYMBOL gboolean
 meta_prop_get_utf8_list (MetaDisplay   *display,
                          Window         xwindow,

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -2,7 +2,7 @@
 
 /* Muffin X property convenience routines */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat Inc.
  *
@@ -10,7 +10,7 @@
  *   Copyright 1987, 1988, 1998  The Open Group
  *   Copyright 1988 by Wyse Technology, Inc., San Jose, Ca,
  *   Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts,
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -20,7 +20,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -33,20 +33,20 @@ Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts,
 
                         All Rights Reserved
 
-Permission to use, copy, modify, and distribute this software and its 
-documentation for any purpose and without fee is hereby granted, 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
 provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in 
+both that copyright notice and this permission notice appear in
 supporting documentation, and that the name Digital not be
 used in advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.  
+software without specific, written prior permission.
 
-DIGITAL AND WYSE DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, 
-INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO 
-EVENT SHALL DIGITAL OR WYSE BE LIABLE FOR ANY SPECIAL, INDIRECT OR 
-CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF 
-USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR 
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR 
+DIGITAL AND WYSE DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL DIGITAL OR WYSE BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ******************************************************************/
@@ -116,12 +116,12 @@ validate_or_free_results (GetPropertyResults *results,
   const char *res_class;
   const char *res_name;
   MetaWindow *w;
-  
+
   if (expected_format == results->format &&
       expected_type == results->type &&
       (!must_have_items || results->n_items > 0))
-    return TRUE;  
-  
+    return TRUE;
+
   meta_error_trap_push (results->display);
   type_name = XGetAtomName (results->display->xdisplay, results->type);
   expected_name = XGetAtomName (results->display->xdisplay, expected_type);
@@ -142,7 +142,7 @@ validate_or_free_results (GetPropertyResults *results,
       res_class = NULL;
       res_name = NULL;
     }
-  
+
   if (title == NULL)
     title = "unknown";
 
@@ -151,7 +151,7 @@ validate_or_free_results (GetPropertyResults *results,
 
   if (res_name == NULL)
     res_name = "unknown";
-  
+
   meta_warning (_("Window 0x%lx has property %s\nthat was expected to have type %s format %d\nand actually has type %s format %d n_items %d.\nThis is most likely an application bug, not a window manager bug.\nThe window has title=\"%s\" class=\"%s\" name=\"%s\"\n"),
                 results->xwindow,
                 prop_name ? prop_name : "(bad atom)",
@@ -173,7 +173,7 @@ validate_or_free_results (GetPropertyResults *results,
       XFree (results->prop);
       results->prop = NULL;
     }
-  
+
   return FALSE;
 }
 
@@ -192,7 +192,7 @@ get_property (MetaDisplay        *display,
   results->type = None;
   results->bytes_after = 0;
   results->format = 0;
-  
+
   meta_error_trap_push_with_return (display);
   if (XGetWindowProperty (display->xdisplay, xwindow, xatom,
                           0, G_MAXLONG,
@@ -224,12 +224,12 @@ atom_list_from_results (GetPropertyResults *results,
                         int                *n_atoms_p)
 {
   if (!validate_or_free_results (results, 32, XA_ATOM, FALSE))
-    return FALSE;  
+    return FALSE;
 
   *atoms_p = (Atom*) results->prop;
   *n_atoms_p = results->n_items;
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -258,12 +258,12 @@ cardinal_list_from_results (GetPropertyResults *results,
                             int                *n_cardinals_p)
 {
   if (!validate_or_free_results (results, 32, XA_CARDINAL, FALSE))
-    return FALSE;  
+    return FALSE;
 
   *cardinals_p = (gulong*) results->prop;
   *n_cardinals_p = results->n_items;
   results->prop = NULL;
-  
+
 #if GLIB_SIZEOF_LONG == 8
   /* Xlib sign-extends format=32 items, but we want them unsigned */
   {
@@ -302,8 +302,8 @@ motif_hints_from_results (GetPropertyResults *results,
 {
   int real_size, max_size;
 #define MAX_ITEMS sizeof (MotifWmHints)/sizeof (gulong)
-  
-  *hints_p = NULL;  
+
+  *hints_p = NULL;
 
   if (results->type == None || results->n_items <= 0)
     {
@@ -339,7 +339,7 @@ motif_hints_from_results (GetPropertyResults *results,
       XFree (results->prop);
       results->prop = NULL;
     }
-  
+
   return TRUE;
 }
 
@@ -350,7 +350,7 @@ meta_prop_get_motif_hints (MetaDisplay   *display,
                            MotifWmHints **hints_p)
 {
   GetPropertyResults results;
-  
+
   *hints_p = NULL;
 
   if (!get_property (display, xwindow, xatom, AnyPropertyType,
@@ -365,13 +365,13 @@ latin1_string_from_results (GetPropertyResults *results,
                             char              **str_p)
 {
   *str_p = NULL;
-  
+
   if (!validate_or_free_results (results, 8, XA_STRING, FALSE))
     return FALSE;
 
   *str_p = (char*) results->prop;
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -388,7 +388,7 @@ meta_prop_get_latin1_string (MetaDisplay *display,
   if (!get_property (display, xwindow, xatom, XA_STRING,
                      &results))
     return FALSE;
-  
+
   return latin1_string_from_results (&results, str_p);
 }
 
@@ -397,7 +397,7 @@ utf8_string_from_results (GetPropertyResults *results,
                           char              **str_p)
 {
   *str_p = NULL;
-  
+
   if (!validate_or_free_results (results, 8,
                                  results->display->atom_UTF8_STRING, FALSE))
     return FALSE;
@@ -413,13 +413,13 @@ utf8_string_from_results (GetPropertyResults *results,
       meta_XFree (name);
       XFree (results->prop);
       results->prop = NULL;
-      
+
       return FALSE;
     }
-  
+
   *str_p = (char*) results->prop;
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -451,14 +451,14 @@ utf8_list_from_results (GetPropertyResults *results,
   int n_strings;
   char **retval;
   const char *p;
-  
+
   *str_p = NULL;
   *n_str_p = 0;
 
   if (!validate_or_free_results (results, 8,
                                  results->display->atom_UTF8_STRING, FALSE))
     return FALSE;
-  
+
   /* I'm not sure this is right, but I'm guessing the
    * property is nul-separated
    */
@@ -473,11 +473,11 @@ utf8_list_from_results (GetPropertyResults *results,
 
   if (results->prop[results->n_items - 1] != '\0')
     ++n_strings;
- 
+
   /* we're guaranteed that results->prop has a nul on the end
    * by XGetWindowProperty
    */
-  
+
   retval = g_new0 (char*, n_strings + 1);
 
   p = (char *)results->prop;
@@ -496,17 +496,17 @@ utf8_list_from_results (GetPropertyResults *results,
           meta_XFree (name);
           meta_XFree (results->prop);
           results->prop = NULL;
-          
+
           g_strfreev (retval);
           return FALSE;
         }
 
       retval[i] = g_strdup (p);
-      
+
       p = p + strlen (p) + 1;
       ++i;
     }
-  
+
   *str_p = retval;
   *n_str_p = i;
 
@@ -543,9 +543,9 @@ meta_prop_set_utf8_string_hint (MetaDisplay *display,
                                 const char *val)
 {
   meta_error_trap_push (display);
-  XChangeProperty (display->xdisplay, 
+  XChangeProperty (display->xdisplay,
                    xwindow, atom,
-                   display->atom_UTF8_STRING, 
+                   display->atom_UTF8_STRING,
                    8, PropModeReplace, (guchar*) val, strlen (val));
   meta_error_trap_pop (display);
 }
@@ -555,12 +555,12 @@ window_from_results (GetPropertyResults *results,
                      Window             *window_p)
 {
   if (!validate_or_free_results (results, 32, XA_WINDOW, TRUE))
-    return FALSE;  
+    return FALSE;
 
   *window_p = *(Window*) results->prop;
   XFree (results->prop);
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -572,12 +572,12 @@ counter_from_results (GetPropertyResults *results,
   if (!validate_or_free_results (results, 32,
                                  XA_CARDINAL,
                                  TRUE))
-    return FALSE;  
+    return FALSE;
 
   *counter_p = *(XSyncCounter*) results->prop;
   XFree (results->prop);
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -608,7 +608,7 @@ meta_prop_get_window (MetaDisplay *display,
   GetPropertyResults results;
 
   *window_p = None;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WINDOW,
                      &results))
     return FALSE;
@@ -632,7 +632,7 @@ cardinal_with_atom_type_from_results (GetPropertyResults *results,
                                       gulong             *cardinal_p)
 {
   if (!validate_or_free_results (results, 32, prop_type, TRUE))
-    return FALSE;  
+    return FALSE;
 
   *cardinal_p = *(gulong*) results->prop;
 #if GLIB_SIZEOF_LONG == 8
@@ -640,8 +640,8 @@ cardinal_with_atom_type_from_results (GetPropertyResults *results,
   *cardinal_p &= 0xffffffff;
 #endif
   XFree (results->prop);
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -670,19 +670,19 @@ text_property_from_results (GetPropertyResults *results,
   XTextProperty tp;
 
   *utf8_str_p = NULL;
-  
+
   tp.value = results->prop;
   results->prop = NULL;
   tp.encoding = results->type;
   tp.format = results->format;
-  tp.nitems = results->n_items;  
-  
+  tp.nitems = results->n_items;
+
   *utf8_str_p = meta_text_property_to_utf8 (results->display->xdisplay,
                                             &tp);
-  
+
   if (tp.value != NULL)
     XFree (tp.value);
-  
+
   return *utf8_str_p != NULL;
 }
 
@@ -693,7 +693,7 @@ meta_prop_get_text_property (MetaDisplay   *display,
                              char         **utf8_str_p)
 {
   GetPropertyResults results;
-  
+
   if (!get_property (display, xwindow, xatom, AnyPropertyType,
                      &results))
     return FALSE;
@@ -732,13 +732,13 @@ wm_hints_from_results (GetPropertyResults *results,
 {
   XWMHints *hints;
   xPropWMHints *raw;
-  
-  *hints_p = NULL;
-  
-  if (!validate_or_free_results (results, 32, XA_WM_HINTS, TRUE))
-    return FALSE;  
 
-  /* pre-R3 bogusly truncated window_group, don't fail on them */  
+  *hints_p = NULL;
+
+  if (!validate_or_free_results (results, 32, XA_WM_HINTS, TRUE))
+    return FALSE;
+
+  /* pre-R3 bogusly truncated window_group, don't fail on them */
   if (results->n_items < (NumPropWMHintsElements - 1))
     {
       meta_verbose ("WM_HINTS property too short: %d should be %d\n",
@@ -750,11 +750,11 @@ wm_hints_from_results (GetPropertyResults *results,
         }
       return FALSE;
     }
-  
+
   hints = ag_Xmalloc0 (sizeof (XWMHints));
 
   raw = (xPropWMHints*) results->prop;
-  
+
   hints->flags = raw->flags;
   hints->input = (raw->input ? True : False);
   hints->initial_state = cvtINT32toInt (raw->initialState);
@@ -788,7 +788,7 @@ meta_prop_get_wm_hints (MetaDisplay   *display,
   GetPropertyResults results;
 
   *hints_p = NULL;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WM_HINTS,
                      &results))
     return FALSE;
@@ -801,13 +801,13 @@ class_hint_from_results (GetPropertyResults *results,
                          XClassHint         *class_hint)
 {
   int len_name, len_class;
-  
+
   class_hint->res_class = NULL;
   class_hint->res_name = NULL;
-  
+
   if (!validate_or_free_results (results, 8, XA_STRING, FALSE))
     return FALSE;
-  
+
   len_name = strlen ((char *) results->prop);
   if (! (class_hint->res_name = ag_Xmalloc (len_name+1)))
     {
@@ -815,14 +815,14 @@ class_hint_from_results (GetPropertyResults *results,
       results->prop = NULL;
       return FALSE;
     }
-  
+
   strcpy (class_hint->res_name, (char *)results->prop);
 
   if (len_name == (int) results->n_items)
     len_name--;
-  
+
   len_class = strlen ((char *)results->prop + len_name + 1);
-  
+
   if (! (class_hint->res_class = ag_Xmalloc(len_class+1)))
     {
       XFree(class_hint->res_name);
@@ -831,12 +831,12 @@ class_hint_from_results (GetPropertyResults *results,
       results->prop = NULL;
       return FALSE;
     }
-  
+
   strcpy (class_hint->res_class, (char *)results->prop + len_name + 1);
 
   XFree (results->prop);
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -847,10 +847,10 @@ meta_prop_get_class_hint (MetaDisplay   *display,
                           XClassHint    *class_hint)
 {
   GetPropertyResults results;
-  
+
   class_hint->res_class = NULL;
   class_hint->res_name = NULL;
-  
+
   if (!get_property (display, xwindow, xatom, XA_STRING,
                      &results))
     return FALSE;
@@ -865,10 +865,10 @@ size_hints_from_results (GetPropertyResults *results,
 {
   xPropSizeHints *raw;
   XSizeHints *hints;
-  
+
   *hints_p = NULL;
   *flags_p = 0;
-  
+
   if (!validate_or_free_results (results, 32, XA_WM_SIZE_HINTS, FALSE))
     return FALSE;
 
@@ -882,7 +882,7 @@ size_hints_from_results (GetPropertyResults *results,
   raw = (xPropSizeHints*) results->prop;
 
   hints = ag_Xmalloc (sizeof (XSizeHints));
-  
+
   /* XSizeHints misdeclares these as int instead of long */
   hints->flags = raw->flags;
   hints->x = cvtINT32toInt (raw->x);
@@ -910,12 +910,12 @@ size_hints_from_results (GetPropertyResults *results,
     }
 
   hints->flags &= (*flags_p);	/* get rid of unwanted bits */
-  
+
   XFree (results->prop);
   results->prop = NULL;
 
   *hints_p = hints;
-  
+
   return TRUE;
 }
 
@@ -930,7 +930,7 @@ meta_prop_get_size_hints (MetaDisplay   *display,
 
   *hints_p = NULL;
   *flags_p = 0;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WM_SIZE_HINTS,
                      &results))
     return FALSE;
@@ -955,7 +955,7 @@ latin1_to_utf8 (const char *text)
 {
   GString *str;
   const char *p;
-  
+
   str = g_string_new ("");
 
   p = text;
@@ -979,10 +979,10 @@ meta_prop_get_values (MetaDisplay   *display,
 
   meta_verbose ("Requesting %d properties of 0x%lx at once\n",
                 n_values, xwindow);
-  
+
   if (n_values == 0)
     return;
-  
+
   tasks = g_new0 (AgGetPropertyTask*, n_values);
 
   /* Start up tasks. The "values" array can have values
@@ -1045,22 +1045,22 @@ meta_prop_get_values (MetaDisplay   *display,
       if (values[i].atom != None)
         tasks[i] = get_task (display, xwindow,
                              values[i].atom, values[i].required_type);
-      
+
       ++i;
-    }  
-  
+    }
+
   /* Get replies for all our tasks */
   meta_topic (META_DEBUG_SYNC, "Syncing to get %d GetProperty replies in %s\n",
               n_values, G_STRFUNC);
   XSync (display->xdisplay, False);
-  
+
   /* Collect results, should arrive in order requested */
   i = 0;
   while (i < n_values)
     {
       AgGetPropertyTask *task;
       GetPropertyResults results;
-      
+
       if (tasks[i] == NULL)
         {
           /* Probably values[i].type was None, or ag_task_create()
@@ -1069,7 +1069,7 @@ meta_prop_get_values (MetaDisplay   *display,
           values[i].type = META_PROP_VALUE_INVALID;
           goto next;
         }
-      
+
       task = ag_get_next_completed_task (display->xdisplay);
       g_assert (task != NULL);
       g_assert (ag_task_have_reply (task));
@@ -1082,7 +1082,7 @@ meta_prop_get_values (MetaDisplay   *display,
       results.type = None;
       results.bytes_after = 0;
       results.format = 0;
-      
+
       if (ag_task_get_reply_and_free (task,
                                       &results.type, &results.format,
                                       &results.n_items,
@@ -1138,7 +1138,7 @@ meta_prop_get_values (MetaDisplay   *display,
                   values[i].v.str = xmalloc_new_str;
                 }
 
-              g_free (new_str);
+              free (new_str);
             }
           break;
         case META_PROP_VALUE_MOTIF_HINTS:
@@ -1216,7 +1216,7 @@ meta_prop_get_values (MetaDisplay   *display,
       ++i;
     }
 
-  g_free (tasks);
+  free (tasks);
 }
 
 static void
@@ -1224,7 +1224,7 @@ free_value (MetaPropValue *value)
 {
   switch (value->type)
     {
-    case META_PROP_VALUE_INVALID:          
+    case META_PROP_VALUE_INVALID:
       break;
     case META_PROP_VALUE_UTF8:
     case META_PROP_VALUE_STRING:
@@ -1233,10 +1233,10 @@ free_value (MetaPropValue *value)
       break;
     case META_PROP_VALUE_MOTIF_HINTS:
       meta_XFree (value->v.motif_hints);
-      break;          
+      break;
     case META_PROP_VALUE_CARDINAL:
       break;
-    case META_PROP_VALUE_WINDOW:          
+    case META_PROP_VALUE_WINDOW:
       break;
     case META_PROP_VALUE_ATOM_LIST:
       meta_XFree (value->v.atom_list.atoms);

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -29,6 +29,7 @@
 #define META_COMMON_H
 
 /* Don't include core headers here */
+#include <stdlib.h>
 #include <X11/Xlib.h>
 #include <glib.h>
 #include <gtk/gtk.h>

--- a/src/tools/muffin-window-demo.c
+++ b/src/tools/muffin-window-demo.c
@@ -1,8 +1,8 @@
 /* Muffin window types/properties demo app */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -36,7 +36,7 @@ set_gdk_window_struts (GdkWindow *window,
                        int        bottom)
 {
   long vals[12];
-  
+
   vals[0] = left;
   vals[1] = right;
   vals[2] = top;
@@ -76,7 +76,7 @@ on_realize_set_struts (GtkWindow *window,
   right = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-right"));
   top = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-top"));
   bottom = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-bottom"));
-  
+
   set_gdk_window_struts (gtk_widget_get_window (widget),
                          left, right, top, bottom);
 }
@@ -120,15 +120,15 @@ set_gdk_window_type (GdkWindow  *window,
                      const char *type)
 {
   Atom atoms[2] = { None, None };
-  
+
   atoms[0] = XInternAtom (GDK_WINDOW_XDISPLAY (window),
                           type, False);
-  
+
   XChangeProperty (GDK_WINDOW_XDISPLAY (window),
                    GDK_WINDOW_XID (window),
                    XInternAtom (GDK_WINDOW_XDISPLAY (window), "_NET_WM_WINDOW_TYPE", False),
                    XA_ATOM, 32, PropModeReplace,
-                   (guchar *)atoms, 
+                   (guchar *)atoms,
                    1);
 }
 
@@ -146,7 +146,7 @@ on_realize_set_type (GtkWindow *window,
   type = g_object_get_data (G_OBJECT (window), "meta-window-type");
 
   g_return_if_fail (type != NULL);
-  
+
   set_gdk_window_type (gtk_widget_get_window (widget),
                        type);
 }
@@ -164,7 +164,7 @@ set_gtk_window_type (GtkWindow  *window,
   g_signal_handlers_disconnect_by_func (G_OBJECT (window),
                                         on_realize_set_type,
                                         NULL);
-                                
+
   g_signal_connect_after (G_OBJECT (window),
                           "realize",
                           G_CALLBACK (on_realize_set_type),
@@ -190,7 +190,7 @@ on_realize_set_border_only (GtkWindow *window,
   widget = GTK_WIDGET (window);
 
   g_return_if_fail (gtk_widget_get_realized (widget));
-  
+
   set_gdk_window_border_only (gtk_widget_get_window (widget));
 }
 
@@ -204,7 +204,7 @@ set_gtk_window_border_only (GtkWindow  *window)
   g_signal_handlers_disconnect_by_func (G_OBJECT (window),
                                         on_realize_set_border_only,
                                         NULL);
-                                
+
   g_signal_connect_after (G_OBJECT (window),
                           "realize",
                           G_CALLBACK (on_realize_set_border_only),
@@ -220,7 +220,7 @@ main (int argc, char **argv)
   GList *list;
   GdkPixbuf *pixbuf;
   GError *err;
-  
+
   gtk_init (&argc, &argv);
 
   err = NULL;
@@ -229,7 +229,7 @@ main (int argc, char **argv)
   if (pixbuf)
     {
       list = g_list_prepend (NULL, pixbuf);
-      
+
       gtk_window_set_default_icon_list (list);
       g_list_free (list);
       g_object_unref (G_OBJECT (pixbuf));
@@ -239,11 +239,11 @@ main (int argc, char **argv)
       g_printerr ("Could not load icon: %s\n", err->message);
       g_error_free (err);
     }
-  
+
   do_appwindow ();
 
   gtk_main ();
-  
+
   return 0;
 }
 
@@ -258,7 +258,7 @@ make_dialog (GtkWidget *parent,
 {
   GtkWidget *dialog;
   char *str;
-  
+
   dialog = gtk_message_dialog_new (parent ? GTK_WINDOW (parent) : NULL,
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -269,12 +269,12 @@ make_dialog (GtkWidget *parent,
 
   str = g_strdup_printf ("%d dialog", depth);
   gtk_window_set_title (GTK_WINDOW (dialog), str);
-  g_free (str);
-  
+  free (str);
+
   gtk_dialog_add_button (GTK_DIALOG (dialog),
                          "Open child dialog",
                          GTK_RESPONSE_ACCEPT);
-  
+
   /* Close dialog on user response */
   g_signal_connect (G_OBJECT (dialog),
                     "response",
@@ -283,7 +283,7 @@ make_dialog (GtkWidget *parent,
 
   g_object_set_data (G_OBJECT (dialog), "depth",
                      GINT_TO_POINTER (depth));
-  
+
   gtk_widget_show (dialog);
 }
 
@@ -318,7 +318,7 @@ modal_dialog_cb (GtkAction           *action,
                  gpointer             callback_data)
 {
   GtkWidget *dialog;
-  
+
   dialog = gtk_message_dialog_new (GTK_WINDOW (callback_data),
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -326,7 +326,7 @@ modal_dialog_cb (GtkAction           *action,
                                    "Here is a MODAL dialog");
 
   set_gtk_window_type (GTK_WINDOW (dialog), "_NET_WM_WINDOW_TYPE_MODAL_DIALOG");
-  
+
   gtk_dialog_run (GTK_DIALOG (dialog));
 
   gtk_widget_destroy (dialog);
@@ -346,13 +346,13 @@ utility_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *button;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_UTILITY");
   gtk_window_set_title (GTK_WINDOW (window), "Utility");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
@@ -368,7 +368,7 @@ utility_cb (GtkAction           *action,
 
   button = gtk_button_new_with_mnemonic ("_D button");
   gtk_box_pack_start (GTK_BOX (vbox), button, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -379,20 +379,20 @@ toolbar_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_TOOLBAR");
   gtk_window_set_title (GTK_WINDOW (window), "Toolbar");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("FIXME this needs a resize grip, etc.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -403,20 +403,20 @@ menu_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_MENU");
   gtk_window_set_title (GTK_WINDOW (window), "Menu");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("FIXME this isn't a menu.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -427,17 +427,17 @@ override_redirect_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_POPUP);
   gtk_window_set_title (GTK_WINDOW (window), "Override Redirect");
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This is an override\nredirect window\nand should not be managed");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -448,20 +448,20 @@ border_only_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_border_only (GTK_WINDOW (window));
   gtk_window_set_title (GTK_WINDOW (window), "Border only");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This window is supposed to have a border but no titlebar.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -473,17 +473,17 @@ changing_icon_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_title (GTK_WINDOW (window), "Changing Icon");
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This window has an icon that changes over time");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 #endif
@@ -513,7 +513,7 @@ focus_out_event_cb (GtkWidget *window,
   widget = GTK_WIDGET (data);
 
   gtk_label_set_text (GTK_LABEL (widget), "Not focused");
-  
+
   return TRUE;
 }
 
@@ -521,7 +521,7 @@ static GtkWidget*
 focus_label (GtkWidget *window)
 {
   GtkWidget *label;
-  
+
   label = gtk_label_new ("Not focused");
 
   g_signal_connect (G_OBJECT (window), "focus_in_event",
@@ -529,7 +529,7 @@ focus_label (GtkWidget *window)
 
   g_signal_connect (G_OBJECT (window), "focus_out_event",
                     G_CALLBACK (focus_out_event_cb), label);
-  
+
   return label;
 }
 
@@ -540,20 +540,20 @@ splashscreen_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *image;
   GtkWidget *vbox;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_SPLASHSCREEN");
   gtk_window_set_title (GTK_WINDOW (window), "Splashscreen");
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-  
+
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO, GTK_ICON_SIZE_DIALOG);
   gtk_box_pack_start (GTK_BOX (vbox), image, FALSE, FALSE, 0);
 
-  gtk_box_pack_start (GTK_BOX (vbox), focus_label (window), FALSE, FALSE, 0);  
-  
+  gtk_box_pack_start (GTK_BOX (vbox), focus_label (window), FALSE, FALSE, 0);
+
   gtk_container_add (GTK_CONTAINER (window), vbox);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -580,7 +580,7 @@ make_dock (int type)
   switch (type)
     {
     case DOCK_LEFT:
-    case DOCK_RIGHT:      
+    case DOCK_RIGHT:
       box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
       break;
     case DOCK_TOP:
@@ -593,18 +593,18 @@ make_dock (int type)
 
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_DOCK");
-  
+
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO, GTK_ICON_SIZE_DIALOG);
-  gtk_box_pack_start (GTK_BOX (box), image, FALSE, FALSE, 0);  
-  
-  gtk_box_pack_start (GTK_BOX (box), focus_label (window), FALSE, FALSE, 0);  
+  gtk_box_pack_start (GTK_BOX (box), image, FALSE, FALSE, 0);
+
+  gtk_box_pack_start (GTK_BOX (box), focus_label (window), FALSE, FALSE, 0);
 
   button = gtk_button_new_with_label ("Close");
   gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
   g_signal_connect_swapped (G_OBJECT (button), "clicked",
                             G_CALLBACK (gtk_widget_destroy), window);
-  
+
   gtk_container_add (GTK_CONTAINER (window), box);
 
 #define DOCK_SIZE 48
@@ -616,7 +616,7 @@ make_dock (int type)
       set_gtk_window_struts (window, DOCK_SIZE, 0, 0, 0);
       gtk_window_set_title (GTK_WINDOW (window), "LeftDock");
       break;
-    case DOCK_RIGHT:      
+    case DOCK_RIGHT:
       gtk_widget_set_size_request (window, DOCK_SIZE, 400);
       gtk_window_move (GTK_WINDOW (window), gdk_screen_width () - DOCK_SIZE, 200);
       set_gtk_window_struts (window, 0, DOCK_SIZE, 0, 0);
@@ -637,7 +637,7 @@ make_dock (int type)
     case DOCK_ALL:
       break;
     }
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -683,25 +683,25 @@ desktop_cb (GtkAction           *action,
   GtkWidget *window;
   GtkWidget *label;
   GdkRGBA desktop_color;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_DESKTOP");
   gtk_window_set_title (GTK_WINDOW (window), "Desktop");
   gtk_widget_set_size_request (window,
                                gdk_screen_width (), gdk_screen_height ());
   gtk_window_move (GTK_WINDOW (window), 0, 0);
-  
+
   desktop_color.red = 0.32;
   desktop_color.green = 0.46;
   desktop_color.blue = 0.65;
   desktop_color.alpha = 1.0;
 
   gtk_widget_override_background_color (window, 0, &desktop_color);
-  
+
   label = focus_label (window);
-  
+
   gtk_container_add (GTK_CONTAINER (window), label);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -739,7 +739,7 @@ toggle_aspect_ratio (GtkAction *action,
                                    widget,
 				   &geom,
 				   GDK_HINT_ASPECT);
-				   
+
 }
 
 static void
@@ -758,7 +758,7 @@ clicked_toolbar_cb (GtkWidget *button,
                     gpointer   data)
 {
   GtkWidget *dialog;
-  
+
   dialog = gtk_message_dialog_new (GTK_WINDOW (data),
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -770,7 +770,7 @@ clicked_toolbar_cb (GtkWidget *button,
                     "response",
                     G_CALLBACK (gtk_widget_destroy),
                     NULL);
-  
+
   gtk_widget_show (dialog);
 }
 
@@ -782,7 +782,7 @@ update_statusbar (GtkTextBuffer *buffer,
   gint row, col;
   gint count;
   GtkTextIter iter;
-  
+
   gtk_statusbar_pop (statusbar, 0); /* clear any previous message, underflow is allowed */
 
   count = gtk_text_buffer_get_char_count (buffer);
@@ -799,7 +799,7 @@ update_statusbar (GtkTextBuffer *buffer,
 
   gtk_statusbar_push (statusbar, 0, msg);
 
-  g_free (msg);
+  free (msg);
 }
 
 static void
@@ -916,7 +916,7 @@ do_appwindow (void)
   GtkTextBuffer *buffer;
   GtkActionGroup *action_group;
   GtkUIManager *ui_manager;
-      
+
   /* Create the toplevel window
    */
 
@@ -926,20 +926,20 @@ do_appwindow (void)
 
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_title (GTK_WINDOW (window), "Application Window");
-  
+
   g_signal_connect (G_OBJECT (window), "destroy",
                     G_CALLBACK (destroy_cb), NULL);
-      
+
   grid = gtk_grid_new ();
 
   gtk_widget_set_vexpand (grid, TRUE);
   gtk_widget_set_hexpand (grid, TRUE);
 
   gtk_container_add (GTK_CONTAINER (window), grid);
-      
+
   /* Create the menubar
    */
-      
+
   contents = gtk_text_view_new ();
 
   action_group = gtk_action_group_new ("mainmenu");
@@ -988,10 +988,10 @@ do_appwindow (void)
 
   gtk_window_set_default_size (GTK_WINDOW (window),
                                200, 200);
-      
+
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
                                PANGO_WRAP_WORD);
-      
+
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);
 
@@ -1024,7 +1024,7 @@ do_appwindow (void)
                             "Be sure to tear off the menu and toolbar, those are also "
                             "a special kind of window.",
                             -1);
-      
+
   g_signal_connect_object (buffer,
                            "changed",
                            G_CALLBACK (update_statusbar),
@@ -1036,7 +1036,7 @@ do_appwindow (void)
                            G_CALLBACK (mark_set_callback),
                            statusbar,
                            0);
-      
+
   update_statusbar (buffer, GTK_STATUSBAR (statusbar));
 
   gtk_widget_show_all (window);

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2,11 +2,11 @@
 
 /* Metacity window frame manager widget */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003 Red Hat, Inc.
  * Copyright (C) 2005, 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -130,7 +130,7 @@ meta_frames_class_init (MetaFramesClass *class)
   widget_class->style_updated = meta_frames_style_updated;
 
   widget_class->draw = meta_frames_draw;
-  widget_class->destroy_event = meta_frames_destroy_event;  
+  widget_class->destroy_event = meta_frames_destroy_event;
   widget_class->button_press_event = meta_frames_button_press_event;
   widget_class->button_release_event = meta_frames_button_release_event;
   widget_class->motion_notify_event = meta_frames_motion_notify_event;
@@ -202,7 +202,7 @@ create_style_context (MetaFrames  *frames,
                                       GTK_STYLE_PROVIDER_PRIORITY_SETTINGS);
     }
 
-  g_free (theme_name);
+  free (theme_name);
 
   return style;
 }
@@ -247,7 +247,7 @@ static void
 meta_frames_init (MetaFrames *frames)
 {
   frames->text_heights = g_hash_table_new (NULL, NULL);
-  
+
   frames->frames = g_hash_table_new (unsigned_long_hash, unsigned_long_equal);
 
   frames->invalidate_cache_timeout_id = 0;
@@ -255,7 +255,7 @@ meta_frames_init (MetaFrames *frames)
   frames->cache = g_hash_table_new (g_direct_hash, g_direct_equal);
 
   frames->style_variants = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                  g_free, g_object_unref);
+                                                  free, g_object_unref);
   frames->entered = FALSE;
   frames->last_cursor_x = -1;
   frames->last_cursor_y = -1;
@@ -286,7 +286,7 @@ meta_frames_destroy (GtkWidget *object)
   GSList *winlist;
   GSList *tmp;
   MetaFrames *frames;
-  
+
   frames = META_FRAMES (object);
 
   winlist = NULL;
@@ -322,11 +322,11 @@ static void
 meta_frames_finalize (GObject *object)
 {
   MetaFrames *frames;
-  
+
   frames = META_FRAMES (object);
 
   meta_prefs_remove_listener (prefs_changed_callback, frames);
-  
+
   g_hash_table_destroy (frames->text_heights);
 
   invalidate_all_caches (frames);
@@ -334,7 +334,7 @@ meta_frames_finalize (GObject *object)
     g_source_remove (frames->invalidate_cache_timeout_id);
     frames->invalidate_cache_timeout_id = 0;
   }
-  
+
   g_assert (g_hash_table_size (frames->frames) == 0);
   g_hash_table_destroy (frames->frames);
   g_hash_table_destroy (frames->cache);
@@ -361,7 +361,7 @@ get_cache (MetaFrames *frames,
            MetaUIFrame *frame)
 {
   CachedPixels *pixels;
-  
+
   pixels = g_hash_table_lookup (frames->cache, frame);
 
   if (!pixels)
@@ -379,12 +379,12 @@ invalidate_cache (MetaFrames *frames,
 {
   CachedPixels *pixels = get_cache (frames, frame);
   int i;
-  
+
   for (i = 0; i < 4; i++)
     if (pixels->piece[i].pixmap)
       cairo_surface_destroy (pixels->piece[i].pixmap);
-  
-  g_free (pixels);
+
+  free (pixels);
   g_hash_table_remove (frames->cache, frame);
 }
 
@@ -399,7 +399,7 @@ invalidate_all_caches (MetaFrames *frames)
 
       invalidate_cache (frames, frame);
     }
-  
+
   g_list_free (frames->invalidate_frames);
   frames->invalidate_frames = NULL;
 }
@@ -408,7 +408,7 @@ static gboolean
 invalidate_cache_timeout (gpointer data)
 {
   MetaFrames *frames = data;
-  
+
   invalidate_all_caches (frames);
   frames->invalidate_cache_timeout_id = 0;
   return FALSE;
@@ -428,8 +428,8 @@ queue_recalc_func (gpointer key, gpointer value, gpointer data)
   if (frame->layout)
     {
       /* save title to recreate layout */
-      g_free (frame->title);
-      
+      free (frame->title);
+
       frame->title = g_strdup (pango_layout_get_text (frame->layout));
 
       g_object_unref (G_OBJECT (frame->layout));
@@ -445,7 +445,7 @@ meta_frames_font_changed (MetaFrames *frames)
       g_hash_table_destroy (frames->text_heights);
       frames->text_heights = g_hash_table_new (NULL, NULL);
     }
-  
+
   /* Queue a draw/resize on all frames */
   g_hash_table_foreach (frames->frames,
                         queue_recalc_func, frames);
@@ -524,8 +524,8 @@ meta_frames_ensure_layout (MetaFrames  *frames,
       if (frame->layout)
         {
           /* save title to recreate layout */
-          g_free (frame->title);
-          
+          free (frame->title);
+
           frame->title = g_strdup (pango_layout_get_text (frame->layout));
 
           g_object_unref (G_OBJECT (frame->layout));
@@ -534,23 +534,23 @@ meta_frames_ensure_layout (MetaFrames  *frames,
     }
 
   frame->cache_style = style;
-  
+
   if (frame->layout == NULL)
     {
       gpointer key, value;
       PangoFontDescription *font_desc;
       double scale;
       int size;
-      
+
       scale = meta_theme_get_title_scale (meta_theme_get_current (),
                                           type,
                                           flags);
-      
+
       frame->layout = gtk_widget_create_pango_layout (widget, frame->title);
 
       pango_layout_set_ellipsize (frame->layout, PANGO_ELLIPSIZE_END);
       pango_layout_set_auto_dir (frame->layout, FALSE);
-      
+
       font_desc = meta_gtk_widget_get_font_desc (widget, scale,
                                                  meta_prefs_get_titlebar_font ());
 
@@ -572,14 +572,14 @@ meta_frames_ensure_layout (MetaFrames  *frames,
                                 GINT_TO_POINTER (size),
                                 GINT_TO_POINTER (frame->text_height));
         }
-      
-      pango_layout_set_font_description (frame->layout, 
+
+      pango_layout_set_font_description (frame->layout,
                                          font_desc);
-      
+
       pango_font_description_free (font_desc);
 
       /* Save some RAM */
-      g_free (frame->title);
+      free (frame->title);
       frame->title = NULL;
     }
 }
@@ -608,7 +608,7 @@ meta_frames_calc_geometry (MetaFrames *frames,
   meta_frames_ensure_layout (frames, frame);
 
   meta_prefs_get_button_layout (&button_layout);
-  
+
   meta_theme_calc_geometry (meta_theme_get_current (),
                             type,
                             frame->text_height,
@@ -681,7 +681,7 @@ meta_frames_manage_window (MetaFrames *frames,
   g_assert (window);
 
   frame = g_new (MetaUIFrame, 1);
-  
+
   frame->window = window;
 
   gdk_window_set_user_data (frame->window, frames);
@@ -689,7 +689,7 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->style = NULL;
 
   /* Don't set event mask here, it's in frame.c */
-  
+
   frame->xwindow = xwindow;
   frame->cache_style = NULL;
   frame->layout = NULL;
@@ -721,7 +721,7 @@ meta_frames_unmanage_window (MetaFrames *frames,
        * is not actually referenced anymore
        */
       invalidate_all_caches (frames);
-      
+
       /* restore the cursor */
       meta_core_set_screen_cursor (frames->xdisplay,
                                    frame->xwindow,
@@ -738,9 +738,9 @@ meta_frames_unmanage_window (MetaFrames *frames,
       if (frame->layout)
         g_object_unref (G_OBJECT (frame->layout));
 
-      g_free (frame->title);
+      free (frame->title);
 
-      g_free (frame);
+      free (frame);
     }
   else
     meta_warning ("Frame 0x%lx not managed, can't unmanage\n", xwindow);
@@ -765,7 +765,7 @@ meta_frames_get_borders (MetaFrames *frames,
   MetaFrameFlags flags;
   MetaUIFrame *frame;
   MetaFrameType type;
-  
+
   frame = meta_frames_lookup_window (frames, xwindow);
 
   if (frame == NULL)
@@ -777,7 +777,7 @@ meta_frames_get_borders (MetaFrames *frames,
   g_return_if_fail (type < META_FRAME_TYPE_LAST);
 
   meta_frames_ensure_layout (frames, frame);
-  
+
   /* We can't get the full geometry, because that depends on
    * the client window size and probably we're being called
    * by the core move/resize code to decide on the client
@@ -854,7 +854,7 @@ get_visible_region (MetaFrames        *frames,
 
   corners_region = cairo_region_create ();
   get_visible_frame_rect (fgeom, window_width, window_height, &frame_rect);
-  
+
   if (fgeom->top_left_corner_rounded_radius != 0)
     {
       const int corner = fgeom->top_left_corner_rounded_radius;
@@ -868,7 +868,7 @@ get_visible_region (MetaFrames        *frames,
           rect.y = frame_rect.y + i;
           rect.width = width;
           rect.height = 1;
-          
+
           cairo_region_union_rectangle (corners_region, &rect);
         }
     }
@@ -886,7 +886,7 @@ get_visible_region (MetaFrames        *frames,
           rect.y = frame_rect.y + i;
           rect.width = width;
           rect.height = 1;
-          
+
           cairo_region_union_rectangle (corners_region, &rect);
         }
     }
@@ -904,7 +904,7 @@ get_visible_region (MetaFrames        *frames,
           rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
           rect.height = 1;
-          
+
           cairo_region_union_rectangle (corners_region, &rect);
         }
     }
@@ -922,11 +922,11 @@ get_visible_region (MetaFrames        *frames,
           rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
           rect.height = 1;
-          
+
           cairo_region_union_rectangle (corners_region, &rect);
         }
     }
-  
+
   visible_region = cairo_region_create_rectangle (&frame_rect);
   cairo_region_subtract (visible_region, corners_region);
   cairo_region_destroy (corners_region);
@@ -960,7 +960,7 @@ meta_frames_move_resize_frame (MetaFrames *frames,
 {
   MetaUIFrame *frame = meta_frames_lookup_window (frames, xwindow);
   int old_width, old_height;
-  
+
   old_width = gdk_window_get_width (frame->window);
   old_height = gdk_window_get_height (frame->window);
 
@@ -977,7 +977,7 @@ meta_frames_queue_draw (MetaFrames *frames,
                         Window      xwindow)
 {
   MetaUIFrame *frame;
-  
+
   frame = meta_frames_lookup_window (frames, xwindow);
 
   invalidate_whole_window (frames, frame);
@@ -989,14 +989,14 @@ meta_frames_set_title (MetaFrames *frames,
                        const char *title)
 {
   MetaUIFrame *frame;
-  
+
   frame = meta_frames_lookup_window (frames, xwindow);
 
   g_assert (frame);
-  
-  g_free (frame->title);
+
+  free (frame->title);
   frame->title = g_strdup (title);
-  
+
   if (frame->layout)
     {
       g_object_unref (frame->layout);
@@ -1025,7 +1025,7 @@ meta_frames_repaint_frame (MetaFrames *frames,
                            Window      xwindow)
 {
   MetaUIFrame *frame;
-  
+
   frame = meta_frames_lookup_window (frames, xwindow);
 
   g_assert (frame);
@@ -1083,8 +1083,8 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
                                event->time);
           }
       }
-      break;          
-      
+      break;
+
     case C_DESKTOP_TITLEBAR_ACTION_TOGGLE_MAXIMIZE:
       {
         flags = meta_frame_get_flags (frame->meta_window->frame);
@@ -1158,7 +1158,7 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
     case C_DESKTOP_TITLEBAR_ACTION_NONE:
       /* Yaay, a sane user that doesn't use that other weird crap! */
       break;
-    
+
     case C_DESKTOP_TITLEBAR_ACTION_LOWER:
       meta_core_user_lower_and_unfocus (display,
                                         frame->xwindow,
@@ -1214,7 +1214,7 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
     case C_DESKTOP_TITLEBAR_SCROLL_ACTION_NONE:
       break;
     }
-  
+
   return TRUE;
 }
 
@@ -1223,7 +1223,7 @@ meta_frame_double_click_event (MetaUIFrame    *frame,
                                GdkEventButton *event)
 {
   int action = meta_prefs_get_action_double_click_titlebar ();
-  
+
   return meta_frame_titlebar_event (frame, event, action);
 }
 
@@ -1232,7 +1232,7 @@ meta_frame_middle_click_event (MetaUIFrame    *frame,
                                GdkEventButton *event)
 {
   int action = meta_prefs_get_action_middle_click_titlebar();
-  
+
   return meta_frame_titlebar_event (frame, event, action);
 }
 
@@ -1241,7 +1241,7 @@ meta_frame_right_click_event(MetaUIFrame     *frame,
                              GdkEventButton  *event)
 {
   int action = meta_prefs_get_action_right_click_titlebar();
-  
+
   return meta_frame_titlebar_event (frame, event, action);
 }
 
@@ -1337,14 +1337,14 @@ meta_frames_button_press_event (GtkWidget      *widget,
   MetaFrames *frames;
   MetaFrameControl control;
   Display *display;
-  
+
   frames = META_FRAMES (widget);
   display = frames->xdisplay;
 
   /* Remember that the display may have already done something with this event.
    * If so there's probably a GrabOp in effect.
    */
-  
+
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
@@ -1362,13 +1362,13 @@ meta_frames_button_press_event (GtkWidget      *widget,
                   frame->xwindow);
       meta_core_user_focus (display,
                             frame->xwindow,
-                            event->time);      
+                            event->time);
     }
 
   /* don't do the rest of this if on client area */
   if (control == META_FRAME_CONTROL_CLIENT_AREA)
     return FALSE; /* not on the frame, just passed through from client */
-  
+
   /* We want to shade even if we have a GrabOp, since we'll have a move grab
    * if we double click the titlebar.
    */
@@ -1426,7 +1426,7 @@ meta_frames_button_press_event (GtkWidget      *widget,
           /* get delta to convert to root coords */
           dx = event->x_root - event->x;
           dy = event->y_root - event->y;
-          
+
           /* Align to the right end of the menu rectangle if RTL */
           if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
             dx += rect->width;
@@ -1450,9 +1450,9 @@ meta_frames_button_press_event (GtkWidget      *widget,
             control == META_FRAME_CONTROL_RESIZE_W))
     {
       MetaGrabOp op;
-      
+
       op = META_GRAB_OP_NONE;
-      
+
       switch (control)
         {
         case META_FRAME_CONTROL_RESIZE_SE:
@@ -1518,7 +1518,7 @@ meta_frames_button_press_event (GtkWidget      *widget,
     {
       return meta_frame_right_click_event (frame, event);
     }
-  
+
   return TRUE;
 }
 
@@ -1530,7 +1530,7 @@ meta_frames_button_release_event    (GtkWidget           *widget,
   MetaFrames *frames;
   MetaGrabOp op;
   Display *display;
-  
+
   frames = META_FRAMES (widget);
   display = frames->xdisplay;
   frames->current_grab_op = META_GRAB_OP_NONE;
@@ -1593,7 +1593,7 @@ meta_frames_button_release_event    (GtkWidget           *widget,
       MetaFrameControl control = get_control (frames, frame, event->x, event->y);
       meta_frames_update_prelit_control (frames, frame, control);
     }
-  
+
   return TRUE;
 }
 
@@ -1608,9 +1608,9 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
 
   meta_verbose ("Updating prelit control from %u to %u\n",
                 frame->prelit_control, control);
-  
+
   cursor = META_CURSOR_DEFAULT;
-  
+
   switch (control)
     {
     case META_FRAME_CONTROL_CLIENT_AREA:
@@ -1665,7 +1665,7 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
     case META_FRAME_CONTROL_RESIZE_E:
       cursor = META_CURSOR_EAST_RESIZE;
       break;
-    }        
+    }
 
   /* set/unset the prelight cursor */
   meta_frame_set_screen_cursor (frame->meta_window->frame, cursor);
@@ -1689,7 +1689,7 @@ meta_frames_update_prelit_control (MetaFrames      *frames,
       /* Only prelight buttons */
       control = META_FRAME_CONTROL_NONE;
       break;
-    }      
+    }
 
   if (control == frame->prelit_control &&
       frame->button_state == META_BUTTON_STATE_PRELIGHT)
@@ -1774,7 +1774,7 @@ meta_frames_destroy_event           (GtkWidget           *widget,
   frame = meta_frames_lookup_window (frames, GDK_WINDOW_XID (event->window));
   if (frame == NULL)
     return FALSE;
-  
+
   return TRUE;
 }
 
@@ -1819,7 +1819,7 @@ generate_pixmap (MetaFrames            *frames,
   result = gdk_window_create_similar_surface (frame->window,
                                               CAIRO_CONTENT_COLOR,
                                               rect->width, rect->height);
-  
+
   cr = cairo_create (result);
   cairo_translate (cr, -rect->x, -rect->y);
 
@@ -1864,7 +1864,7 @@ populate_cache (MetaFrames *frames,
     {
       return;
     }
-  
+
   meta_theme_get_frame_borders (meta_theme_get_current (),
                                 frame_type,
                                 frame->text_height,
@@ -1916,12 +1916,12 @@ populate_cache (MetaFrames *frames,
       if (!piece->pixmap)
         piece->pixmap = generate_pixmap (frames, frame, &piece->rect);
     }
-  
+
   if (frames->invalidate_cache_timeout_id) {
     g_source_remove (frames->invalidate_cache_timeout_id);
     frames->invalidate_cache_timeout_id = 0;
   }
-  
+
   frames->invalidate_cache_timeout_id = g_timeout_add (1000, invalidate_cache_timeout, frames);
 
   if (!g_list_find (frames->invalidate_frames, frame))
@@ -1936,7 +1936,7 @@ clip_to_screen (cairo_region_t *region,
   cairo_rectangle_int_t frame_area;
   cairo_rectangle_int_t screen_area = { 0, 0, 0, 0 };
   cairo_region_t *tmp_region;
-  
+
   /* Chop off stuff outside the screen; this optimization
    * is crucial to handle huge client windows,
    * like "xterm -geometry 1000x1000"
@@ -1984,7 +1984,7 @@ subtract_client_area (cairo_region_t *region,
                  META_CORE_GET_CLIENT_HEIGHT, &area.height,
                  META_CORE_GET_END);
   meta_theme_get_frame_borders (meta_theme_get_current (),
-                                type, frame->text_height, flags, 
+                                type, frame->text_height, flags,
                                 &borders);
 
   area.x = borders.total.left;
@@ -2007,13 +2007,13 @@ cached_pixels_draw (CachedPixels   *pixels,
     {
       CachedFramePiece *piece;
       piece = &pixels->piece[i];
-      
+
       if (piece->pixmap)
         {
           cairo_set_source_surface (cr, piece->pixmap,
                                     piece->rect.x, piece->rect.y);
           cairo_paint (cr);
-          
+
           region_piece = cairo_region_create_rectangle (&piece->rect);
           cairo_region_subtract (region, region_piece);
           cairo_region_destroy (region_piece);
@@ -2045,11 +2045,11 @@ meta_frames_draw (GtkWidget *widget,
   populate_cache (frames, frame);
 
   region = cairo_region_create_rectangle (&clip);
-  
+
   pixels = get_cache (frames, frame);
 
   cached_pixels_draw (pixels, cr, region);
-  
+
   clip_to_screen (region, frame);
   subtract_client_area (region, frame);
 
@@ -2077,7 +2077,7 @@ meta_frames_draw (GtkWidget *widget,
     }
 
   cairo_region_destroy (region);
-  
+
   return TRUE;
 }
 
@@ -2095,7 +2095,7 @@ meta_frames_paint (MetaFrames   *frames,
   int button_type = -1;
   MetaButtonLayout button_layout;
   Display *display;
-  
+
   widget = GTK_WIDGET (frames);
   display = frame->meta_window->display->xdisplay;
 
@@ -2176,7 +2176,7 @@ meta_frames_enter_notify_event      (GtkWidget           *widget,
   MetaUIFrame *frame;
   MetaFrames *frames;
   MetaFrameControl control;
-  
+
   frames = META_FRAMES (widget);
 
   frames->entered = TRUE;
@@ -2187,7 +2187,7 @@ meta_frames_enter_notify_event      (GtkWidget           *widget,
 
   control = get_control (frames, frame, event->x, event->y);
   meta_frames_update_prelit_control (frames, frame, control);
-  
+
   return TRUE;
 }
 
@@ -2207,7 +2207,7 @@ meta_frames_leave_notify_event      (GtkWidget           *widget,
     return FALSE;
 
   meta_frames_update_prelit_control (frames, frame, META_FRAME_CONTROL_NONE);
-  
+
   return TRUE;
 }
 
@@ -2216,7 +2216,7 @@ control_rect (MetaFrameControl control,
               MetaFrameGeometry *fgeom)
 {
   GdkRectangle *rect;
-  
+
   rect = NULL;
   switch (control)
     {

--- a/src/ui/gradient.c
+++ b/src/ui/gradient.c
@@ -2,11 +2,11 @@
 
 /* Metacity gradient rendering */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, 99% copied from wrlib in
  * WindowMaker, Copyright (C) 1997-2000 Dan Pascu and Alfredo Kojima
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -59,7 +59,7 @@ static GdkPixbuf* meta_gradient_create_multi_diagonal   (int             width,
 static void
 free_buffer (guchar *pixels, gpointer data)
 {
-  g_free (pixels);
+  free (pixels);
 }
 
 static GdkPixbuf*
@@ -74,7 +74,7 @@ blank_pixbuf (int width, int height, gboolean no_padding)
   if (no_padding)
     rowstride = width * 3;
   else
-    /* Always align rows to 32-bit boundaries */  
+    /* Always align rows to 32-bit boundaries */
     rowstride = 4 * ((3 * width + 3) / 4);
 
   buf = g_try_malloc (height * rowstride);
@@ -186,7 +186,7 @@ meta_gradient_create_interwoven (int            width,
                                  const GdkRGBA  colors2[2],
                                  int            thickness2)
 {
-  
+
   int i, j, k, l, ll;
   long r1, g1, b1, dr1, dg1, db1;
   long r2, g2, b2, dr2, dg2, db2;
@@ -194,14 +194,14 @@ meta_gradient_create_interwoven (int            width,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r1 = (long)(colors1[0].red*0xffffff);
   g1 = (long)(colors1[0].green*0xffffff);
   b1 = (long)(colors1[0].blue*0xffffff);
@@ -221,7 +221,7 @@ meta_gradient_create_interwoven (int            width,
   for (i=0,k=0,l=0,ll=thickness1; i<height; i++)
     {
       ptr = pixels + i * rowstride;
-      
+
       if (k == 0)
         {
           ptr[0] = (unsigned char) (r1>>16);
@@ -256,7 +256,7 @@ meta_gradient_create_interwoven (int            width,
       r1+=dr1;
       g1+=dg1;
       b1+=db1;
-	
+
       r2+=dr2;
       g2+=dg2;
       b2+=db2;
@@ -269,20 +269,20 @@ meta_gradient_create_interwoven (int            width,
  *----------------------------------------------------------------------
  * meta_gradient_create_horizontal--
  * 	Renders a horizontal linear gradient of the specified size in the
- * GdkPixbuf format with a border of the specified type. 
- * 
+ * GdkPixbuf format with a border of the specified type.
+ *
  * Returns:
  * 	A 24bit GdkPixbuf with the gradient (no alpha channel).
- * 
+ *
  * Side effects:
  * 	None
- *---------------------------------------------------------------------- 
+ *----------------------------------------------------------------------
  */
 static GdkPixbuf*
 meta_gradient_create_horizontal (int width, int height,
                                  const GdkRGBA *from,
                                  const GdkRGBA *to)
-{    
+{
   int i;
   long r, g, b, dr, dg, db;
   GdkPixbuf *pixbuf;
@@ -295,22 +295,22 @@ meta_gradient_create_horizontal (int width, int height,
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   ptr = pixels;
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r0 = (guchar) (from->red * 0xff);
   g0 = (guchar) (from->green * 0xff);
   b0 = (guchar) (from->blue * 0xff);
   rf = (guchar) (to->red * 0xff);
   gf = (guchar) (to->green * 0xff);
   bf = (guchar) (to->blue * 0xff);
-  
+
   r = r0 << 16;
   g = g0 << 16;
   b = b0 << 16;
-    
+
   dr = ((rf-r0)<<16)/(int)width;
   dg = ((gf-g0)<<16)/(int)width;
   db = ((bf-b0)<<16)/(int)width;
@@ -359,21 +359,21 @@ meta_gradient_create_vertical (int width, int height,
   int rf, gf, bf;
   int rowstride;
   unsigned char *pixels;
-  
+
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r0 = (guchar) (from->red * 0xff);
   g0 = (guchar) (from->green * 0xff);
   b0 = (guchar) (from->blue * 0xff);
   rf = (guchar) (to->red * 0xff);
   gf = (guchar) (to->green * 0xff);
   bf = (guchar) (to->blue * 0xff);
-  
+
   r = r0<<16;
   g = g0<<16;
   b = b0<<16;
@@ -385,7 +385,7 @@ meta_gradient_create_vertical (int width, int height,
   for (i=0; i<height; i++)
     {
       ptr = pixels + i * rowstride;
-      
+
       ptr[0] = (unsigned char)(r>>16);
       ptr[1] = (unsigned char)(g>>16);
       ptr[2] = (unsigned char)(b>>16);
@@ -428,7 +428,7 @@ meta_gradient_create_diagonal (int width, int height,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   if (width == 1)
     return meta_gradient_create_vertical (width, height, from, to);
   else if (height == 1)
@@ -437,7 +437,7 @@ meta_gradient_create_diagonal (int width, int height,
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
 
@@ -475,27 +475,27 @@ meta_gradient_create_multi_horizontal (int width, int height,
   GdkPixbuf *pixbuf;
   unsigned char *ptr;
   unsigned char *pixels;
-  int width2;  
+  int width2;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   ptr = pixels;
-    
+
   if (count > width)
     count = width;
-    
+
   if (count > 1)
     width2 = width/(count-1);
   else
     width2 = width;
-    
+
   k = 0;
 
   r = (long)(colors[0].red * 0xffffff);
@@ -528,7 +528,7 @@ meta_gradient_create_multi_horizontal (int width, int height,
       *ptr++ = (unsigned char)(g>>16);
       *ptr++ = (unsigned char)(b>>16);
     }
-    
+
   /* copy the first line to the other lines */
   for (i=1; i<height; i++)
     {
@@ -549,25 +549,25 @@ meta_gradient_create_multi_vertical (int width, int height,
   int height2;
   int x;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   ptr = pixels;
-    
+
   if (count > height)
     count = height;
-    
+
   if (count > 1)
     height2 = height/(count-1);
   else
     height2 = height;
-    
+
   k = 0;
 
   r = (long)(colors[0].red * 0xffffff);
@@ -591,7 +591,7 @@ meta_gradient_create_multi_vertical (int width, int height,
           memcpy (&(ptr[x*3]), ptr, (width - x)*3);
 
           ptr += rowstride;
-          
+
           r += dr;
           g += dg;
           b += db;
@@ -615,14 +615,14 @@ meta_gradient_create_multi_vertical (int width, int height,
       memcpy (&(ptr[x*3]), ptr, (width - x)*3);
 
       ptr += rowstride;
-      
+
       for (j=k+1; j<height; j++)
         {
           memcpy (ptr, tmp, rowstride);
           ptr += rowstride;
         }
     }
-    
+
   return pixbuf;
 }
 
@@ -638,7 +638,7 @@ meta_gradient_create_multi_diagonal (int width, int height,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   if (width == 1)
@@ -650,10 +650,10 @@ meta_gradient_create_multi_diagonal (int width, int height,
                            width, height);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   if (count > width)
     count = width;
   if (count > height)
@@ -700,12 +700,12 @@ simple_multiply_alpha (GdkPixbuf *pixbuf,
   int row;
 
   g_return_if_fail (GDK_IS_PIXBUF (pixbuf));
-  
+
   if (alpha == 255)
     return;
-  
+
   g_assert (gdk_pixbuf_get_has_alpha (pixbuf));
-  
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   height = gdk_pixbuf_get_height (pixbuf);
@@ -730,7 +730,7 @@ simple_multiply_alpha (GdkPixbuf *pixbuf,
            */
           /* ((*p / 255.0) * (alpha / 255.0)) * 255; */
           *p = (guchar) (((int) *p * (int) alpha) / (int) 255);
-          
+
           ++p; /* skip A */
         }
 
@@ -747,13 +747,13 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
   long a, da;
   unsigned char *p;
   unsigned char *pixels;
-  int width2;  
+  int width2;
   int rowstride;
   int width, height;
   unsigned char *gradient;
   unsigned char *gradient_p;
   unsigned char *gradient_end;
-  
+
   g_return_if_fail (n_alphas > 0);
 
   if (n_alphas == 1)
@@ -762,24 +762,24 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       simple_multiply_alpha (pixbuf, alphas[0]);
       return;
     }
-  
+
   width = gdk_pixbuf_get_width (pixbuf);
   height = gdk_pixbuf_get_height (pixbuf);
 
   gradient = g_new (unsigned char, width);
   gradient_end = gradient + width;
-  
+
   if (n_alphas > width)
     n_alphas = width;
-    
+
   if (n_alphas > 1)
     width2 = width / (n_alphas - 1);
   else
     width2 = width;
-    
+
   a = alphas[0] << 8;
   gradient_p = gradient;
-  
+
   /* render the gradient into an array */
   for (i = 1; i < n_alphas; i++)
     {
@@ -788,7 +788,7 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       for (j = 0; j < width2; j++)
         {
           *gradient_p++ = (a >> 8);
-          
+
           a += da;
 	}
 
@@ -800,11 +800,11 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
     {
       *gradient_p++ = a >> 8;
     }
-    
+
   /* Now for each line of the pixbuf, fill in with the gradient */
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   p = pixels;
   i = 0;
   while (i < height)
@@ -830,8 +830,8 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       p = row_end;
       ++i;
     }
-  
-  g_free (gradient);
+
+  free (gradient);
 }
 
 void
@@ -843,21 +843,21 @@ meta_gradient_add_alpha (GdkPixbuf       *pixbuf,
   g_return_if_fail (GDK_IS_PIXBUF (pixbuf));
   g_return_if_fail (gdk_pixbuf_get_has_alpha (pixbuf));
   g_return_if_fail (n_alphas > 0);
-  
+
   switch (type)
     {
     case META_GRADIENT_HORIZONTAL:
       meta_gradient_add_alpha_horizontal (pixbuf, alphas, n_alphas);
       break;
-      
+
     case META_GRADIENT_VERTICAL:
       g_printerr ("metacity: vertical alpha channel gradient not implemented yet\n");
       break;
-      
+
     case META_GRADIENT_DIAGONAL:
       g_printerr ("metacity: diagonal alpha channel gradient not implemented yet\n");
       break;
-      
+
     case META_GRADIENT_LAST:
       g_assert_not_reached ();
       break;

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -233,7 +233,7 @@ get_workspace_name_with_accel (Display *display,
        * Assume the worst case, that every character is a _.  We also
        * provide memory for " (_#)"
        */
-      new_name = g_malloc0 (strlen (name) * 2 + 6 + 1);
+      new_name = calloc (1, strlen (name) * 2 + 6 + 1);
 
       /*
        * Now iterate down the strings, adding '_' to escape as we go

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -2,11 +2,11 @@
 
 /* Muffin window menu */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2004 Rob Adams
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -113,18 +113,18 @@ popup_position_func (GtkMenu   *menu,
                      gboolean  *push_in,
                      gpointer  user_data)
 {
-  GtkRequisition req;      
+  GtkRequisition req;
   GdkPoint *pos;
 
   pos = user_data;
-  
+
   gtk_widget_get_preferred_size (GTK_WIDGET (menu), &req, NULL);
 
   *x = pos->x;
   *y = pos->y;
-  
+
   if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
-    *x = MAX (0, *x - req.width); 
+    *x = MAX (0, *x - req.width);
 
   /* Ensure onscreen */
   *x = CLAMP (*x, 0, MAX (0, gdk_screen_width () - req.width));
@@ -136,7 +136,7 @@ menu_closed (GtkMenu *widget,
              gpointer data)
 {
   MetaWindowMenu *menu;
-  
+
   menu = data;
 
   (* menu->func) (menu,
@@ -145,7 +145,7 @@ menu_closed (GtkMenu *widget,
                   gtk_get_current_event_time (),
                   0, 0,
                   menu->data);
-  
+
   /* menu may now be freed */
 }
 
@@ -153,9 +153,9 @@ static void
 activate_cb (GtkWidget *menuitem, gpointer data)
 {
   MenuData *md;
-  
+
   g_return_if_fail (GTK_IS_WIDGET (menuitem));
-  
+
   md = data;
 
   (* md->menu->func) (md->menu,
@@ -175,7 +175,7 @@ activate_cb (GtkWidget *menuitem, gpointer data)
  * accelerators. At the moment this means adding a _ if the name is of
  * the form "Workspace n" where n is less than 10, and escaping any
  * other '_'s so they do not create inadvertant accelerators.
- * 
+ *
  * The calling code owns the string, and is reponsible to free the
  * memory after use.
  *
@@ -194,7 +194,7 @@ get_workspace_name_with_accel (Display *display,
   name = meta_core_get_workspace_name_with_index (display, xroot, index);
 
   g_assert (name != NULL);
-  
+
   /*
    * If the name is of the form "Workspace x" where x is an unsigned
    * integer, insert a '_' before the number if it is less than 10 and
@@ -205,7 +205,7 @@ get_workspace_name_with_accel (Display *display,
       *(name + charcount)=='\0')
     {
       char *new_name;
-      
+
       /*
        * Above name is a pointer into the Workspace struct. Here we make
        * a copy copy so we can have our wicked way with it.
@@ -277,20 +277,20 @@ menu_item_new (MenuItem *menuitem, int workspace_id)
   else if (menuitem->type == MENU_ITEM_IMAGE)
     {
       GtkWidget *image;
-      
+
       image = gtk_image_new_from_stock (menuitem->stock_id, GTK_ICON_SIZE_MENU);
       mi = gtk_image_menu_item_new ();
-     
+
       gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (mi), image);
       gtk_widget_show (image);
     }
   else if (menuitem->type == MENU_ITEM_CHECKBOX)
     {
       mi = gtk_check_menu_item_new ();
-      
+
       gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (mi),
                                       menuitem->checked);
-    }    
+    }
   else if (menuitem->type == MENU_ITEM_RADIOBUTTON)
     {
       mi = gtk_check_menu_item_new ();
@@ -316,7 +316,7 @@ menu_item_new (MenuItem *menuitem, int workspace_id)
 
   meta_accel_label_set_accelerator (META_ACCEL_LABEL (accel_label),
                                     key, mods);
-  
+
   return mi;
 }
 
@@ -336,15 +336,15 @@ meta_window_menu_new   (MetaFrames         *frames,
   /* FIXME: Modifications to 'ops' should happen in meta_window_show_menu */
   if (n_workspaces < 2)
     ops &= ~(META_MENU_OP_STICK | META_MENU_OP_UNSTICK | META_MENU_OP_WORKSPACES);
-  
+
   menu = g_new (MetaWindowMenu, 1);
   menu->frames = frames;
   menu->client_xwindow = client_xwindow;
   menu->func = func;
   menu->data = data;
   menu->ops = ops;
-  menu->insensitive = insensitive;  
-  
+  menu->insensitive = insensitive;
+
   menu->menu = gtk_menu_new ();
 
   gtk_menu_set_screen (GTK_MENU (menu->menu),
@@ -429,7 +429,7 @@ meta_window_menu_new   (MetaFrames         *frames,
                       moveitem.label = label;
                       submi = menu_item_new (&moveitem, j + 1);
 
-                      g_free (label);
+                      free (label);
 
                       if ((active_workspace == (unsigned)j) && (ops & META_MENU_OP_UNSTICK))
                         gtk_widget_set_sensitive (submi, FALSE);
@@ -447,7 +447,7 @@ meta_window_menu_new   (MetaFrames         *frames,
                           "activate",
                           G_CALLBACK (activate_cb),
                           md,
-                          (GClosureNotify) g_free, 0);
+                          (GClosureNotify) free, 0);
 
                       gtk_menu_shell_append (GTK_MENU_SHELL (submenu), submi);
 
@@ -464,31 +464,31 @@ meta_window_menu_new   (MetaFrames         *frames,
 
               if (insensitive & menuitem.op)
                 gtk_widget_set_sensitive (mi, FALSE);
-              
+
               md = g_new (MenuData, 1);
-              
+
               md->menu = menu;
               md->op = menuitem.op;
-              
+
               g_signal_connect_data (G_OBJECT (mi),
                                      "activate",
                                      G_CALLBACK (activate_cb),
                                      md,
-                                     (GClosureNotify) g_free, 0);
+                                     (GClosureNotify) free, 0);
             }
 
           if (mi)
             {
               gtk_menu_shell_append (GTK_MENU_SHELL (menu->menu), mi);
-          
+
               gtk_widget_show (mi);
             }
         }
     }
 
- 
+
   g_signal_connect (menu->menu, "selection_done",
-                    G_CALLBACK (menu_closed), menu);  
+                    G_CALLBACK (menu_closed), menu);
 
   return menu;
 }
@@ -501,17 +501,17 @@ meta_window_menu_popup (MetaWindowMenu     *menu,
                         guint32             timestamp)
 {
   GdkPoint *pt;
-  
+
   pt = g_new (GdkPoint, 1);
 
   g_object_set_data_full (G_OBJECT (menu->menu),
                           "destroy-point",
                           pt,
-                          g_free);
+                          free);
 
   pt->x = root_x;
   pt->y = root_y;
-  
+
   gtk_menu_popup (GTK_MENU (menu->menu),
                   NULL, NULL,
                   popup_position_func, pt,
@@ -526,5 +526,5 @@ LOCAL_SYMBOL void
 meta_window_menu_free (MetaWindowMenu *menu)
 {
   gtk_widget_destroy (menu->menu);
-  g_free (menu);
+  free (menu);
 }

--- a/src/ui/metaaccellabel.c
+++ b/src/ui/metaaccellabel.c
@@ -164,7 +164,7 @@ meta_accel_label_destroy (GtkWidget *object)
   MetaAccelLabel *accel_label = META_ACCEL_LABEL (object);
 
 
-  g_free (accel_label->accel_string);
+  free (accel_label->accel_string);
   accel_label->accel_string = NULL;
 
   accel_label->accel_mods = 0;
@@ -178,7 +178,7 @@ meta_accel_label_finalize (GObject *object)
 {
   MetaAccelLabel *accel_label = META_ACCEL_LABEL (object);
 
-  g_free (accel_label->accel_string);
+  free (accel_label->accel_string);
 
   G_OBJECT_CLASS (meta_accel_label_parent_class)->finalize (object);
 }
@@ -273,9 +273,9 @@ meta_accel_label_draw (GtkWidget *widget,
         cairo_translate (cr, ac_width, 0);
       if (gtk_label_get_ellipsize (label))
         pango_layout_set_width (label_layout,
-                                pango_layout_get_width (label_layout) 
+                                pango_layout_get_width (label_layout)
                                 - ac_width * PANGO_SCALE);
-      
+
       allocation.width -= ac_width;
       gtk_widget_set_allocation (widget, &allocation);
       if (GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw)
@@ -285,7 +285,7 @@ meta_accel_label_draw (GtkWidget *widget,
       gtk_widget_set_allocation (widget, &allocation);
       if (gtk_label_get_ellipsize (label))
         pango_layout_set_width (label_layout,
-                                pango_layout_get_width (label_layout) 
+                                pango_layout_get_width (label_layout)
                                 + ac_width * PANGO_SCALE);
 
       cairo_restore (cr);
@@ -320,7 +320,7 @@ meta_accel_label_draw (GtkWidget *widget,
       if (GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw)
         GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw (widget, cr);
     }
-  
+
   return FALSE;
 }
 
@@ -336,7 +336,7 @@ meta_accel_label_update (MetaAccelLabel *accel_label)
 
   class = META_ACCEL_LABEL_GET_CLASS (accel_label);
 
-  g_free (accel_label->accel_string);
+  free (accel_label->accel_string);
   accel_label->accel_string = NULL;
 
   gstring = g_string_new (accel_label->accel_string);
@@ -439,10 +439,10 @@ meta_accel_label_update (MetaAccelLabel *accel_label)
       if (tmp[0] != 0 && tmp[1] == 0)
         tmp[0] = g_ascii_toupper (tmp[0]);
       g_string_append (gstring, tmp);
-      g_free (tmp);
+      free (tmp);
     }
 
-  g_free (accel_label->accel_string);
+  free (accel_label->accel_string);
   accel_label->accel_string = gstring->str;
   g_string_free (gstring, FALSE);
 

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -2,9 +2,9 @@
 
 /* Metacity theme preview widget */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -77,13 +77,13 @@ meta_preview_init (MetaPreview *preview)
       preview->button_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
       ++i;
     }
-  
+
   preview->button_layout.left_buttons[0] = META_BUTTON_FUNCTION_MENU;
 
   preview->button_layout.right_buttons[0] = META_BUTTON_FUNCTION_MINIMIZE;
   preview->button_layout.right_buttons[1] = META_BUTTON_FUNCTION_MAXIMIZE;
   preview->button_layout.right_buttons[2] = META_BUTTON_FUNCTION_CLOSE;
-  
+
   preview->type = META_FRAME_TYPE_NORMAL;
   preview->flags =
     META_FRAME_ALLOWS_DELETE |
@@ -103,9 +103,9 @@ GtkWidget*
 meta_preview_new (void)
 {
   MetaPreview *preview;
-  
+
   preview = g_object_new (META_TYPE_PREVIEW, NULL);
-  
+
   return GTK_WIDGET (preview);
 }
 
@@ -116,9 +116,9 @@ meta_preview_finalize (GObject *object)
 
   preview = META_PREVIEW (object);
 
-  g_free (preview->title);
+  free (preview->title);
   preview->title = NULL;
-  
+
   G_OBJECT_CLASS (meta_preview_parent_class)->finalize (object);
 }
 
@@ -128,7 +128,7 @@ ensure_info (MetaPreview *preview)
   GtkWidget *widget;
 
   widget = GTK_WIDGET (preview);
-  
+
   if (preview->layout == NULL)
     {
       PangoFontDescription *font_desc;
@@ -136,34 +136,34 @@ ensure_info (MetaPreview *preview)
       PangoAttrList *attrs;
       PangoAttribute *attr;
 
-      if (preview->theme)        
+      if (preview->theme)
         scale = meta_theme_get_title_scale (preview->theme,
                                             preview->type,
                                             preview->flags);
       else
         scale = 1.0;
-      
+
       preview->layout = gtk_widget_create_pango_layout (widget,
                                                         preview->title);
-      
+
       font_desc = meta_gtk_widget_get_font_desc (widget, scale, NULL);
-      
+
       preview->text_height =
         meta_pango_font_desc_get_text_height (font_desc,
                                               gtk_widget_get_pango_context (widget));
-          
+
       attrs = pango_attr_list_new ();
-      
+
       attr = pango_attr_size_new (pango_font_description_get_size (font_desc));
       attr->start_index = 0;
       attr->end_index = G_MAXINT;
-      
+
       pango_attr_list_insert (attrs, attr);
-      
+
       pango_layout_set_attributes (preview->layout, attrs);
-      
-      pango_attr_list_unref (attrs);      
-  
+
+      pango_attr_list_unref (attrs);
+
       pango_font_description_free (font_desc);
     }
 
@@ -201,7 +201,7 @@ meta_preview_draw (GtkWidget *widget,
         META_BUTTON_STATE_NORMAL,
         META_BUTTON_STATE_NORMAL
       };
-  
+
       ensure_info (preview);
       cairo_save (cr);
 
@@ -211,8 +211,8 @@ meta_preview_draw (GtkWidget *widget,
       if (client_width < 0)
         client_width = 1;
       if (client_height < 0)
-        client_height = 1;  
-      
+        client_height = 1;
+
       meta_theme_draw_frame (preview->theme,
                              widget,
                              cr,
@@ -343,7 +343,7 @@ meta_preview_set_theme (MetaPreview    *preview,
   g_return_if_fail (META_IS_PREVIEW (preview));
 
   preview->theme = theme;
-  
+
   clear_cache (preview);
 
   gtk_widget_queue_resize (GTK_WIDGET (preview));
@@ -355,9 +355,9 @@ meta_preview_set_title (MetaPreview    *preview,
 {
   g_return_if_fail (META_IS_PREVIEW (preview));
 
-  g_free (preview->title);
+  free (preview->title);
   preview->title = g_strdup (title);
-  
+
   clear_cache (preview);
 
   gtk_widget_queue_resize (GTK_WIDGET (preview));
@@ -394,9 +394,9 @@ meta_preview_set_button_layout (MetaPreview            *preview,
                                 const MetaButtonLayout *button_layout)
 {
   g_return_if_fail (META_IS_PREVIEW (preview));
-  
-  preview->button_layout = *button_layout;  
-  
+
+  preview->button_layout = *button_layout;
+
   gtk_widget_queue_draw (GTK_WIDGET (preview));
 }
 

--- a/src/ui/resizepopup.c
+++ b/src/ui/resizepopup.c
@@ -2,9 +2,9 @@
 
 /* Metacity resizing-terminal-window feedback */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -32,13 +32,13 @@ struct _MetaResizePopup
   GtkWidget *size_window;
   GtkWidget *size_label;
   Display *display;
-  int screen_number;  
+  int screen_number;
 
   int vertical_size;
   int horizontal_size;
-  
+
   gboolean showing;
-  
+
   MetaRectangle rect;
 };
 
@@ -52,7 +52,7 @@ meta_ui_resize_popup_new (Display *display,
 
   popup->display = display;
   popup->screen_number = screen_number;
-  
+
   return popup;
 }
 
@@ -60,31 +60,31 @@ LOCAL_SYMBOL void
 meta_ui_resize_popup_free (MetaResizePopup *popup)
 {
   g_return_if_fail (popup != NULL);
-  
+
   if (popup->size_window)
     gtk_widget_destroy (popup->size_window);
-  
-  g_free (popup);
+
+  free (popup);
 }
 
 static void
 ensure_size_window (MetaResizePopup *popup)
 {
   GtkWidget *frame;
-  
+
   if (popup->size_window)
     return;
-  
+
   popup->size_window = gtk_window_new (GTK_WINDOW_POPUP);
 
   gtk_window_set_screen (GTK_WINDOW (popup->size_window),
 			 gdk_display_get_screen (gdk_x11_lookup_xdisplay (popup->display),
 						 popup->screen_number));
-  
+
   /* never shrink the size window */
   gtk_window_set_resizable (GTK_WINDOW (popup->size_window),
                             TRUE);
-  
+
   frame = gtk_frame_new (NULL);
   gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_OUT);
 
@@ -104,9 +104,9 @@ update_size_window (MetaResizePopup *popup)
   char *str;
   int x, y;
   int width, height;
-  
+
   g_return_if_fail (popup->size_window != NULL);
-  
+
   /* Translators: This represents the size of a window.  The first number is
    * the width of the window and the second is the height.
    */
@@ -116,13 +116,13 @@ update_size_window (MetaResizePopup *popup)
 
   gtk_label_set_text (GTK_LABEL (popup->size_label), str);
 
-  g_free (str);
+  free (str);
 
   gtk_window_get_size (GTK_WINDOW (popup->size_window), &width, &height);
 
   x = popup->rect.x + (popup->rect.width - width) / 2;
   y = popup->rect.y + (popup->rect.height - height) / 2;
-  
+
   if (gtk_widget_get_realized (popup->size_window))
     {
       /* using move_resize to avoid jumpiness */
@@ -144,7 +144,7 @@ sync_showing (MetaResizePopup *popup)
     {
       if (popup->size_window)
         gtk_widget_show (popup->size_window);
-      
+
       if (popup->size_window && gtk_widget_get_realized (popup->size_window))
         gdk_window_raise (gtk_widget_get_window (popup->size_window));
     }
@@ -165,11 +165,11 @@ meta_ui_resize_popup_set (MetaResizePopup *popup,
 {
   gboolean need_update_size;
   int display_w, display_h;
-  
+
   g_return_if_fail (popup != NULL);
 
   need_update_size = FALSE;
-  
+
   display_w = rect.width - base_width;
   if (width_inc > 0)
     display_w /= width_inc;
@@ -182,17 +182,17 @@ meta_ui_resize_popup_set (MetaResizePopup *popup,
       display_w != popup->horizontal_size ||
       display_h != popup->vertical_size)
     need_update_size = TRUE;
-  
+
   popup->rect = rect;
   popup->vertical_size = display_h;
   popup->horizontal_size = display_w;
-  
+
   if (need_update_size)
     {
       ensure_size_window (popup);
       update_size_window (popup);
     }
-      
+
   sync_showing (popup);
 }
 
@@ -201,7 +201,7 @@ meta_ui_resize_popup_set_showing  (MetaResizePopup *popup,
                                    gboolean         showing)
 {
   g_return_if_fail (popup != NULL);
-  
+
   if (showing == popup->showing)
     return;
 
@@ -212,6 +212,6 @@ meta_ui_resize_popup_set_showing  (MetaResizePopup *popup,
       ensure_size_window (popup);
       update_size_window (popup);
     }
-  
+
   sync_showing (popup);
 }

--- a/src/ui/theme-parser.c
+++ b/src/ui/theme-parser.c
@@ -94,7 +94,7 @@ typedef enum
   STATE_MENU_ICON,
   STATE_FALLBACK,
   /* an ubuntu specific ignore-this-element state */
-  UBUNTU_STATE_IGNORE  
+  UBUNTU_STATE_IGNORE
 } ParseState;
 
 typedef struct
@@ -109,7 +109,7 @@ typedef struct
   const char *theme_file;       /* theme filename */
   const char *theme_dir;        /* dir the theme is inside */
   MetaTheme *theme;             /* theme being parsed */
-  guint format_version;         /* version of format of theme file */  
+  guint format_version;         /* version of format of theme file */
   char *name;                   /* name of named thing being parsed */
   MetaFrameLayout *layout;      /* layout being parsed if any */
   MetaDrawOpList *op_list;      /* op list being parsed if any */
@@ -258,7 +258,7 @@ set_error (GError             **err,
   int line, ch;
   va_list args;
   char *str;
-  
+
   g_markup_parse_context_get_position (context, &line, &ch);
 
   va_start (args, format);
@@ -269,7 +269,7 @@ set_error (GError             **err,
                _("Line %d character %d: %s"),
                line, ch, str);
 
-  g_free (str);
+  free (str);
 }
 
 static void
@@ -286,7 +286,7 @@ add_context_to_error (GError             **err,
 
   str = g_strdup_printf (_("Line %d character %d: %s"),
                          line, ch, (*err)->message);
-  g_free ((*err)->message);
+  free ((*err)->message);
   (*err)->message = str;
 }
 
@@ -314,7 +314,7 @@ parse_info_free (ParseInfo *info)
 {
   g_slist_free (info->states);
   g_slist_free (info->required_versions);
-  
+
   if (info->theme)
     meta_theme_free (info->theme);
 
@@ -326,7 +326,7 @@ parse_info_free (ParseInfo *info)
 
   if (info->op)
     meta_draw_op_free (info->op);
-  
+
   if (info->style)
     meta_frame_style_unref (info->style);
 
@@ -345,7 +345,7 @@ static void
 pop_state (ParseInfo *info)
 {
   g_return_if_fail (info->states != NULL);
-  
+
   info->states = g_slist_remove (info->states, info->states->data);
 }
 
@@ -426,7 +426,7 @@ locate_attributes (GMarkupParseContext *context,
   if (attrs[0].required)
     attrs[0].name++; /* skip past it */
   *first_attribute_retloc = NULL;
-  
+
   va_start (args, first_attribute_retloc);
 
   name = va_arg (args, const char*);
@@ -437,7 +437,7 @@ locate_attributes (GMarkupParseContext *context,
       g_return_val_if_fail (retloc != NULL, FALSE);
 
       g_assert (n_attrs < MAX_ATTRS);
-      
+
       attrs[n_attrs].name = name;
       attrs[n_attrs].retloc = retloc;
       attrs[n_attrs].required = attrs[n_attrs].name[0]=='!';
@@ -445,7 +445,7 @@ locate_attributes (GMarkupParseContext *context,
         attrs[n_attrs].name++; /* skip past it */
 
       n_attrs += 1;
-      *retloc = NULL;      
+      *retloc = NULL;
 
       name = va_arg (args, const char*);
       retloc = va_arg (args, const char**);
@@ -476,7 +476,7 @@ locate_attributes (GMarkupParseContext *context,
 
               if (*retloc != NULL)
                 {
-                
+
                   set_error (error, context,
                              G_MARKUP_ERROR,
                              G_MARKUP_ERROR_PARSE,
@@ -500,7 +500,7 @@ locate_attributes (GMarkupParseContext *context,
         {
           g_warning ("It could have been %s.\n", attrs[j++].name);
         }
-                  
+
           set_error (error, context,
                      G_MARKUP_ERROR,
                      G_MARKUP_ERROR_PARSE,
@@ -574,9 +574,9 @@ parse_positive_integer (const char          *str,
   int j;
 
   *val = 0;
-  
+
   end = NULL;
-  
+
   /* Is str a constant? */
 
   if (META_THEME_ALLOWS (theme, META_THEME_UBIQUITOUS_CONSTANTS) &&
@@ -626,7 +626,7 @@ parse_positive_integer (const char          *str,
                  l, MAX_REASONABLE);
       return FALSE;
     }
-  
+
   *val = (int) l * theme->scale;
 
   return TRUE;
@@ -641,9 +641,9 @@ parse_double (const char          *str,
   char *end;
 
   *val = 0;
-  
+
   end = NULL;
-  
+
   *val = g_ascii_strtod (str, &end);
 
   if (end == NULL || end == str)
@@ -685,7 +685,7 @@ parse_boolean (const char          *str,
                  str);
       return FALSE;
     }
-  
+
   return TRUE;
 }
 
@@ -713,14 +713,14 @@ parse_rounding (const char          *str,
                       str);
            return FALSE;
          }
-   
+
       result = parse_positive_integer (str, &tmp, context, theme, error);
 
       *val = tmp;
 
-      return result;    
+      return result;
     }
-  
+
   return TRUE;
 }
 
@@ -756,7 +756,7 @@ parse_alpha (const char             *str,
   MetaAlphaGradientSpec *spec;
 
   *spec_ret = NULL;
-  
+
   split = g_strsplit (str, ":", -1);
 
   i = 0;
@@ -770,7 +770,7 @@ parse_alpha (const char             *str,
                  str);
 
       g_strfreev (split);
-      
+
       return FALSE;
     }
 
@@ -786,13 +786,13 @@ parse_alpha (const char             *str,
   while (i < n_alphas)
     {
       double v;
-      
+
       if (!parse_double (split[i], &v, context, error))
         {
           /* clear up, but don't set error: it was set by parse_double */
           g_strfreev (split);
           meta_alpha_gradient_spec_free (spec);
-          
+
           return FALSE;
         }
 
@@ -803,20 +803,20 @@ parse_alpha (const char             *str,
                      v);
 
           g_strfreev (split);
-          meta_alpha_gradient_spec_free (spec);          
-          
+          meta_alpha_gradient_spec_free (spec);
+
           return FALSE;
         }
 
       spec->alphas[i] = (unsigned char) (v * 255);
-      
+
       ++i;
-    }  
+    }
 
   g_strfreev (split);
-  
+
   *spec_ret = spec;
-  
+
   return TRUE;
 }
 
@@ -832,10 +832,10 @@ parse_color (MetaTheme *theme,
     {
       if (referent)
         return meta_color_spec_new_from_string (referent, err);
-      
+
       /* no need to free referent: it's a pointer into the actual hash table */
     }
-  
+
   return meta_color_spec_new_from_string (str, err);
 }
 
@@ -846,7 +846,7 @@ parse_title_scale (const char          *str,
                    GError             **error)
 {
   double factor;
-  
+
   if (strcmp (str, "xx-small") == 0)
     factor = PANGO_SCALE_XX_SMALL;
   else if (strcmp (str, "x-small") == 0)
@@ -870,7 +870,7 @@ parse_title_scale (const char          *str,
     }
 
   *val = factor;
-  
+
   return TRUE;
 }
 
@@ -899,7 +899,7 @@ parse_toplevel_element (GMarkupParseContext  *context,
       const char *value;
       int ival = 0;
       double dval = 0.0;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!name", &name, "!value", &value,
@@ -1009,14 +1009,14 @@ parse_toplevel_element (GMarkupParseContext  *context,
       if (rounded_top_right && !parse_rounding (rounded_top_right, &rounded_top_right_val, context, info->theme, error))
         return;
       if (rounded_bottom_left && !parse_rounding (rounded_bottom_left, &rounded_bottom_left_val, context, info->theme, error))
-        return;      
+        return;
       if (rounded_bottom_right && !parse_rounding (rounded_bottom_right, &rounded_bottom_right_val, context, info->theme, error))
         return;
-      
+
       title_scale_val = 1.0;
       if (title_scale && !parse_title_scale (title_scale, &title_scale_val, context, error))
         return;
-      
+
       if (meta_theme_lookup_layout (info->theme, name))
         {
           set_error (error, context, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
@@ -1065,7 +1065,7 @@ parse_toplevel_element (GMarkupParseContext  *context,
 
       if (rounded_bottom_right)
         info->layout->bottom_right_corner_rounded_radius = rounded_bottom_right_val;
-      
+
       meta_theme_insert_layout (info->theme, name, info->layout);
 
       push_state (info, STATE_FRAME_GEOMETRY);
@@ -1175,16 +1175,16 @@ parse_toplevel_element (GMarkupParseContext  *context,
 
           if (alpha != NULL)
             {
-            
+
                gboolean success;
                MetaAlphaGradientSpec *alpha_vector;
-               
+
                g_clear_error (error);
                /* fortunately, we already have a routine to parse alpha values,
                 * though it produces a vector of them, which is a superset of
                 * what we want.
                 */
-               success = parse_alpha (alpha, &alpha_vector, context, error); 
+               success = parse_alpha (alpha, &alpha_vector, context, error);
                if (!success)
                  return;
 
@@ -1300,7 +1300,7 @@ parse_toplevel_element (GMarkupParseContext  *context,
        * for backwards compatibility.
        */
       g_assert (info->op_list == NULL);
-      
+
       push_state (info, STATE_MENU_ICON);
     }
   else if (ELEMENT_IS ("fallback"))
@@ -1406,7 +1406,7 @@ parse_distance (GMarkupParseContext  *context,
   const char *name;
   const char *value;
   int val;
-  
+
   if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                           error,
                           "!name", &name, "!value", &value,
@@ -1435,13 +1435,13 @@ parse_distance (GMarkupParseContext  *context,
   else if (strcmp (name, "button_width") == 0)
     {
       info->layout->button_width = val;
-            
+
       if (!(info->layout->button_sizing == META_BUTTON_SIZING_LAST ||
             info->layout->button_sizing == META_BUTTON_SIZING_FIXED))
         {
           set_error (error, context, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                      _("Cannot specify both \"button_width\"/\"button_height\" and \"aspect_ratio\" for buttons"));
-          return;      
+          return;
         }
 
       info->layout->button_sizing = META_BUTTON_SIZING_FIXED;
@@ -1449,13 +1449,13 @@ parse_distance (GMarkupParseContext  *context,
   else if (strcmp (name, "button_height") == 0)
     {
       info->layout->button_height = val;
-      
+
       if (!(info->layout->button_sizing == META_BUTTON_SIZING_LAST ||
             info->layout->button_sizing == META_BUTTON_SIZING_FIXED))
         {
           set_error (error, context, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                      _("Cannot specify both \"button_width\"/\"button_height\" and \"aspect_ratio\" for buttons"));
-          return;      
+          return;
         }
 
       info->layout->button_sizing = META_BUTTON_SIZING_FIXED;
@@ -1479,7 +1479,7 @@ parse_aspect_ratio (GMarkupParseContext  *context,
   const char *name;
   const char *value;
   double val;
-  
+
   if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                           error,
                           "!name", &name, "!value", &value,
@@ -1491,7 +1491,7 @@ parse_aspect_ratio (GMarkupParseContext  *context,
     return;
 
   g_assert (info->layout);
-  
+
   if (strcmp (name, "button") == 0)
     {
       info->layout->button_aspect = val;
@@ -1502,7 +1502,7 @@ parse_aspect_ratio (GMarkupParseContext  *context,
                      _("Cannot specify both \"button_width\"/\"button_height\" and \"aspect_ratio\" for buttons"));
           return;
         }
-      
+
       info->layout->button_sizing = META_BUTTON_SIZING_ASPECT;
     }
   else
@@ -1531,7 +1531,7 @@ parse_border (GMarkupParseContext  *context,
   int left_val;
   int right_val;
   GtkBorder *border;
-  
+
   if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                           error,
                           "!name", &name,
@@ -1541,7 +1541,7 @@ parse_border (GMarkupParseContext  *context,
                           "!right", &right,
                           NULL))
     return;
-  
+
   top_val = 0;
   if (!parse_positive_integer (top, &top_val, context, info->theme, error))
     return;
@@ -1557,11 +1557,11 @@ parse_border (GMarkupParseContext  *context,
   right_val = 0;
   if (!parse_positive_integer (right, &right_val, context, info->theme, error))
     return;
-  
+
   g_assert (info->layout);
 
   border = NULL;
-  
+
   if (strcmp (name, "title_border") == 0)
     border = &info->layout->title_border;
   else if (strcmp (name, "button_border") == 0)
@@ -1637,7 +1637,7 @@ check_expression (PosToken            *tokens,
    * it's possible we should instead guarantee that widths and heights
    * are at least 1.
    */
-  
+
   env.rect = meta_rect (0, 0, 0, 0);
   if (has_object)
     {
@@ -1658,7 +1658,7 @@ check_expression (PosToken            *tokens,
   env.title_height = 0;
 
   env.theme = theme;
-  
+
   if (!meta_parse_position_expression (tokens, n_tokens,
                                        &env,
                                        &x, &y,
@@ -1679,7 +1679,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
                        const gchar         **attribute_values,
                        ParseInfo            *info,
                        GError              **error)
-{  
+{
   g_return_if_fail (peek_state (info) == STATE_DRAW_OPS);
 
   if (ELEMENT_IS ("line"))
@@ -1697,7 +1697,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       int dash_on_val;
       int dash_off_val;
       int width_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!color", &color,
@@ -1718,11 +1718,11 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (x2, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (y2, FALSE, info->theme, context, error))
         return;
 #endif
- 
+
       dash_on_val = 0;
       if (dash_on_length &&
           !parse_positive_integer (dash_on_length, &dash_on_val, context, info->theme, error))
@@ -1747,7 +1747,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
           add_context_to_error (error, context);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_LINE);
 
       op->data.line.color_spec = color_spec;
@@ -1770,7 +1770,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.line.dash_off_length = dash_off_val;
 
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_LINE);
@@ -1786,7 +1786,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *filled;
       gboolean filled_val;
       MetaColorSpec *color_spec;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!color", &color,
@@ -1805,7 +1805,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -1813,7 +1813,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       filled_val = FALSE;
       if (filled && !parse_boolean (filled, &filled_val, context, error))
         return;
-      
+
       /* Check last so we don't have to free it when other
        * stuff fails
        */
@@ -1823,20 +1823,20 @@ parse_draw_op_element (GMarkupParseContext  *context,
           add_context_to_error (error, context);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_RECTANGLE);
 
       op->data.rectangle.color_spec = color_spec;
       op->data.rectangle.x = meta_draw_spec_new (info->theme, x, NULL);
       op->data.rectangle.y = meta_draw_spec_new (info->theme, y, NULL);
       op->data.rectangle.width = meta_draw_spec_new (info->theme, width, NULL);
-      op->data.rectangle.height = meta_draw_spec_new (info->theme, 
+      op->data.rectangle.height = meta_draw_spec_new (info->theme,
                                                       height, NULL);
 
       op->data.rectangle.filled = filled_val;
 
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_RECTANGLE);
@@ -1858,7 +1858,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       double start_angle_val;
       double extent_angle_val;
       MetaColorSpec *color_spec;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!color", &color,
@@ -1905,7 +1905,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
             }
         }
 
-#if 0     
+#if 0
       if (!check_expression (x, FALSE, info->theme, context, error))
         return;
 
@@ -1914,7 +1914,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -1923,7 +1923,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
         {
           if (!parse_angle (from, &start_angle_val, context, error))
             return;
-          
+
           start_angle_val = (180-start_angle_val)/360.0;
         }
       else
@@ -1931,12 +1931,12 @@ parse_draw_op_element (GMarkupParseContext  *context,
           if (!parse_angle (start_angle, &start_angle_val, context, error))
             return;
         }
-      
+
       if (extent_angle == NULL)
         {
           if (!parse_angle (to, &extent_angle_val, context, error))
             return;
-          
+
           extent_angle_val = ((180-extent_angle_val)/360.0) - start_angle_val;
         }
       else
@@ -1944,11 +1944,11 @@ parse_draw_op_element (GMarkupParseContext  *context,
            if (!parse_angle (extent_angle, &extent_angle_val, context, error))
              return;
         }
-     
+
       filled_val = FALSE;
       if (filled && !parse_boolean (filled, &filled_val, context, error))
         return;
-      
+
       /* Check last so we don't have to free it when other
        * stuff fails
        */
@@ -1958,7 +1958,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
           add_context_to_error (error, context);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_ARC);
 
       op->data.arc.color_spec = color_spec;
@@ -1971,9 +1971,9 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.arc.filled = filled_val;
       op->data.arc.start_angle = start_angle_val;
       op->data.arc.extent_angle = extent_angle_val;
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_ARC);
@@ -1985,14 +1985,14 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *y;
       const char *width;
       const char *height;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!x", &x, "!y", &y,
                               "!width", &width, "!height", &height,
                               NULL))
         return;
-      
+
 #if 0
       if (!check_expression (x, FALSE, info->theme, context, error))
         return;
@@ -2002,10 +2002,10 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
-#endif 
+#endif
       op = meta_draw_op_new (META_DRAW_CLIP);
 
       op->data.clip.x = meta_draw_spec_new (info->theme, x, NULL);
@@ -2014,7 +2014,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.clip.height = meta_draw_spec_new (info->theme, height, NULL);
 
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_CLIP);
@@ -2030,7 +2030,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *alpha;
       MetaAlphaGradientSpec *alpha_spec;
       MetaColorSpec *color_spec;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!color", &color,
@@ -2049,14 +2049,14 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
       alpha_spec = NULL;
       if (!parse_alpha (alpha, &alpha_spec, context, error))
         return;
-      
+
       /* Check last so we don't have to free it when other
        * stuff fails
        */
@@ -2065,11 +2065,11 @@ parse_draw_op_element (GMarkupParseContext  *context,
         {
           if (alpha_spec)
             meta_alpha_gradient_spec_free (alpha_spec);
-          
+
           add_context_to_error (error, context);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_TINT);
 
       op->data.tint.color_spec = color_spec;
@@ -2081,7 +2081,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.tint.height = meta_draw_spec_new (info->theme, height, NULL);
 
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_TINT);
@@ -2096,7 +2096,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *alpha;
       MetaAlphaGradientSpec *alpha_spec;
       MetaGradientType type_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!type", &type,
@@ -2115,11 +2115,11 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
-  
+
       type_val = meta_gradient_type_from_string (type);
       if (type_val == META_GRADIENT_LAST)
         {
@@ -2132,13 +2132,13 @@ parse_draw_op_element (GMarkupParseContext  *context,
       alpha_spec = NULL;
       if (alpha && !parse_alpha (alpha, &alpha_spec, context, error))
         return;
-      
+
       g_assert (info->op == NULL);
       info->op = meta_draw_op_new (META_DRAW_GRADIENT);
 
       info->op->data.gradient.x = meta_draw_spec_new (info->theme, x, NULL);
       info->op->data.gradient.y = meta_draw_spec_new (info->theme, y, NULL);
-      info->op->data.gradient.width = meta_draw_spec_new (info->theme, 
+      info->op->data.gradient.width = meta_draw_spec_new (info->theme,
                                                         width, NULL);
       info->op->data.gradient.height = meta_draw_spec_new (info->theme,
                                                          height, NULL);
@@ -2146,7 +2146,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       info->op->data.gradient.gradient_spec = meta_gradient_spec_new (type_val);
 
       info->op->data.gradient.alpha_spec = alpha_spec;
-      
+
       push_state (info, STATE_GRADIENT);
 
       /* op gets appended on close tag */
@@ -2169,7 +2169,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       int h, w, c;
       int pixbuf_width, pixbuf_height, pixbuf_n_channels, pixbuf_rowstride;
       guchar *pixbuf_pixels;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!x", &x, "!y", &y,
@@ -2179,8 +2179,8 @@ parse_draw_op_element (GMarkupParseContext  *context,
                               "fill_type", &fill_type,
                               NULL))
         return;
-      
-#if 0      
+
+#if 0
       if (!check_expression (x, TRUE, info->theme, context, error))
         return;
 
@@ -2189,7 +2189,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, TRUE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, TRUE, info->theme, context, error))
         return;
 #endif
@@ -2197,7 +2197,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       if (fill_type)
         {
           fill_type_val = meta_image_fill_type_from_string (fill_type);
-          
+
           if (((int) fill_type_val) == -1)
             {
               set_error (error, context, G_MARKUP_ERROR,
@@ -2206,7 +2206,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
                          fill_type, element_name);
             }
         }
-      
+
       /* Check last so we don't have to free it when other
        * stuff fails.
        *
@@ -2222,7 +2222,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       if (colorize)
         {
           colorize_spec = parse_color (info->theme, colorize, error);
-          
+
           if (colorize_spec == NULL)
             {
               add_context_to_error (error, context);
@@ -2237,7 +2237,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
           g_object_unref (G_OBJECT (pixbuf));
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_IMAGE);
 
       op->data.image.pixbuf = pixbuf;
@@ -2250,7 +2250,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       op->data.image.alpha_spec = alpha_spec;
       op->data.image.fill_type = fill_type_val;
-      
+
       /* Check for vertical & horizontal stripes */
       pixbuf_n_channels = gdk_pixbuf_get_n_channels(pixbuf);
       pixbuf_width = gdk_pixbuf_get_width(pixbuf);
@@ -2278,11 +2278,11 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (h >= pixbuf_height)
         {
-          op->data.image.horizontal_stripes = TRUE; 
+          op->data.image.horizontal_stripes = TRUE;
         }
       else
         {
-          op->data.image.horizontal_stripes = FALSE; 
+          op->data.image.horizontal_stripes = FALSE;
         }
 
       /* Check for vertical stripes */
@@ -2305,15 +2305,15 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (w >= pixbuf_width)
         {
-          op->data.image.vertical_stripes = TRUE; 
+          op->data.image.vertical_stripes = TRUE;
         }
       else
         {
-          op->data.image.vertical_stripes = FALSE; 
+          op->data.image.vertical_stripes = FALSE;
         }
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_IMAGE);
@@ -2333,7 +2333,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       GtkStateFlags state_val;
       GtkShadowType shadow_val;
       GtkArrowType arrow_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!state", &state,
@@ -2354,7 +2354,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -2391,22 +2391,22 @@ parse_draw_op_element (GMarkupParseContext  *context,
                      arrow, element_name);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_GTK_ARROW);
 
       op->data.gtk_arrow.x = meta_draw_spec_new (info->theme, x, NULL);
       op->data.gtk_arrow.y = meta_draw_spec_new (info->theme, y, NULL);
       op->data.gtk_arrow.width = meta_draw_spec_new (info->theme, width, NULL);
-      op->data.gtk_arrow.height = meta_draw_spec_new (info->theme, 
+      op->data.gtk_arrow.height = meta_draw_spec_new (info->theme,
                                                       height, NULL);
 
       op->data.gtk_arrow.filled = filled_val;
       op->data.gtk_arrow.state = state_val;
       op->data.gtk_arrow.shadow = shadow_val;
       op->data.gtk_arrow.arrow = arrow_val;
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_GTK_ARROW);
@@ -2422,7 +2422,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *height;
       GtkStateFlags state_val;
       GtkShadowType shadow_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!state", &state,
@@ -2441,7 +2441,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -2464,7 +2464,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
                      shadow, element_name);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_GTK_BOX);
 
       op->data.gtk_box.x = meta_draw_spec_new (info->theme, x, NULL);
@@ -2474,9 +2474,9 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       op->data.gtk_box.state = state_val;
       op->data.gtk_box.shadow = shadow_val;
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_GTK_BOX);
@@ -2489,7 +2489,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *y1;
       const char *y2;
       GtkStateFlags state_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!state", &state,
@@ -2517,7 +2517,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
                      state, element_name);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_GTK_VLINE);
 
       op->data.gtk_vline.x = meta_draw_spec_new (info->theme, x, NULL);
@@ -2525,9 +2525,9 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.gtk_vline.y2 = meta_draw_spec_new (info->theme, y2, NULL);
 
       op->data.gtk_vline.state = state_val;
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_GTK_VLINE);
@@ -2543,7 +2543,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *fill_type;
       MetaAlphaGradientSpec *alpha_spec;
       MetaImageFillType fill_type_val;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!x", &x, "!y", &y,
@@ -2552,8 +2552,8 @@ parse_draw_op_element (GMarkupParseContext  *context,
                               "fill_type", &fill_type,
                               NULL))
         return;
-      
-#if 0      
+
+#if 0
       if (!check_expression (x, FALSE, info->theme, context, error))
         return;
 
@@ -2562,7 +2562,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (!check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -2579,13 +2579,13 @@ parse_draw_op_element (GMarkupParseContext  *context,
                          fill_type, element_name);
             }
         }
-      
+
       alpha_spec = NULL;
       if (alpha && !parse_alpha (alpha, &alpha_spec, context, error))
         return;
-      
+
       op = meta_draw_op_new (META_DRAW_ICON);
-      
+
       op->data.icon.x = meta_draw_spec_new (info->theme, x, NULL);
       op->data.icon.y = meta_draw_spec_new (info->theme, y, NULL);
       op->data.icon.width = meta_draw_spec_new (info->theme, width, NULL);
@@ -2593,9 +2593,9 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       op->data.icon.alpha_spec = alpha_spec;
       op->data.icon.fill_type = fill_type_val;
-      
+
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_ICON);
@@ -2608,7 +2608,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *y;
       const char *ellipsize_width;
       MetaColorSpec *color_spec;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!color", &color,
@@ -2644,7 +2644,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
           add_context_to_error (error, context);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_TITLE);
 
       op->data.title.color_spec = color_spec;
@@ -2655,7 +2655,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
         op->data.title.ellipsize_width = meta_draw_spec_new (info->theme, ellipsize_width, NULL);
 
       g_assert (info->op_list);
-      
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_TITLE);
@@ -2669,7 +2669,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *width;
       const char *height;
       MetaDrawOpList *op_list;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "x", &x, "y", &y,
@@ -2681,7 +2681,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       /* x/y/width/height default to 0,0,width,height - should
        * probably do this for all the draw ops
        */
-#if 0      
+#if 0
       if (x && !check_expression (x, FALSE, info->theme, context, error))
         return;
 
@@ -2690,7 +2690,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (width && !check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (height && !check_expression (height, FALSE, info->theme, context, error))
         return;
 #endif
@@ -2707,7 +2707,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
         }
 
       g_assert (info->op_list);
-      
+
       if (op_list == info->op_list ||
           meta_draw_op_list_contains (op_list, info->op_list))
         {
@@ -2717,15 +2717,15 @@ parse_draw_op_element (GMarkupParseContext  *context,
                      name);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_OP_LIST);
 
       meta_draw_op_list_ref (op_list);
-      op->data.op_list.op_list = op_list;      
+      op->data.op_list.op_list = op_list;
 
       op->data.op_list.x = meta_draw_spec_new (info->theme, x ? x : "0", NULL);
       op->data.op_list.y = meta_draw_spec_new (info->theme, y ? y : "0", NULL);
-      op->data.op_list.width = meta_draw_spec_new (info->theme, 
+      op->data.op_list.width = meta_draw_spec_new (info->theme,
                                                    width ? width : "width",
                                                    NULL);
       op->data.op_list.height = meta_draw_spec_new (info->theme,
@@ -2749,7 +2749,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *tile_width;
       const char *tile_height;
       MetaDrawOpList *op_list;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "x", &x, "y", &y,
@@ -2769,7 +2769,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (tile_yoffset && !check_expression (tile_yoffset, FALSE, info->theme, context, error))
         return;
-      
+
       /* x/y/width/height default to 0,0,width,height - should
        * probably do this for all the draw ops
        */
@@ -2781,7 +2781,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (width && !check_expression (width, FALSE, info->theme, context, error))
         return;
-      
+
       if (height && !check_expression (height, FALSE, info->theme, context, error))
         return;
 
@@ -2790,7 +2790,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
 
       if (!check_expression (tile_height, FALSE, info->theme, context, error))
         return;
-#endif 
+#endif
       op_list = meta_theme_lookup_draw_op_list (info->theme,
                                                 name);
       if (op_list == NULL)
@@ -2803,7 +2803,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
         }
 
       g_assert (info->op_list);
-      
+
       if (op_list == info->op_list ||
           meta_draw_op_list_contains (op_list, info->op_list))
         {
@@ -2813,7 +2813,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
                      name);
           return;
         }
-      
+
       op = meta_draw_op_new (META_DRAW_TILE);
 
       meta_draw_op_list_ref (op_list);
@@ -2835,8 +2835,8 @@ parse_draw_op_element (GMarkupParseContext  *context,
       op->data.tile.tile_width = meta_draw_spec_new (info->theme, tile_width, NULL);
       op->data.tile.tile_height = meta_draw_spec_new (info->theme, tile_height, NULL);
 
-      op->data.tile.op_list = op_list;      
-      
+      op->data.tile.op_list = op_list;
+
       meta_draw_op_list_append (info->op_list, op);
 
       push_state (info, STATE_TILE);
@@ -2884,7 +2884,7 @@ parse_gradient_element (GMarkupParseContext  *context,
       info->op->data.gradient.gradient_spec->color_specs =
         g_slist_append (info->op->data.gradient.gradient_spec->color_specs,
                         color_spec);
-      
+
       push_state (info, STATE_COLOR);
     }
   else
@@ -2907,12 +2907,12 @@ parse_style_element (GMarkupParseContext  *context,
   g_return_if_fail (peek_state (info) == STATE_FRAME_STYLE);
 
   g_assert (info->style);
-  
+
   if (ELEMENT_IS ("piece"))
     {
       const char *position = NULL;
       const char *draw_ops = NULL;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!position", &position,
@@ -2928,7 +2928,7 @@ parse_style_element (GMarkupParseContext  *context,
                      position);
           return;
         }
-      
+
       if (info->style->pieces[info->piece] != NULL)
         {
           set_error (error, context, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
@@ -2938,7 +2938,7 @@ parse_style_element (GMarkupParseContext  *context,
         }
 
       g_assert (info->op_list == NULL);
-      
+
       if (draw_ops)
         {
           MetaDrawOpList *op_list;
@@ -2957,7 +2957,7 @@ parse_style_element (GMarkupParseContext  *context,
           meta_draw_op_list_ref (op_list);
           info->op_list = op_list;
         }
-      
+
       push_state (info, STATE_PIECE);
     }
   else if (ELEMENT_IS ("button"))
@@ -2966,7 +2966,7 @@ parse_style_element (GMarkupParseContext  *context,
       const char *state = NULL;
       const char *draw_ops = NULL;
       gint required_version;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!function", &function,
@@ -3005,7 +3005,7 @@ parse_style_element (GMarkupParseContext  *context,
                      state);
           return;
         }
-      
+
       if (info->style->buttons[info->button_type][info->button_state] != NULL)
         {
           set_error (error, context, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
@@ -3015,7 +3015,7 @@ parse_style_element (GMarkupParseContext  *context,
         }
 
       g_assert (info->op_list == NULL);
-      
+
       if (draw_ops)
         {
           MetaDrawOpList *op_list;
@@ -3034,7 +3034,7 @@ parse_style_element (GMarkupParseContext  *context,
           meta_draw_op_list_ref (op_list);
           info->op_list = op_list;
         }
-      
+
       push_state (info, STATE_BUTTON);
     }
   else if (ELEMENT_IS ("shadow"))
@@ -3078,7 +3078,7 @@ parse_style_set_element (GMarkupParseContext  *context,
       MetaFrameState frame_state;
       MetaFrameResize frame_resize;
       MetaFrameStyle *frame_style;
-      
+
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,
                               "!focus", &focus,
@@ -3096,7 +3096,7 @@ parse_style_set_element (GMarkupParseContext  *context,
                      focus);
           return;
         }
-      
+
       frame_state = meta_frame_state_from_string (state);
       if (frame_state == META_FRAME_STATE_LAST)
         {
@@ -3127,7 +3127,7 @@ parse_style_set_element (GMarkupParseContext  *context,
               return;
             }
 
-          
+
           frame_resize = meta_frame_resize_from_string (resize);
           if (frame_resize == META_FRAME_RESIZE_LAST)
             {
@@ -3136,7 +3136,7 @@ parse_style_set_element (GMarkupParseContext  *context,
                          focus);
               return;
             }
-          
+
           break;
 
         case META_FRAME_STATE_SHADED:
@@ -3175,7 +3175,7 @@ parse_style_set_element (GMarkupParseContext  *context,
               frame_resize = META_FRAME_RESIZE_BOTH;
             }
           break;
-          
+
         default:
           if (resize != NULL)
             {
@@ -3187,7 +3187,7 @@ parse_style_set_element (GMarkupParseContext  *context,
 
           frame_resize = META_FRAME_RESIZE_LAST;
         }
-      
+
       switch (frame_state)
         {
         case META_FRAME_STATE_NORMAL:
@@ -3286,7 +3286,7 @@ parse_style_set_element (GMarkupParseContext  *context,
           break;
         }
 
-      push_state (info, STATE_FRAME);      
+      push_state (info, STATE_FRAME);
     }
   else
     {
@@ -3316,7 +3316,7 @@ parse_piece_element (GMarkupParseContext  *context,
                      _("Can't have a two draw_ops for a <piece> element (theme specified a draw_ops attribute and also a <draw_ops> element, or specified two elements)"));
           return;
         }
-            
+
       if (!check_no_attributes (context, element_name, attribute_names, attribute_values,
                                 error))
         return;
@@ -3344,7 +3344,7 @@ parse_button_element (GMarkupParseContext  *context,
                       GError              **error)
 {
   g_return_if_fail (peek_state (info) == STATE_BUTTON);
-  
+
   if (ELEMENT_IS ("draw_ops"))
     {
       if (info->op_list)
@@ -3354,7 +3354,7 @@ parse_button_element (GMarkupParseContext  *context,
                      _("Can't have a two draw_ops for a <button> element (theme specified a draw_ops attribute and also a <draw_ops> element, or specified two elements)"));
           return;
         }
-            
+
       if (!check_no_attributes (context, element_name, attribute_names, attribute_values,
                                 error))
         return;
@@ -3392,7 +3392,7 @@ parse_menu_icon_element (GMarkupParseContext  *context,
                      _("Can't have a two draw_ops for a <menu_icon> element (theme specified a draw_ops attribute and also a <draw_ops> element, or specified two elements)"));
           return;
         }
-            
+
       if (!check_no_attributes (context, element_name, attribute_names, attribute_values,
                                 error))
         return;
@@ -3489,9 +3489,9 @@ check_version (GMarkupParseContext *context,
         }
     }
 
-  g_free (comparison_str);
-  g_free (major_str);
-  g_free (minor_str);
+  free (comparison_str);
+  free (major_str);
+  free (minor_str);
   g_match_info_free (info);
 
   return TRUE;
@@ -3577,7 +3577,7 @@ start_element_handler (GMarkupParseContext *context,
           info->theme->dirname = g_strdup (info->theme_dir);
           info->theme->format_version = info->format_version;
           info->theme->scale = meta_prefs_get_ui_scale ();
-          
+
           push_state (info, STATE_THEME);
         }
       else
@@ -3726,7 +3726,7 @@ end_element_handler (GMarkupParseContext *context,
           meta_theme_free (info->theme);
           info->theme = NULL;
         }
-      
+
       pop_state (info);
       g_assert (peek_state (info) == STATE_START);
       break;
@@ -3790,7 +3790,7 @@ end_element_handler (GMarkupParseContext *context,
     case STATE_DRAW_OPS:
       {
         g_assert (info->op_list);
-        
+
         if (!meta_draw_op_list_validate (info->op_list,
                                          error))
           {
@@ -4001,10 +4001,10 @@ all_whitespace (const char *text,
 {
   const char *p;
   const char *end;
-  
+
   p = text;
   end = text + text_len;
-  
+
   while (p != end)
     {
       if (!g_ascii_isspace (*p))
@@ -4030,7 +4030,7 @@ text_handler (GMarkupParseContext *context,
 
   if (all_whitespace (text, text_len))
     return;
-  
+
   /* FIXME http://bugzilla.gnome.org/show_bug.cgi?id=70448 would
    * allow a nice cleanup here.
    */
@@ -4271,9 +4271,9 @@ load_theme (const char *theme_dir,
                   theme_file, (*error)->message);
     }
 
-  g_free (theme_filename);
-  g_free (theme_file);
-  g_free (text);
+  free (theme_filename);
+  free (theme_file);
+  free (text);
 
   if (context)
     {
@@ -4321,7 +4321,7 @@ meta_theme_load (const char *theme_name,
         {
           theme_dir = g_build_filename ("./themes", theme_name, NULL);
           retval = load_theme (theme_dir, theme_name, major_version, &error);
-          g_free (theme_dir);
+          free (theme_dir);
           if (!keep_trying (&error))
             goto out;
         }
@@ -4335,11 +4335,11 @@ meta_theme_load (const char *theme_name,
                                     NULL);
 
       retval = load_theme (theme_dir, "Default", 3, &error);
-      g_free (theme_dir);
+      free (theme_dir);
       if (!keep_trying (&error))
         goto out;
     }
-  
+
   /* We try all supported major versions from current to oldest */
   for (major_version = THEME_MAJOR_VERSION; (major_version > 0); major_version--)
     {
@@ -4353,7 +4353,7 @@ meta_theme_load (const char *theme_name,
                                     NULL);
 
       retval = load_theme (theme_dir, theme_name, major_version, &error);
-      g_free (theme_dir);
+      free (theme_dir);
       if (!keep_trying (&error))
         goto out;
 
@@ -4365,7 +4365,7 @@ meta_theme_load (const char *theme_name,
                                     NULL);
 
       retval = load_theme (theme_dir, theme_name, major_version, &error);
-      g_free (theme_dir);
+      free (theme_dir);
       if (!keep_trying (&error))
         goto out;
 
@@ -4380,7 +4380,7 @@ meta_theme_load (const char *theme_name,
                                         NULL);
 
           retval = load_theme (theme_dir, theme_name, major_version, &error);
-          g_free (theme_dir);
+          free (theme_dir);
           if (!keep_trying (&error))
             goto out;
         }
@@ -4393,7 +4393,7 @@ meta_theme_load (const char *theme_name,
                                     NULL);
 
       retval = load_theme (theme_dir, theme_name, major_version, &error);
-      g_free (theme_dir);
+      free (theme_dir);
       if (!keep_trying (&error))
         goto out;
     }

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -128,7 +128,7 @@ normal_contents (void)
   GtkWidget *sw;
   GtkActionGroup *action_group;
   GtkUIManager *ui_manager;
-      
+
   grid = gtk_grid_new ();
 
   /* Create the menubar
@@ -178,18 +178,18 @@ normal_contents (void)
 
   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sw),
                                        GTK_SHADOW_IN);
-      
+
   gtk_grid_attach (GTK_GRID (grid),
                    sw,
                    0, 2, 1, 1);
 
   gtk_widget_set_hexpand (sw, TRUE);
   gtk_widget_set_vexpand (sw, TRUE);
-      
+
   contents = gtk_text_view_new ();
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
                                PANGO_WRAP_WORD);
-      
+
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);
 
@@ -227,19 +227,19 @@ dialog_contents (void)
   GtkWidget *label;
   GtkWidget *image;
   GtkWidget *button;
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
   action_area = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
 
   gtk_button_box_set_layout (GTK_BUTTON_BOX (action_area),
-                             GTK_BUTTONBOX_END);  
+                             GTK_BUTTONBOX_END);
 
   button = gtk_button_new_from_stock (GTK_STOCK_OK);
   gtk_box_pack_end (GTK_BOX (action_area),
                     button,
                     FALSE, TRUE, 0);
-  
+
   gtk_box_pack_end (GTK_BOX (vbox), action_area,
                     FALSE, TRUE, 0);
 
@@ -249,10 +249,10 @@ dialog_contents (void)
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO,
                                     GTK_ICON_SIZE_DIALOG);
   gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.0);
-  
+
   gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
   gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-  
+
   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 
   gtk_box_pack_start (GTK_BOX (hbox), image,
@@ -288,11 +288,11 @@ utility_contents (void)
           char *str;
 
           str = g_strdup_printf ("_%c", (char) ('A' + 4*i + j));
-          
+
           button = gtk_button_new_with_mnemonic (str);
 
-          g_free (str);
-          
+          free (str);
+
           gtk_grid_attach (GTK_GRID (grid),
                            button,
                            i, j, 1, 1);
@@ -304,7 +304,7 @@ utility_contents (void)
     }
 
   gtk_widget_show_all (grid);
-  
+
   return grid;
 }
 
@@ -312,7 +312,7 @@ static GtkWidget*
 menu_contents (void)
 {
   GtkWidget *vbox;
-  GtkWidget *mi;  
+  GtkWidget *mi;
   int i;
   GtkWidget *frame;
 
@@ -328,16 +328,16 @@ menu_contents (void)
       char *str = g_strdup_printf (_("Fake menu item %d\n"), i + 1);
       mi = gtk_label_new (str);
       gtk_misc_set_alignment (GTK_MISC (mi), 0.0, 0.5);
-      g_free (str);
+      free (str);
       gtk_box_pack_start (GTK_BOX (vbox), mi, FALSE, FALSE, 0);
-      
+
       ++i;
     }
 
   gtk_container_add (GTK_CONTAINER (frame), vbox);
-  
+
   gtk_widget_show_all (frame);
-  
+
   return frame;
 }
 
@@ -356,19 +356,19 @@ border_only_contents (void)
   color.blue = 0.6;
   color.alpha = 1.0;
   gtk_widget_override_background_color (event_box, 0, &color);
-  
+
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 3);
-  
+
   w = gtk_label_new (_("Border-only window"));
   gtk_box_pack_start (GTK_BOX (vbox), w, FALSE, FALSE, 0);
   w = gtk_button_new_with_label (_("Bar"));
   gtk_box_pack_start (GTK_BOX (vbox), w, FALSE, FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (event_box), vbox);
-  
+
   gtk_widget_show_all (event_box);
-  
+
   return event_box;
 }
 
@@ -405,7 +405,7 @@ get_window_contents (MetaFrameType  type,
     case META_FRAME_TYPE_ATTACHED:
       *title = _("Attached Modal Dialog");
       return dialog_contents ();
-      
+
     case META_FRAME_TYPE_LAST:
       g_assert_not_reached ();
       break;
@@ -428,7 +428,7 @@ get_window_flags (MetaFrameType type)
     META_FRAME_HAS_FOCUS |
     META_FRAME_ALLOWS_SHADE |
     META_FRAME_ALLOWS_MOVE;
-  
+
   switch (type)
     {
     case META_FRAME_TYPE_NORMAL:
@@ -455,12 +455,12 @@ get_window_flags (MetaFrameType type)
 
     case META_FRAME_TYPE_ATTACHED:
       break;
-      
+
     case META_FRAME_TYPE_LAST:
       g_assert_not_reached ();
       break;
-    }  
-  
+    }
+
   return flags;
 }
 
@@ -505,23 +505,23 @@ preview_collection (int font_size,
       GtkWidget *preview;
       PangoFontDescription *font_desc;
       double scale;
-      
+
       eventbox2 = gtk_event_box_new ();
-      
+
       preview = meta_preview_new ();
-      
+
       gtk_container_add (GTK_CONTAINER (eventbox2), preview);
-      
+
       meta_preview_set_frame_type (META_PREVIEW (preview), i);
       meta_preview_set_frame_flags (META_PREVIEW (preview),
                                     get_window_flags (i));
-            
+
       meta_preview_set_theme (META_PREVIEW (preview), global_theme);
-      
+
       contents = get_window_contents (i, &title);
-      
+
       meta_preview_set_title (META_PREVIEW (preview), title);
-      
+
       gtk_container_add (GTK_CONTAINER (preview), contents);
 
       if (i == META_FRAME_TYPE_MENU)
@@ -534,10 +534,10 @@ preview_collection (int font_size,
           xalign = 0.5;
           yalign = 0.5;
         }
-      
+
       align = gtk_alignment_new (0.0, 0.0, xalign, yalign);
       gtk_container_add (GTK_CONTAINER (align), eventbox2);
-      
+
       gtk_box_pack_start (GTK_BOX (box), align, TRUE, TRUE, 0);
 
       switch (font_size)
@@ -556,17 +556,17 @@ preview_collection (int font_size,
       if (scale != 1.0)
         {
           font_desc = pango_font_description_new ();
-          
+
           pango_font_description_set_size (font_desc,
                                            MAX (pango_font_description_get_size (base_desc) * scale, 1));
-          
+
           gtk_widget_override_font (preview, font_desc);
 
           pango_font_description_free (font_desc);
         }
-      
+
       previews[font_size*META_FRAME_TYPE_LAST + i] = preview;
-      
+
       ++i;
     }
 
@@ -595,13 +595,13 @@ init_layouts (void)
         }
       ++i;
     }
-  
+
 #ifndef ALLOW_DUPLICATE_BUTTONS
   i = 0;
   while (i <= MAX_BUTTONS_PER_CORNER)
     {
       int j;
-      
+
       j = 0;
       while (j < i)
         {
@@ -613,34 +613,34 @@ init_layouts (void)
           different_layouts[i].left_buttons[j-i] = (MetaButtonFunction) j;
           ++j;
         }
-      
+
       ++i;
     }
 
   /* Special extra case for no buttons on either side */
   different_layouts[i].left_buttons[0] = META_BUTTON_FUNCTION_LAST;
   different_layouts[i].right_buttons[0] = META_BUTTON_FUNCTION_LAST;
-  
+
 #else
   /* FIXME this code is if we allow duplicate buttons,
    * which we currently do not
    */
   int left;
   int i;
-  
+
   left = 0;
   i = 0;
 
   while (left < MAX_BUTTONS_PER_CORNER)
     {
       int right;
-      
+
       right = 0;
-      
+
       while (right < MAX_BUTTONS_PER_CORNER)
         {
           int j;
-          
+
           static MetaButtonFunction left_functions[MAX_BUTTONS_PER_CORNER] = {
             META_BUTTON_FUNCTION_MENU,
             META_BUTTON_FUNCTION_MINIMIZE,
@@ -655,7 +655,7 @@ init_layouts (void)
           };
 
           g_assert (i < BUTTON_LAYOUT_COMBINATIONS);
-          
+
           j = 0;
           while (j <= left)
             {
@@ -669,12 +669,12 @@ init_layouts (void)
               different_layouts[i].right_buttons[j] = right_functions[j];
               ++j;
             }
-          
+
           ++i;
-          
+
           ++right;
         }
-      
+
       ++left;
     }
 #endif
@@ -690,13 +690,13 @@ previews_of_button_layouts (void)
   GdkRGBA desktop_color;
   int i;
   GtkWidget *eventbox;
-  
+
   if (!initted)
     {
       init_layouts ();
       initted = TRUE;
     }
-  
+
   sw = gtk_scrolled_window_new (NULL, NULL);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
                                   GTK_POLICY_AUTOMATIC,
@@ -727,33 +727,33 @@ previews_of_button_layouts (void)
       char *title;
 
       eventbox2 = gtk_event_box_new ();
-  
+
       preview = meta_preview_new ();
-  
-      gtk_container_add (GTK_CONTAINER (eventbox2), preview);  
-  
+
+      gtk_container_add (GTK_CONTAINER (eventbox2), preview);
+
       meta_preview_set_theme (META_PREVIEW (preview), global_theme);
 
       title = g_strdup_printf (_("Button layout test %d"), i+1);
       meta_preview_set_title (META_PREVIEW (preview), title);
-      g_free (title);
+      free (title);
 
       meta_preview_set_button_layout (META_PREVIEW (preview),
                                       &different_layouts[i]);
-  
+
       xalign = 0.5;
       yalign = 0.5;
-      
+
       align = gtk_alignment_new (0.0, 0.0, xalign, yalign);
       gtk_container_add (GTK_CONTAINER (align), eventbox2);
-  
+
       gtk_box_pack_start (GTK_BOX (box), align, TRUE, TRUE, 0);
 
       previews[META_FRAME_TYPE_LAST*FONT_SIZE_LAST + i] = preview;
-      
+
       ++i;
     }
-  
+
   return sw;
 }
 
@@ -762,11 +762,11 @@ benchmark_summary (void)
 {
   char *msg;
   GtkWidget *label;
-  
+
   msg = g_strdup_printf (_("%g milliseconds to draw one window frame"),
                          milliseconds_to_draw_frame);
   label = gtk_label_new (msg);
-  g_free (msg);
+  free (msg);
 
   return label;
 }
@@ -782,7 +782,7 @@ main (int argc, char **argv)
   clock_t start, end;
   GtkWidget *notebook;
   int i;
-  
+
   bindtextdomain (GETTEXT_PACKAGE, MUFFIN_LOCALEDIR);
   textdomain(GETTEXT_PACKAGE);
   bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
@@ -799,7 +799,7 @@ main (int argc, char **argv)
       meta_set_debugging (TRUE);
       meta_set_verbose (TRUE);
     }
-  
+
   start = clock ();
   err = NULL;
   if (argc == 1)
@@ -826,7 +826,7 @@ main (int argc, char **argv)
            (end - start) / (double) CLOCKS_PER_SEC);
 
   run_theme_benchmark ();
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_default_size (GTK_WINDOW (window), 350, 350);
 
@@ -845,8 +845,8 @@ main (int argc, char **argv)
       gtk_window_set_title (GTK_WINDOW (window),
                             title);
 
-      g_free (title);
-    }       
+      free (title);
+    }
 
   g_signal_connect (G_OBJECT (window), "destroy",
                     G_CALLBACK (gtk_main_quit), NULL);
@@ -859,7 +859,7 @@ main (int argc, char **argv)
 
   g_assert (style);
   g_assert (font_desc);
-  
+
   notebook = gtk_notebook_new ();
   gtk_container_add (GTK_CONTAINER (window), notebook);
 
@@ -868,13 +868,13 @@ main (int argc, char **argv)
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                             collection,
                             gtk_label_new (_("Normal Title Font")));
-  
+
   collection = preview_collection (FONT_SIZE_SMALL,
                                    font_desc);
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                             collection,
                             gtk_label_new (_("Small Title Font")));
-  
+
   collection = preview_collection (FONT_SIZE_LARGE,
                                    font_desc);
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
@@ -903,7 +903,7 @@ main (int argc, char **argv)
 
       ++i;
     }
-  
+
   gtk_widget_show_all (window);
 
   gtk_main ();
@@ -978,18 +978,18 @@ run_theme_benchmark (void)
   int client_height;
   cairo_t *cr;
   int inc;
-  
+
   widget = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_widget_realize (widget);
-  
+
   meta_theme_get_frame_borders (global_theme,
                                 META_FRAME_TYPE_NORMAL,
                                 get_text_height (widget),
                                 get_flags (widget),
                                 &borders);
-  
+
   layout = create_title_layout (widget);
-  
+
   i = 0;
   while (i < MAX_BUTTONS_PER_CORNER)
     {
@@ -997,7 +997,7 @@ run_theme_benchmark (void)
       button_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
       ++i;
     }
-  
+
   button_layout.left_buttons[0] = META_BUTTON_FUNCTION_MENU;
 
   button_layout.right_buttons[0] = META_BUTTON_FUNCTION_MINIMIZE;
@@ -1012,7 +1012,7 @@ run_theme_benchmark (void)
   inc = 1000 / ITERATIONS; /* Increment to grow width/height,
                             * eliminates caching effects.
                             */
-  
+
   i = 0;
   while (i < ITERATIONS)
     {
@@ -1038,7 +1038,7 @@ run_theme_benchmark (void)
                              button_states);
       cairo_destroy (cr);
       cairo_surface_destroy (pixmap);
-      
+
       ++i;
       client_width += inc;
       client_height += inc;
@@ -1048,7 +1048,7 @@ run_theme_benchmark (void)
   g_timer_stop (timer);
 
   milliseconds_to_draw_frame = (g_timer_elapsed (timer, NULL) / (double) ITERATIONS) * 1000;
-  
+
   g_print (_("Drew %d frames in %g client-side seconds (%g milliseconds per frame) and %g seconds wall clock time including X server resources (%g milliseconds per frame)\n"),
            ITERATIONS,
            ((double)end - (double)start) / CLOCKS_PER_SEC,
@@ -1242,7 +1242,7 @@ run_position_expression_tests (void)
                  test->expr, test->expected_x, test->expected_y);
 
       err = NULL;
-      
+
       env.rect = meta_rect (test->rect.x, test->rect.y,
                             test->rect.width, test->rect.height);
       env.object_width = -1;

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -110,14 +110,14 @@ colorize_pixbuf (GdkPixbuf *orig,
   gboolean has_alpha;
   const guchar *src_pixels;
   guchar *dest_pixels;
-  
+
   pixbuf = gdk_pixbuf_new (gdk_pixbuf_get_colorspace (orig), gdk_pixbuf_get_has_alpha (orig),
 			   gdk_pixbuf_get_bits_per_sample (orig),
 			   gdk_pixbuf_get_width (orig), gdk_pixbuf_get_height (orig));
 
   if (pixbuf == NULL)
     return NULL;
-  
+
   orig_rowstride = gdk_pixbuf_get_rowstride (orig);
   dest_rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   width = gdk_pixbuf_get_width (pixbuf);
@@ -125,7 +125,7 @@ colorize_pixbuf (GdkPixbuf *orig,
   has_alpha = gdk_pixbuf_get_has_alpha (orig);
   src_pixels = gdk_pixbuf_get_pixels (orig);
   dest_pixels = gdk_pixbuf_get_pixels (pixbuf);
-  
+
   for (y = 0; y < height; y++)
     {
       src = src_pixels + y * orig_rowstride;
@@ -134,7 +134,7 @@ colorize_pixbuf (GdkPixbuf *orig,
       for (x = 0; x < width; x++)
         {
           double dr, dg, db;
-          
+
           intensity = INTENSITY (src[0], src[1], src[2]) / 255.0;
 
           if (intensity <= 0.5)
@@ -151,11 +151,11 @@ colorize_pixbuf (GdkPixbuf *orig,
               dg = new_color->green + (1.0 - new_color->green) * (intensity - 0.5) * 2.0;
               db = new_color->blue + (1.0 - new_color->blue) * (intensity - 0.5) * 2.0;
             }
-          
+
           dest[0] = CLAMP_UCHAR (255 * dr);
           dest[1] = CLAMP_UCHAR (255 * dg);
           dest[2] = CLAMP_UCHAR (255 * db);
-          
+
           if (has_alpha)
             {
               dest[3] = src[3];
@@ -224,7 +224,7 @@ meta_frame_layout_new  (void)
   init_border (&layout->title_border);
 
   layout->title_vertical_pad = -1;
-  
+
   layout->right_titlebar_edge = -1;
   layout->left_titlebar_edge = -1;
 
@@ -235,7 +235,7 @@ meta_frame_layout_new  (void)
 
   layout->has_title = TRUE;
   layout->title_scale = 1.0;
-  
+
   init_border (&layout->button_border);
 
   return layout;
@@ -249,7 +249,7 @@ validate_border (const GtkBorder *border,
                  const char     **bad)
 {
   *bad = NULL;
-  
+
   if (border->top < 0)
     *bad = _("top");
   else if (border->bottom < 0)
@@ -394,7 +394,7 @@ meta_frame_layout_unref (MetaFrameLayout *layout)
   if (layout->refcount == 0)
     {
       DEBUG_FILL_STRUCT (layout);
-      g_free (layout);
+      free (layout);
     }
 }
 
@@ -406,7 +406,7 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
                                MetaFrameBorders      *borders)
 {
   int buttons_height, title_height, draggable_borders;
-  
+
   meta_frame_borders_clear (borders);
 
   /* For a full-screen window, we don't have any borders, visible or not. */
@@ -417,7 +417,7 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
 
   if (!layout->has_title)
     text_height = 0;
-  
+
   buttons_height = layout->button_height +
     layout->button_border.top + layout->button_border.bottom;
   title_height = text_height +
@@ -498,7 +498,7 @@ rect_for_function (MetaFrameGeometry *fgeom,
 {
 
   /* Firstly, check version-specific things. */
-  
+
   if (META_THEME_ALLOWS(theme, META_THEME_SHADE_STICK_ABOVE_BUTTONS))
     {
       switch (function)
@@ -572,7 +572,7 @@ rect_for_function (MetaFrameGeometry *fgeom,
        * be well.
        */
       return NULL;
-      
+
     case META_BUTTON_FUNCTION_LAST:
       return NULL;
     }
@@ -587,7 +587,7 @@ strip_button (MetaButtonSpace *func_rects[MAX_BUTTONS_PER_CORNER],
               MetaButtonSpace *to_strip)
 {
   int i;
-  
+
   i = 0;
   while (i < *n_rects)
     {
@@ -606,7 +606,7 @@ strip_button (MetaButtonSpace *func_rects[MAX_BUTTONS_PER_CORNER],
 
           func_rects[i] = NULL;
           bg_rects[i] = NULL;
-          
+
           return TRUE;
         }
 
@@ -634,7 +634,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   int width, height;
   int button_width, button_height;
   int min_size_for_rounding;
-  
+
   /* the left/right rects in order; the max # of rects
    * is the number of button functions
    */
@@ -646,7 +646,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   gboolean right_buttons_has_spacer[MAX_BUTTONS_PER_CORNER];
 
   MetaFrameBorders borders;
-  
+
   meta_frame_layout_get_borders (layout, text_height,
                                  flags, type,
                                  &borders);
@@ -669,7 +669,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   /* gcc warnings */
   button_width = -1;
   button_height = -1;
-  
+
   switch (layout->button_sizing)
     {
     case META_BUTTON_SIZING_ASPECT:
@@ -690,11 +690,11 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
    * code in frames.c, so isn't really allowed right now.
    * Would need left_close_rect, right_close_rect, etc.
    */
-  
+
   /* Init all button rects to 0, lame hack */
   memset (ADDRESS_OF_BUTTON_RECTS (fgeom), '\0',
           LENGTH_OF_BUTTON_RECTS);
-  
+
   n_left = 0;
   n_right = 0;
   n_left_spacers = 0;
@@ -717,7 +717,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
               ++n_left;
             }
         }
-      
+
       for (i = 0; i < MAX_BUTTONS_PER_CORNER && button_layout->right_buttons[i] != META_BUTTON_FUNCTION_LAST; i++)
         {
           right_func_rects[n_right] = rect_for_function (fgeom, flags,
@@ -763,7 +763,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
       else
         right_bg_rects[i] = &fgeom->right_middle_backgrounds[i - 1];
     }
-  
+
   /* Be sure buttons fit */
   while (n_left > 0 || n_right > 0)
     {
@@ -771,7 +771,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
       int space_available;
 
       space_available = fgeom->width - layout->left_titlebar_edge - layout->right_titlebar_edge;
-      
+
       space_used_by_buttons = 0;
 
       space_used_by_buttons += button_width * n_left;
@@ -786,7 +786,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
 
       if (space_used_by_buttons <= space_available)
         break; /* Everything fits, bail out */
-      
+
       /* First try to remove separators */
       if (n_left_spacers > 0)
         {
@@ -856,14 +856,14 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   fgeom->button_layout = *button_layout;
   fgeom->n_left_buttons = n_left;
   fgeom->n_right_buttons = n_right;
-  
+
   /* center buttons vertically */
   button_y = (borders.visible.top -
               (button_height + layout->button_border.top + layout->button_border.bottom)) / 2 + layout->button_border.top + borders.invisible.top;
 
   /* right edge of farthest-right button */
   x = width - layout->right_titlebar_edge - borders.invisible.right;
-  
+
   i = n_right - 1;
   while (i >= 0)
     {
@@ -871,7 +871,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
 
       if (x < 0) /* if we go negative, leave the buttons we don't get to as 0-width */
         break;
-      
+
       rect = right_func_rects[i];
       rect->visible.x = x - layout->button_border.right - button_width;
       if (right_buttons_has_spacer[i])
@@ -898,9 +898,9 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
         g_memmove (&(rect->clickable), &(rect->visible), sizeof(rect->clickable));
 
       *(right_bg_rects[i]) = rect->visible;
-      
+
       x = rect->visible.x - layout->button_border.left;
-      
+
       --i;
     }
 
@@ -916,7 +916,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
       MetaButtonSpace *rect;
 
       rect = left_func_rects[i];
-      
+
       rect->visible.x = x + layout->button_border.left;
       rect->visible.y = button_y;
       rect->visible.width = button_width;
@@ -969,7 +969,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
     min_size_for_rounding = 0;
   else
     min_size_for_rounding = 5;
-  
+
   fgeom->top_left_corner_rounded_radius = 0;
   fgeom->top_right_corner_rounded_radius = 0;
   fgeom->bottom_left_corner_rounded_radius = 0;
@@ -1016,9 +1016,9 @@ meta_gradient_spec_free (MetaGradientSpec *spec)
 
   g_slist_foreach (spec->color_specs, free_color_spec, NULL);
   g_slist_free (spec->color_specs);
-  
+
   DEBUG_FILL_STRUCT (spec);
-  g_free (spec);
+  free (spec);
 }
 
 LOCAL_SYMBOL GdkPixbuf*
@@ -1054,7 +1054,7 @@ meta_gradient_spec_render (const MetaGradientSpec *spec,
                                        colors, n_colors,
                                        spec->type);
 
-  g_free (colors);
+  free (colors);
 
   return pixbuf;
 }
@@ -1064,7 +1064,7 @@ meta_gradient_spec_validate (MetaGradientSpec *spec,
                              GError          **error)
 {
   g_return_val_if_fail (spec != NULL, FALSE);
-  
+
   if (g_slist_length (spec->color_specs) < 2)
     {
       g_set_error (error, META_THEME_ERROR,
@@ -1087,7 +1087,7 @@ meta_alpha_gradient_spec_new (MetaGradientType       type,
   MetaAlphaGradientSpec *spec;
 
   g_return_val_if_fail (n_alphas > 0, NULL);
-  
+
   spec = g_new0 (MetaAlphaGradientSpec, 1);
 
   spec->type = type;
@@ -1102,8 +1102,8 @@ meta_alpha_gradient_spec_free (MetaAlphaGradientSpec *spec)
 {
   g_return_if_fail (spec != NULL);
 
-  g_free (spec->alphas);
-  g_free (spec);
+  free (spec->alphas);
+  free (spec);
 }
 
 /**
@@ -1165,7 +1165,7 @@ meta_color_spec_free (MetaColorSpec *spec)
       break;
 
     case META_COLOR_SPEC_GTK_CUSTOM:
-      g_free (spec->data.gtkcustom.color_name);
+      free (spec->data.gtkcustom.color_name);
       if (spec->data.gtkcustom.fallback)
         meta_color_spec_free (spec->data.gtkcustom.fallback);
       DEBUG_FILL_STRUCT (&spec->data.gtkcustom);
@@ -1186,7 +1186,7 @@ meta_color_spec_free (MetaColorSpec *spec)
       break;
     }
 
-  g_free (spec);
+  free (spec);
 }
 
 /**
@@ -1200,7 +1200,7 @@ meta_color_spec_new_from_string (const char *str,
   MetaColorSpec *spec;
 
   spec = NULL;
-  
+
   if (str[0] == 'g' && str[1] == 't' && str[2] == 'k' && str[3] == ':' &&
       str[4] == 'c' && str[5] == 'u' && str[6] == 's' && str[7] == 't' &&
       str[8] == 'o' && str[9] == 'm')
@@ -1261,7 +1261,7 @@ meta_color_spec_new_from_string (const char *str,
           fallback_str = g_strndup (fallback_str_start,
                                     end - fallback_str_start);
           fallback = meta_color_spec_new_from_string (fallback_str, err);
-          g_free (fallback_str);
+          free (fallback_str);
         }
       else
         {
@@ -1286,7 +1286,7 @@ meta_color_spec_new_from_string (const char *str,
       char *tmp;
       GtkStateFlags state;
       MetaGtkColorComponent component;
-      
+
       bracket = str;
       while (*bracket && *bracket != '[')
         ++bracket;
@@ -1304,7 +1304,7 @@ meta_color_spec_new_from_string (const char *str,
       ++end_bracket;
       while (*end_bracket && *end_bracket != ']')
         ++end_bracket;
-      
+
       if (*end_bracket == '\0')
         {
           g_set_error (err, META_THEME_ERROR,
@@ -1322,11 +1322,11 @@ meta_color_spec_new_from_string (const char *str,
                        META_THEME_ERROR_FAILED,
                        _("Did not understand state \"%s\" in color specification"),
                        tmp);
-          g_free (tmp);
+          free (tmp);
           return NULL;
         }
-      g_free (tmp);
-      
+      free (tmp);
+
       tmp = g_strndup (str + 4, bracket - str - 4);
       component = meta_color_component_from_string (tmp);
       if (component == META_GTK_COLOR_LAST)
@@ -1335,10 +1335,10 @@ meta_color_spec_new_from_string (const char *str,
                        META_THEME_ERROR_FAILED,
                        _("Did not understand color component \"%s\" in color specification"),
                        tmp);
-          g_free (tmp);
+          free (tmp);
           return NULL;
         }
-      g_free (tmp);
+      free (tmp);
 
       spec = meta_color_spec_new (META_COLOR_SPEC_GTK);
       spec->data.gtk.state = state;
@@ -1354,9 +1354,9 @@ meta_color_spec_new_from_string (const char *str,
       char *end;
       MetaColorSpec *fg;
       MetaColorSpec *bg;
-      
+
       split = g_strsplit (str, "/", 4);
-      
+
       if (split[0] == NULL || split[1] == NULL ||
           split[2] == NULL || split[3] == NULL)
         {
@@ -1388,7 +1388,7 @@ meta_color_spec_new_from_string (const char *str,
           g_strfreev (split);
           return NULL;
         }
-      
+
       fg = NULL;
       bg = NULL;
 
@@ -1408,7 +1408,7 @@ meta_color_spec_new_from_string (const char *str,
         }
 
       g_strfreev (split);
-      
+
       spec = meta_color_spec_new (META_COLOR_SPEC_BLEND);
       spec->data.blend.alpha = alpha;
       spec->data.blend.background = bg;
@@ -1422,9 +1422,9 @@ meta_color_spec_new_from_string (const char *str,
       double factor;
       char *end;
       MetaColorSpec *base;
-      
+
       split = g_strsplit (str, "/", 3);
-      
+
       if (split[0] == NULL || split[1] == NULL ||
           split[2] == NULL)
         {
@@ -1456,7 +1456,7 @@ meta_color_spec_new_from_string (const char *str,
           g_strfreev (split);
           return NULL;
         }
-      
+
       base = NULL;
 
       base = meta_color_spec_new_from_string (split[1], err);
@@ -1467,7 +1467,7 @@ meta_color_spec_new_from_string (const char *str,
         }
 
       g_strfreev (split);
-      
+
       spec = meta_color_spec_new (META_COLOR_SPEC_SHADE);
       spec->data.shade.factor = factor;
       spec->data.shade.base = base;
@@ -1475,7 +1475,7 @@ meta_color_spec_new_from_string (const char *str,
   else
     {
       spec = meta_color_spec_new (META_COLOR_SPEC_BASIC);
-      
+
       if (!gdk_rgba_parse (&spec->data.basic.color, str))
         {
           g_set_error (err, META_THEME_ERROR,
@@ -1488,7 +1488,7 @@ meta_color_spec_new_from_string (const char *str,
     }
 
   g_assert (spec);
-  
+
   return spec;
 }
 
@@ -1640,7 +1640,7 @@ meta_color_spec_render (MetaColorSpec   *spec,
         meta_color_spec_render (spec->data.blend.background, context, &bg);
         meta_color_spec_render (spec->data.blend.foreground, context, &fg);
 
-        color_composite (&bg, &fg, spec->data.blend.alpha, 
+        color_composite (&bg, &fg, spec->data.blend.alpha,
                          &spec->data.blend.color);
 
         *color = spec->data.blend.color;
@@ -1651,8 +1651,8 @@ meta_color_spec_render (MetaColorSpec   *spec,
       {
         meta_color_spec_render (spec->data.shade.base, context,
                                 &spec->data.shade.color);
-            
-        gtk_style_shade (&spec->data.shade.color, 
+
+        gtk_style_shade (&spec->data.shade.color,
                          &spec->data.shade.color, spec->data.shade.factor);
 
         *color = spec->data.shade.color;
@@ -1706,7 +1706,7 @@ op_from_string (const char *p,
                 int        *len)
 {
   *len = 0;
-  
+
   switch (*p)
     {
     case '+':
@@ -1768,9 +1768,9 @@ free_tokens (PosToken *tokens,
 
   for (i = 0; i < n_tokens; i++)
     if (tokens[i].type == POS_TOKEN_VARIABLE)
-      g_free (tokens[i].d.v.name);
+      free (tokens[i].d.v.name);
 
-  g_free (tokens);
+  free (tokens);
 }
 
 /*
@@ -1838,7 +1838,7 @@ parse_number (const char  *p,
                        META_THEME_ERROR_FAILED,
                        _("Coordinate expression contains floating point number '%s' which could not be parsed"),
                        num_str);
-          g_free (num_str);
+          free (num_str);
           return FALSE;
         }
     }
@@ -1852,12 +1852,12 @@ parse_number (const char  *p,
                        META_THEME_ERROR_FAILED,
                        _("Coordinate expression contains integer '%s' which could not be parsed"),
                        num_str);
-          g_free (num_str);
+          free (num_str);
           return FALSE;
         }
     }
 
-  g_free (num_str);
+  free (num_str);
 
   g_assert (next->type == POS_TOKEN_INT || next->type == POS_TOKEN_DOUBLE);
 
@@ -1875,7 +1875,7 @@ debug_print_tokens (PosToken *tokens,
                     int       n_tokens)
 {
   int i;
-  
+
   for (i = 0; i < n_tokens; i++)
     {
       PosToken *t = &tokens[i];
@@ -1931,7 +1931,7 @@ pos_tokenize (const char  *expr,
   int n_tokens;
   int allocated;
   const char *p;
-  
+
   *tokens_p = NULL;
   *n_tokens_p = 0;
 
@@ -1944,7 +1944,7 @@ pos_tokenize (const char  *expr,
     {
       PosToken *next;
       int len;
-      
+
       if (n_tokens == allocated)
         {
           allocated *= 2;
@@ -1974,7 +1974,7 @@ pos_tokenize (const char  *expr,
                            META_THEME_ERROR_FAILED,
                            _("Coordinate expression contained unknown operator at the start of this text: \"%s\""),
                            p);
-              
+
               goto error;
             }
           break;
@@ -1991,7 +1991,7 @@ pos_tokenize (const char  *expr,
 
         case ' ':
         case '\t':
-        case '\n':		
+        case '\n':
           break;
 
         default:
@@ -2423,7 +2423,7 @@ pos_eval_get_variable (PosToken                  *t,
           return FALSE;
         }
     }
-  else 
+  else
     {
       if (strcmp (t->d.v.name, "width") == 0)
         *result = env->rect.width;
@@ -2472,7 +2472,7 @@ pos_eval_get_variable (PosToken                  *t,
  * \param n_tokens  How many tokens are in the list.
  * \param env  The environment context in which to evaluate the expression.
  * \param[out] result  The current value of the expression
- * 
+ *
  * \bug Yes, we really do reparse the expression every time it's evaluated.
  *      We should keep the parse tree around all the time and just
  *      run the new values through it.
@@ -2493,7 +2493,7 @@ pos_eval_helper (PosToken                   *tokens,
   PosExpr exprs[MAX_EXPRS];
   int n_exprs;
   int precedence;
-  
+
   /* Our first goal is to get a list of PosExpr, essentially
    * substituting variables and handling parentheses.
    */
@@ -2550,7 +2550,7 @@ pos_eval_helper (PosToken                   *tokens,
                */
               if (!pos_eval_get_variable (t, &exprs[n_exprs].d.int_val, env, err))
                 return FALSE;
-                  
+
               ++n_exprs;
               break;
 
@@ -2746,7 +2746,7 @@ meta_parse_size_expression (MetaDrawSpec              *spec,
 
   if (spec->constant)
     val = spec->value;
-  else 
+  else
     {
       if (pos_eval (spec, env, &spec->value, err) == FALSE)
         {
@@ -2779,37 +2779,37 @@ meta_theme_replace_constants (MetaTheme   *theme,
   double dval;
   int ival;
   gboolean is_constant = TRUE;
-  
+
   /* Loop through tokenized string looking for variables to replace */
   for (i = 0; i < n_tokens; i++)
     {
-      PosToken *t = &tokens[i];      
+      PosToken *t = &tokens[i];
 
       if (t->type == POS_TOKEN_VARIABLE)
         {
           if (meta_theme_lookup_int_constant (theme, t->d.v.name, &ival))
             {
-              g_free (t->d.v.name);
+              free (t->d.v.name);
               t->type = POS_TOKEN_INT;
               t->d.i.val = ival;
             }
           else if (meta_theme_lookup_float_constant (theme, t->d.v.name, &dval))
             {
-              g_free (t->d.v.name);
+              free (t->d.v.name);
               t->type = POS_TOKEN_DOUBLE;
               t->d.d.val = dval;
             }
-          else 
+          else
             {
               /* If we've found a variable that cannot be replaced then the
-                 expression is not a constant expression and we want to 
+                 expression is not a constant expression and we want to
                  replace it with a GQuark */
 
               t->d.v.name_quark = g_quark_from_string (t->d.v.name);
               is_constant = FALSE;
             }
         }
-    }  
+    }
 
   return is_constant;
 }
@@ -2827,10 +2827,10 @@ parse_x_position_unchecked (MetaDrawSpec              *spec,
     {
       meta_warning (_("Theme contained an expression that resulted in an error: %s\n"),
                     error->message);
-      
+
       g_error_free (error);
     }
-  
+
   return retval;
 }
 
@@ -2896,10 +2896,10 @@ meta_draw_spec_new (MetaTheme  *theme,
   spec = g_slice_new0 (MetaDrawSpec);
 
   pos_tokenize (expr, &spec->tokens, &spec->n_tokens, NULL);
-  
-  spec->constant = meta_theme_replace_constants (theme, spec->tokens, 
+
+  spec->constant = meta_theme_replace_constants (theme, spec->tokens,
                                                  spec->n_tokens, NULL);
-  if (spec->constant) 
+  if (spec->constant)
     {
       gboolean result;
 
@@ -2910,7 +2910,7 @@ meta_draw_spec_new (MetaTheme  *theme,
           return NULL;
         }
     }
-    
+
   return spec;
 }
 
@@ -2944,7 +2944,7 @@ meta_draw_op_new (MetaDrawType type)
     case META_DRAW_CLIP:
       size += sizeof (dummy.data.clip);
       break;
-      
+
     case META_DRAW_TINT:
       size += sizeof (dummy.data.tint);
       break;
@@ -3009,7 +3009,7 @@ meta_draw_op_free (MetaDrawOp *op)
       break;
 
     case META_DRAW_RECTANGLE:
-      g_free (op->data.rectangle.color_spec);
+      free (op->data.rectangle.color_spec);
       meta_draw_spec_free (op->data.rectangle.x);
       meta_draw_spec_free (op->data.rectangle.y);
       meta_draw_spec_free (op->data.rectangle.width);
@@ -3017,7 +3017,7 @@ meta_draw_op_free (MetaDrawOp *op)
       break;
 
     case META_DRAW_ARC:
-      g_free (op->data.arc.color_spec);
+      free (op->data.arc.color_spec);
       meta_draw_spec_free (op->data.arc.x);
       meta_draw_spec_free (op->data.arc.y);
       meta_draw_spec_free (op->data.arc.width);
@@ -3030,7 +3030,7 @@ meta_draw_op_free (MetaDrawOp *op)
       meta_draw_spec_free (op->data.clip.width);
       meta_draw_spec_free (op->data.clip.height);
       break;
-      
+
     case META_DRAW_TINT:
       if (op->data.tint.color_spec)
         meta_color_spec_free (op->data.tint.color_spec);
@@ -3141,7 +3141,7 @@ meta_draw_op_free (MetaDrawOp *op)
       break;
     }
 
-  g_free (op);
+  free (op);
 }
 
 static GdkPixbuf*
@@ -3151,15 +3151,15 @@ apply_alpha (GdkPixbuf             *pixbuf,
 {
   GdkPixbuf *new_pixbuf;
   gboolean needs_alpha;
-  
+
   g_return_val_if_fail (GDK_IS_PIXBUF (pixbuf), NULL);
-  
+
   needs_alpha = spec && (spec->n_alphas > 1 ||
                          spec->alphas[0] != 0xff);
 
   if (!needs_alpha)
     return pixbuf;
-  
+
   if (!gdk_pixbuf_get_has_alpha (pixbuf))
     {
       new_pixbuf = gdk_pixbuf_add_alpha (pixbuf, FALSE, 0, 0, 0);
@@ -3172,11 +3172,11 @@ apply_alpha (GdkPixbuf             *pixbuf,
       g_object_unref (G_OBJECT (pixbuf));
       pixbuf = new_pixbuf;
     }
-  
+
   g_assert (gdk_pixbuf_get_has_alpha (pixbuf));
 
   meta_gradient_add_alpha (pixbuf, spec->alphas, spec->n_alphas, spec->type);
-  
+
   return pixbuf;
 }
 
@@ -3189,10 +3189,10 @@ pixbuf_tile (GdkPixbuf *tile,
   int tile_width;
   int tile_height;
   int i, j;
-  
+
   tile_width = gdk_pixbuf_get_width (tile);
   tile_height = gdk_pixbuf_get_height (tile);
-  
+
   pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB,
                            gdk_pixbuf_get_has_alpha (tile),
                            8, width, height);
@@ -3207,7 +3207,7 @@ pixbuf_tile (GdkPixbuf *tile,
 
           w = MIN (tile_width, width - i);
           h = MIN (tile_height, height - j);
-          
+
           gdk_pixbuf_copy_area (tile,
                                 0, 0,
                                 w, h,
@@ -3216,10 +3216,10 @@ pixbuf_tile (GdkPixbuf *tile,
 
           j += tile_height;
         }
-      
+
       i += tile_width;
     }
-  
+
   return pixbuf;
 }
 
@@ -3243,7 +3243,7 @@ replicate_rows (GdkPixbuf  *src,
                            width, height);
   dest_rowstride = gdk_pixbuf_get_rowstride (result);
   dest_pixels = gdk_pixbuf_get_pixels (result);
-  
+
   for (i = 0; i < height; i++)
     memcpy (dest_pixels + dest_rowstride * i, pixels, n_channels * width);
 
@@ -3279,18 +3279,18 @@ replicate_cols (GdkPixbuf  *src,
       unsigned char r = *(q++);
       unsigned char g = *(q++);
       unsigned char b = *(q++);
-      
+
       if (n_channels == 4)
         {
           unsigned char a;
-          
+
           a = *(q++);
-          
+
           for (j = 0; j < width; j++)
             {
               *(p++) = r;
               *(p++) = g;
-              *(p++) = b;                    
+              *(p++) = b;
               *(p++) = a;
             }
         }
@@ -3411,7 +3411,7 @@ scale_and_alpha_pixbuf (GdkPixbuf             *src,
               pixbuf = replicate_rows (temp_pixbuf, 0, 0, width, height);
               g_object_unref (G_OBJECT (temp_pixbuf));
             }
-          else 
+          else
             {
               pixbuf = temp_pixbuf;
             }
@@ -3420,7 +3420,7 @@ scale_and_alpha_pixbuf (GdkPixbuf             *src,
 
   if (pixbuf)
     pixbuf = apply_alpha (pixbuf, alpha_spec, pixbuf == src);
-  
+
   return pixbuf;
 }
 
@@ -3466,7 +3466,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
 
     case META_DRAW_CLIP:
       break;
-      
+
     case META_DRAW_TINT:
       {
         GdkRGBA color;
@@ -3481,7 +3481,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
           op->data.tint.alpha_spec &&
           (op->data.tint.alpha_spec->n_alphas > 1 ||
            op->data.tint.alpha_spec->alphas[0] != 0xff);
-        
+
         pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB,
                                  has_alpha,
                                  8, width, height);
@@ -3489,7 +3489,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
         if (!has_alpha)
           {
             rgba = GDK_COLOR_RGBA (color);
-            
+
             gdk_pixbuf_fill (pixbuf, rgba);
           }
         else if (op->data.tint.alpha_spec->n_alphas == 1)
@@ -3497,13 +3497,13 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
             rgba = GDK_COLOR_RGBA (color);
             rgba &= ~0xff;
             rgba |= op->data.tint.alpha_spec->alphas[0];
-            
+
             gdk_pixbuf_fill (pixbuf, rgba);
           }
         else
           {
             rgba = GDK_COLOR_RGBA (color);
-            
+
             gdk_pixbuf_fill (pixbuf, rgba);
 
             meta_gradient_add_alpha (pixbuf,
@@ -3525,7 +3525,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
       }
       break;
 
-      
+
     case META_DRAW_IMAGE:
       {
 	if (op->data.image.colorize_spec)
@@ -3534,13 +3534,13 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
 
             meta_color_spec_render (op->data.image.colorize_spec,
                                     context, &color);
-            
+
             if (op->data.image.colorize_cache_pixbuf == NULL ||
                 op->data.image.colorize_cache_pixel != GDK_COLOR_RGB (color))
               {
                 if (op->data.image.colorize_cache_pixbuf)
                   g_object_unref (G_OBJECT (op->data.image.colorize_cache_pixbuf));
-                
+
                 /* const cast here */
                 ((MetaDrawOp*)op)->data.image.colorize_cache_pixbuf =
                   colorize_pixbuf (op->data.image.pixbuf,
@@ -3548,7 +3548,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
                 ((MetaDrawOp*)op)->data.image.colorize_cache_pixel =
                   GDK_COLOR_RGB (color);
               }
-            
+
             if (op->data.image.colorize_cache_pixbuf)
               {
                 pixbuf = scale_and_alpha_pixbuf (op->data.image.colorize_cache_pixbuf,
@@ -3570,7 +3570,7 @@ draw_op_as_pixbuf (const MetaDrawOp    *op,
 	  }
         break;
       }
-      
+
     case META_DRAW_GTK_ARROW:
     case META_DRAW_GTK_BOX:
     case META_DRAW_GTK_VLINE:
@@ -3673,7 +3673,7 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
           }
 
         x1 = parse_x_position_unchecked (op->data.line.x1, env);
-        y1 = parse_y_position_unchecked (op->data.line.y1, env); 
+        y1 = parse_y_position_unchecked (op->data.line.y1, env);
 
         if (!op->data.line.x2 &&
             !op->data.line.y2 &&
@@ -3801,16 +3801,16 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
 
     case META_DRAW_CLIP:
       break;
-      
+
     case META_DRAW_TINT:
       {
         int rx, ry, rwidth, rheight;
         gboolean needs_alpha;
-        
+
         needs_alpha = op->data.tint.alpha_spec &&
           (op->data.tint.alpha_spec->n_alphas > 1 ||
            op->data.tint.alpha_spec->alphas[0] != 0xff);
-        
+
         rx = parse_x_position_unchecked (op->data.tint.x, env);
         ry = parse_y_position_unchecked (op->data.tint.y, env);
         rwidth = parse_size_unchecked (op->data.tint.width, env);
@@ -3879,7 +3879,7 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
 
         rwidth = parse_size_unchecked (op->data.image.width, env);
         rheight = parse_size_unchecked (op->data.image.height, env);
-        
+
         pixbuf = draw_op_as_pixbuf (op, style_gtk, info,
                                     rwidth, rheight);
 
@@ -3953,7 +3953,7 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
         rx = parse_x_position_unchecked (op->data.gtk_vline.x, env);
         ry1 = parse_y_position_unchecked (op->data.gtk_vline.y1, env);
         ry2 = parse_y_position_unchecked (op->data.gtk_vline.y2, env);
-        
+
         gtk_style_context_set_state (style_gtk, op->data.gtk_vline.state);
         gtk_render_line (style_gtk, cr, rx, ry1, rx, ry2);
       }
@@ -3966,7 +3966,7 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
 
         rwidth = parse_size_unchecked (op->data.icon.width, env);
         rheight = parse_size_unchecked (op->data.icon.height, env);
-        
+
         pixbuf = draw_op_as_pixbuf (op, style_gtk, info,
                                     rwidth, rheight);
 
@@ -4056,9 +4056,9 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
     case META_DRAW_TILE:
       {
         int rx, ry, rwidth, rheight;
-        int tile_xoffset, tile_yoffset; 
+        int tile_xoffset, tile_yoffset;
         MetaRectangle tile;
-        
+
         rx = parse_x_position_unchecked (op->data.tile.x, env);
         ry = parse_y_position_unchecked (op->data.tile.y, env);
         rwidth = parse_size_unchecked (op->data.tile.width, env);
@@ -4074,12 +4074,12 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
         /* tile offset should not include x/y */
         tile_xoffset -= rect.x;
         tile_yoffset -= rect.y;
-        
+
         tile.width = parse_size_unchecked (op->data.tile.tile_width, env);
         tile.height = parse_size_unchecked (op->data.tile.tile_height, env);
 
         tile.x = rx - tile_xoffset;
-    
+
         while (tile.x < (rx + rwidth))
           {
             tile.y = ry - tile_yoffset;
@@ -4177,10 +4177,10 @@ meta_draw_op_list_unref (MetaDrawOpList *op_list)
       for (i = 0; i < op_list->n_ops; i++)
         meta_draw_op_free (op_list->ops[i]);
 
-      g_free (op_list->ops);
+      free (op_list->ops);
 
       DEBUG_FILL_STRUCT (op_list);
-      g_free (op_list);
+      free (op_list);
     }
 }
 
@@ -4197,9 +4197,9 @@ meta_draw_op_list_draw_with_style  (const MetaDrawOpList *op_list,
 
   if (op_list->n_ops == 0)
     return;
-  
+
   fill_env (&env, info, rect);
-  
+
   /* FIXME this can be optimized, potentially a lot, by
    * compressing multiple ops when possible. For example,
    * anything convertible to a pixbuf can be composited
@@ -4217,18 +4217,18 @@ meta_draw_op_list_draw_with_style  (const MetaDrawOpList *op_list,
   for (i = 0; i < op_list->n_ops; i++)
     {
       MetaDrawOp *op = op_list->ops[i];
-      
+
       if (op->type == META_DRAW_CLIP)
         {
           cairo_restore (cr);
 
-          cairo_rectangle (cr, 
+          cairo_rectangle (cr,
                            parse_x_position_unchecked (op->data.clip.x, &env),
                            parse_y_position_unchecked (op->data.clip.y, &env),
                            parse_size_unchecked (op->data.clip.width, &env),
                            parse_size_unchecked (op->data.clip.height, &env));
           cairo_clip (cr);
-          
+
           cairo_save (cr);
         }
       else if (gdk_cairo_get_clip_rectangle (cr, NULL))
@@ -4298,7 +4298,7 @@ meta_draw_op_list_contains (MetaDrawOpList    *op_list,
         {
           if (op_list->ops[i]->data.op_list.op_list == child)
             return TRUE;
-          
+
           if (meta_draw_op_list_contains (op_list->ops[i]->data.op_list.op_list,
                                           child))
             return TRUE;
@@ -4307,7 +4307,7 @@ meta_draw_op_list_contains (MetaDrawOpList    *op_list,
         {
           if (op_list->ops[i]->data.tile.op_list == child)
             return TRUE;
-          
+
           if (meta_draw_op_list_contains (op_list->ops[i]->data.tile.op_list,
                                           child))
             return TRUE;
@@ -4399,7 +4399,7 @@ meta_frame_style_unref (MetaFrameStyle *style)
         meta_frame_style_unref (style->parent);
 
       DEBUG_FILL_STRUCT (style);
-      g_free (style);
+      free (style);
     }
 }
 
@@ -4470,7 +4470,7 @@ get_button (MetaFrameStyle *style,
 {
   MetaDrawOpList *op_list;
   MetaFrameStyle *parent;
-  
+
   parent = style;
   op_list = NULL;
   while (parent && op_list == NULL)
@@ -4503,7 +4503,7 @@ get_button (MetaFrameStyle *style,
        type == META_BUTTON_TYPE_RIGHT_RIGHT_BACKGROUND))
     return get_button (style, META_BUTTON_TYPE_RIGHT_MIDDLE_BACKGROUND,
                        state);
-  
+
   /* We fall back to normal if no prelight */
   if (op_list == NULL &&
       state == META_BUTTON_STATE_PRELIGHT)
@@ -4518,7 +4518,7 @@ meta_frame_style_validate (MetaFrameStyle    *style,
                            GError           **error)
 {
   int i, j;
-  
+
   g_return_val_if_fail (style != NULL, FALSE);
   g_return_val_if_fail (style->layout != NULL, FALSE);
 
@@ -4543,7 +4543,7 @@ meta_frame_style_validate (MetaFrameStyle    *style,
             }
         }
     }
-  
+
   return TRUE;
 }
 
@@ -4562,7 +4562,7 @@ button_rect (MetaButtonType           type,
     case META_BUTTON_TYPE_LEFT_MIDDLE_BACKGROUND:
       *rect = fgeom->left_middle_backgrounds[middle_background_offset];
       break;
-      
+
     case META_BUTTON_TYPE_LEFT_RIGHT_BACKGROUND:
       *rect = fgeom->left_right_background;
       break;
@@ -4570,15 +4570,15 @@ button_rect (MetaButtonType           type,
     case META_BUTTON_TYPE_LEFT_SINGLE_BACKGROUND:
       *rect = fgeom->left_single_background;
       break;
-      
+
     case META_BUTTON_TYPE_RIGHT_LEFT_BACKGROUND:
       *rect = fgeom->right_left_background;
       break;
-      
+
     case META_BUTTON_TYPE_RIGHT_MIDDLE_BACKGROUND:
       *rect = fgeom->right_middle_backgrounds[middle_background_offset];
       break;
-      
+
     case META_BUTTON_TYPE_RIGHT_RIGHT_BACKGROUND:
       *rect = fgeom->right_right_background;
       break;
@@ -4586,7 +4586,7 @@ button_rect (MetaButtonType           type,
     case META_BUTTON_TYPE_RIGHT_SINGLE_BACKGROUND:
       *rect = fgeom->right_single_background;
       break;
-      
+
     case META_BUTTON_TYPE_CLOSE:
       *rect = fgeom->close_rect.visible;
       break;
@@ -4626,7 +4626,7 @@ button_rect (MetaButtonType           type,
     case META_BUTTON_TYPE_MENU:
       *rect = fgeom->menu_rect.visible;
       break;
-      
+
     case META_BUTTON_TYPE_LAST:
       g_assert_not_reached ();
       break;
@@ -4712,13 +4712,13 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
   draw_info.title_layout_width = title_layout ? logical_rect.width : 0;
   draw_info.title_layout_height = title_layout ? logical_rect.height : 0;
   draw_info.fgeom = fgeom;
-  
+
   /* The enum is in the order the pieces should be rendered. */
   i = 0;
   while (i < META_FRAME_PIECE_LAST)
     {
       GdkRectangle rect;
-      
+
       switch ((MetaFramePiece) i)
         {
         case META_FRAME_PIECE_ENTIRE_BACKGROUND:
@@ -4824,11 +4824,11 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
               MetaButtonState button_state;
 
               button_rect (j, fgeom, middle_bg_offset, &rect);
-              
+
               button_state = map_button_state (j, fgeom, middle_bg_offset, button_states);
 
               op_list = get_button (style, j, button_state);
-              
+
               if (op_list)
                 {
                   cairo_save (cr);
@@ -4901,7 +4901,7 @@ meta_frame_style_set_new (MetaFrameStyleSet *parent)
     meta_frame_style_set_ref (parent);
 
   style_set->refcount = 1;
-  
+
   return style_set;
 }
 
@@ -4952,7 +4952,7 @@ meta_frame_style_set_unref (MetaFrameStyleSet *style_set)
         meta_frame_style_set_unref (style_set->parent);
 
       DEBUG_FILL_STRUCT (style_set);
-      g_free (style_set);
+      free (style_set);
     }
 }
 
@@ -4963,8 +4963,8 @@ get_style (MetaFrameStyleSet *style_set,
            MetaFrameResize    resize,
            MetaFrameFocus     focus)
 {
-  MetaFrameStyle *style;  
-  
+  MetaFrameStyle *style;
+
   style = NULL;
 
   switch (state)
@@ -4980,7 +4980,7 @@ get_style (MetaFrameStyleSet *style_set,
         /* Try parent if we failed here */
         if (style == NULL && style_set->parent)
           style = get_style (style_set->parent, state, resize, focus);
-      
+
         /* Allow people to omit the vert/horz/none resize modes */
         if (style == NULL &&
             resize != META_FRAME_RESIZE_BOTH)
@@ -4992,7 +4992,7 @@ get_style (MetaFrameStyleSet *style_set,
         MetaFrameStyle **styles;
 
         styles = NULL;
-      
+
         switch (state)
           {
           case META_FRAME_STATE_MAXIMIZED:
@@ -5036,7 +5036,7 @@ get_style (MetaFrameStyleSet *style_set,
 
         /* Try parent if we failed here */
         if (style == NULL && style_set->parent)
-          style = get_style (style_set->parent, state, resize, focus);      
+          style = get_style (style_set->parent, state, resize, focus);
       }
     }
 
@@ -5077,7 +5077,7 @@ meta_frame_style_set_validate  (MetaFrameStyleSet *style_set,
                                 GError           **error)
 {
   int i, j;
-  
+
   g_return_val_if_fail (style_set != NULL, FALSE);
 
   for (i = 0; i < META_FRAME_RESIZE_LAST; i++)
@@ -5095,13 +5095,13 @@ meta_frame_style_set_validate  (MetaFrameStyleSet *style_set,
 
   if (!check_state (style_set, META_FRAME_STATE_SHADED, error))
     return FALSE;
-  
+
   if (!check_state (style_set, META_FRAME_STATE_MAXIMIZED, error))
     return FALSE;
 
   if (!check_state (style_set, META_FRAME_STATE_MAXIMIZED_AND_SHADED, error))
     return FALSE;
-  
+
   return TRUE;
 }
 
@@ -5123,12 +5123,12 @@ meta_theme_set_current (const char *name,
   GError *err;
 
   meta_topic (META_DEBUG_THEMES, "Setting current theme to \"%s\"\n", name);
-  
+
   if (!force_reload &&
       meta_current_theme &&
       strcmp (name, meta_current_theme->name) == 0)
     return;
-  
+
   err = NULL;
   new_theme = meta_theme_load (name, &err);
 
@@ -5163,33 +5163,33 @@ meta_theme_new (void)
   theme->images_by_filename =
     g_hash_table_new_full (g_str_hash,
                            g_str_equal,
-                           g_free,
+                           free,
                            (GDestroyNotify) g_object_unref);
-  
+
   theme->layouts_by_name =
     g_hash_table_new_full (g_str_hash,
                            g_str_equal,
-                           g_free,
+                           free,
                            (GDestroyNotify) meta_frame_layout_unref);
 
   theme->draw_op_lists_by_name =
     g_hash_table_new_full (g_str_hash,
                            g_str_equal,
-                           g_free,
+                           free,
                            (GDestroyNotify) meta_draw_op_list_unref);
 
   theme->styles_by_name =
     g_hash_table_new_full (g_str_hash,
                            g_str_equal,
-                           g_free,
+                           free,
                            (GDestroyNotify) meta_frame_style_unref);
 
   theme->style_sets_by_name =
     g_hash_table_new_full (g_str_hash,
                            g_str_equal,
-                           g_free,
+                           free,
                            (GDestroyNotify) meta_frame_style_set_unref);
-  
+
   /* Create our variable quarks so we can look up variables without
      having to strcmp for the names */
   theme->quark_width = g_quark_from_static_string ("width");
@@ -5215,14 +5215,14 @@ meta_theme_free (MetaTheme *theme)
 
   g_return_if_fail (theme != NULL);
 
-  g_free (theme->name);
-  g_free (theme->dirname);
-  g_free (theme->filename);
-  g_free (theme->readable_name);
-  g_free (theme->date);
-  g_free (theme->description);
-  g_free (theme->author);
-  g_free (theme->copyright);
+  free (theme->name);
+  free (theme->dirname);
+  free (theme->filename);
+  free (theme->readable_name);
+  free (theme->date);
+  free (theme->description);
+  free (theme->author);
+  free (theme->copyright);
 
   /* be more careful when destroying the theme hash tables,
      since they are only constructed as needed, and may be NULL. */
@@ -5232,11 +5232,11 @@ meta_theme_free (MetaTheme *theme)
     g_hash_table_destroy (theme->images_by_filename);
   if (theme->layouts_by_name)
     g_hash_table_destroy (theme->layouts_by_name);
-  if (theme->draw_op_lists_by_name)  
+  if (theme->draw_op_lists_by_name)
     g_hash_table_destroy (theme->draw_op_lists_by_name);
-  if (theme->styles_by_name)  
+  if (theme->styles_by_name)
     g_hash_table_destroy (theme->styles_by_name);
-  if (theme->style_sets_by_name)  
+  if (theme->style_sets_by_name)
     g_hash_table_destroy (theme->style_sets_by_name);
 
   for (i = 0; i < META_FRAME_TYPE_LAST; i++)
@@ -5244,7 +5244,7 @@ meta_theme_free (MetaTheme *theme)
       meta_frame_style_set_unref (theme->style_sets_by_type[i]);
 
   DEBUG_FILL_STRUCT (theme);
-  g_free (theme);
+  free (theme);
 }
 
 gboolean
@@ -5252,13 +5252,13 @@ meta_theme_validate (MetaTheme *theme,
                      GError   **error)
 {
   int i;
-  
+
   g_return_val_if_fail (theme != NULL, FALSE);
 
   /* FIXME what else should be checked? */
 
   g_assert (theme->name);
-  
+
   if (theme->readable_name == NULL)
     {
       /* Translators: This error means that a necessary XML tag (whose name
@@ -5306,8 +5306,8 @@ meta_theme_validate (MetaTheme *theme,
                      meta_frame_type_to_string (i),
                      theme->name,
                      meta_frame_type_to_string (i));
-        
-        return FALSE;          
+
+        return FALSE;
       }
 
   return TRUE;
@@ -5330,7 +5330,7 @@ meta_theme_load_image (MetaTheme  *theme,
 
   if (pixbuf == NULL)
     {
-       
+
       if (g_str_has_prefix (filename, "theme:") &&
           META_THEME_ALLOWS (theme, META_THEME_IMAGES_FROM_ICON_THEMES))
         {
@@ -5346,7 +5346,7 @@ meta_theme_load_image (MetaTheme  *theme,
         {
           char *full_path;
           full_path = g_build_filename (theme->dirname, filename, NULL);
-      
+
           GdkPixbuf *test_pixbuf = NULL;
           gint test_height, test_width;
 
@@ -5362,19 +5362,19 @@ meta_theme_load_image (MetaTheme  *theme,
           pixbuf = gdk_pixbuf_new_from_file_at_size (full_path, test_width, test_height, error);
           if (pixbuf == NULL)
             {
-              g_free (full_path);
+              free (full_path);
               return NULL;
             }
-      
-          g_free (full_path);
-        }      
+
+          free (full_path);
+        }
       g_hash_table_replace (theme->images_by_filename,
                             g_strdup (filename),
                             pixbuf);
     }
 
   g_assert (pixbuf);
-  
+
   g_object_ref (G_OBJECT (pixbuf));
 
   return pixbuf;
@@ -5403,7 +5403,7 @@ theme_get_style (MetaTheme     *theme,
     style_set = theme->style_sets_by_type[META_FRAME_TYPE_NORMAL];
   if (style_set == NULL)
     return NULL;
-  
+
   switch (flags & (META_FRAME_MAXIMIZED | META_FRAME_SHADED |
                    META_FRAME_TILED_LEFT | META_FRAME_TILED_RIGHT))
     {
@@ -5463,7 +5463,7 @@ theme_get_style (MetaTheme     *theme,
       resize = META_FRAME_RESIZE_LAST; /* compiler */
       break;
     }
-  
+
   /* re invert the styles used for focus/unfocussed while flashing a frame */
   if (((flags & META_FRAME_HAS_FOCUS) && !(flags & META_FRAME_IS_FLASHING))
       || (!(flags & META_FRAME_HAS_FOCUS) && (flags & META_FRAME_IS_FLASHING)))
@@ -5484,7 +5484,7 @@ meta_theme_get_frame_style (MetaTheme     *theme,
   MetaFrameStyle *style;
 
   g_return_val_if_fail (type < META_FRAME_TYPE_LAST, NULL);
-  
+
   style = theme_get_style (theme, type, flags);
 
   return style;
@@ -5498,9 +5498,9 @@ meta_theme_get_title_scale (MetaTheme     *theme,
   MetaFrameStyle *style;
 
   g_return_val_if_fail (type < META_FRAME_TYPE_LAST, 1.0);
-  
+
   style = theme_get_style (theme, type, flags);
-  
+
   /* Parser is not supposed to allow this currently */
   if (style == NULL)
     return 1.0;
@@ -5526,13 +5526,13 @@ meta_theme_draw_frame_with_style (MetaTheme              *theme,
   MetaFrameStyle *style;
 
   g_return_if_fail (type < META_FRAME_TYPE_LAST);
-  
+
   style = theme_get_style (theme, type, flags);
-  
+
   /* Parser is not supposed to allow this currently */
   if (style == NULL)
     return;
-  
+
   meta_frame_layout_calc_geometry (style->layout,
                                    text_height,
                                    flags,
@@ -5540,7 +5540,7 @@ meta_theme_draw_frame_with_style (MetaTheme              *theme,
                                    button_layout,
                                    type,
                                    &fgeom,
-                                   theme);  
+                                   theme);
 
   meta_frame_style_draw_with_style (style,
                                     style_gtk,
@@ -5611,9 +5611,9 @@ meta_theme_calc_geometry (MetaTheme              *theme,
   MetaFrameStyle *style;
 
   g_return_if_fail (type < META_FRAME_TYPE_LAST);
-  
+
   style = theme_get_style (theme, type, flags);
-  
+
   /* Parser is not supposed to allow this currently */
   if (style == NULL)
     return;
@@ -5694,7 +5694,7 @@ meta_theme_insert_style_set    (MetaTheme         *theme,
 
 static gboolean
 first_uppercase (const char *str)
-{  
+{
   return g_ascii_isupper (*str);
 }
 
@@ -5707,7 +5707,7 @@ meta_theme_define_int_constant (MetaTheme   *theme,
   if (theme->integer_constants == NULL)
     theme->integer_constants = g_hash_table_new_full (g_str_hash,
                                                       g_str_equal,
-                                                      g_free,
+                                                      free,
                                                       NULL);
 
   if (!first_uppercase (name))
@@ -5717,13 +5717,13 @@ meta_theme_define_int_constant (MetaTheme   *theme,
                    name);
       return FALSE;
     }
-  
+
   if (g_hash_table_lookup_extended (theme->integer_constants, name, NULL, NULL))
     {
       g_set_error (error, META_THEME_ERROR, META_THEME_ERROR_FAILED,
                    _("Constant \"%s\" has already been defined"),
                    name);
-      
+
       return FALSE;
     }
 
@@ -5742,10 +5742,10 @@ meta_theme_lookup_int_constant (MetaTheme   *theme,
   gpointer old_value;
 
   *value = 0;
-  
+
   if (theme->integer_constants == NULL)
     return FALSE;
-  
+
   if (g_hash_table_lookup_extended (theme->integer_constants,
                                     name, NULL, &old_value))
     {
@@ -5765,12 +5765,12 @@ meta_theme_define_float_constant (MetaTheme   *theme,
                                   GError     **error)
 {
   double *d;
-  
+
   if (theme->float_constants == NULL)
     theme->float_constants = g_hash_table_new_full (g_str_hash,
                                                     g_str_equal,
-                                                    g_free,
-                                                    g_free);
+                                                    free,
+                                                    free);
 
   if (!first_uppercase (name))
     {
@@ -5779,19 +5779,19 @@ meta_theme_define_float_constant (MetaTheme   *theme,
                    name);
       return FALSE;
     }
-  
+
   if (g_hash_table_lookup_extended (theme->float_constants, name, NULL, NULL))
     {
       g_set_error (error, META_THEME_ERROR, META_THEME_ERROR_FAILED,
                    _("Constant \"%s\" has already been defined"),
                    name);
-      
+
       return FALSE;
     }
 
   d = g_new (double, 1);
   *d = value;
-  
+
   g_hash_table_insert (theme->float_constants,
                        g_strdup (name), d);
 
@@ -5806,7 +5806,7 @@ meta_theme_lookup_float_constant (MetaTheme   *theme,
   double *d;
 
   *value = 0.0;
-  
+
   if (theme->float_constants == NULL)
     return FALSE;
 
@@ -5832,7 +5832,7 @@ meta_theme_define_color_constant (MetaTheme   *theme,
   if (theme->color_constants == NULL)
     theme->color_constants = g_hash_table_new_full (g_str_hash,
                                                     g_str_equal,
-                                                    g_free,
+                                                    free,
                                                     NULL);
 
   if (!first_uppercase (name))
@@ -5842,13 +5842,13 @@ meta_theme_define_color_constant (MetaTheme   *theme,
                    name);
       return FALSE;
     }
-  
+
   if (g_hash_table_lookup_extended (theme->color_constants, name, NULL, NULL))
     {
       g_set_error (error, META_THEME_ERROR, META_THEME_ERROR_FAILED,
                    _("Constant \"%s\" has already been defined"),
                    name);
-      
+
       return FALSE;
     }
 
@@ -5876,7 +5876,7 @@ meta_theme_lookup_color_constant (MetaTheme   *theme,
   char *result;
 
   *value = NULL;
-  
+
   if (theme->color_constants == NULL)
     return FALSE;
 
@@ -5901,7 +5901,7 @@ meta_gtk_widget_get_font_desc (GtkWidget *widget,
 {
   GtkStyleContext *style;
   PangoFontDescription *font_desc;
-  
+
   g_return_val_if_fail (gtk_widget_get_realized (widget), NULL);
 
   style = gtk_widget_get_style_context (widget);
@@ -5936,11 +5936,11 @@ meta_pango_font_desc_get_text_height (const PangoFontDescription *font_desc,
   lang = pango_context_get_language (context);
   metrics = pango_context_get_metrics (context, font_desc, lang);
 
-  retval = PANGO_PIXELS (pango_font_metrics_get_ascent (metrics) + 
+  retval = PANGO_PIXELS (pango_font_metrics_get_ascent (metrics) +
                          pango_font_metrics_get_descent (metrics));
-  
+
   pango_font_metrics_unref (metrics);
-  
+
   return retval;
 }
 
@@ -6111,7 +6111,7 @@ meta_button_type_to_string (MetaButtonType type)
     case META_BUTTON_TYPE_RIGHT_MIDDLE_BACKGROUND:
       return "right_middle_background";
     case META_BUTTON_TYPE_RIGHT_RIGHT_BACKGROUND:
-      return "right_right_background";      
+      return "right_right_background";
     case META_BUTTON_TYPE_RIGHT_SINGLE_BACKGROUND:
       return "right_single_background";
     case META_BUTTON_TYPE_LAST:
@@ -6569,7 +6569,7 @@ meta_image_fill_type_to_string (MetaImageFillType fill_type)
     case META_IMAGE_FILL_SCALE:
       return "scale";
     }
-  
+
   return "<unknown>";
 }
 
@@ -6581,7 +6581,7 @@ meta_image_fill_type_to_string (MetaImageFillType fill_type)
  * \param a  the starting colour
  * \param b  [out] the resulting colour
  * \param k  amount to scale lightness and saturation by
- */ 
+ */
 static void
 gtk_style_shade (GdkRGBA *a,
                  GdkRGBA *b,
@@ -6590,27 +6590,27 @@ gtk_style_shade (GdkRGBA *a,
   gdouble red;
   gdouble green;
   gdouble blue;
-  
+
   red = a->red;
   green = a->green;
   blue = a->blue;
-  
+
   rgb_to_hls (&red, &green, &blue);
-  
+
   green *= k;
   if (green > 1.0)
     green = 1.0;
   else if (green < 0.0)
     green = 0.0;
-  
+
   blue *= k;
   if (blue > 1.0)
     blue = 1.0;
   else if (blue < 0.0)
     blue = 0.0;
-  
+
   hls_to_rgb (&red, &green, &blue);
-  
+
   b->red = red;
   b->green = green;
   b->blue = blue;
@@ -6635,18 +6635,18 @@ rgb_to_hls (gdouble *r,
   gdouble blue;
   gdouble h, l, s;
   gdouble delta;
-  
+
   red = *r;
   green = *g;
   blue = *b;
-  
+
   if (red > green)
     {
       if (red > blue)
         max = red;
       else
         max = blue;
-      
+
       if (green < blue)
         min = green;
       else
@@ -6658,24 +6658,24 @@ rgb_to_hls (gdouble *r,
         max = green;
       else
         max = blue;
-      
+
       if (red < blue)
         min = red;
       else
         min = blue;
     }
-  
+
   l = (max + min) / 2;
   s = 0;
   h = 0;
-  
+
   if (max != min)
     {
       if (l <= 0.5)
         s = (max - min) / (max + min);
       else
         s = (max - min) / (2 - max - min);
-      
+
       delta = max -min;
       if (red == max)
         h = (green - blue) / delta;
@@ -6683,12 +6683,12 @@ rgb_to_hls (gdouble *r,
         h = 2 + (blue - red) / delta;
       else if (blue == max)
         h = 4 + (red - green) / delta;
-      
+
       h *= 60;
       if (h < 0.0)
         h += 360;
     }
-  
+
   *r = h;
   *g = l;
   *b = s;
@@ -6711,16 +6711,16 @@ hls_to_rgb (gdouble *h,
   gdouble saturation;
   gdouble m1, m2;
   gdouble r, g, b;
-  
+
   lightness = *l;
   saturation = *s;
-  
+
   if (lightness <= 0.5)
     m2 = lightness * (1 + saturation);
   else
     m2 = lightness + saturation - lightness * saturation;
   m1 = 2 * lightness - m2;
-  
+
   if (saturation == 0)
     {
       *h = lightness;
@@ -6734,7 +6734,7 @@ hls_to_rgb (gdouble *h,
         hue -= 360;
       while (hue < 0)
         hue += 360;
-      
+
       if (hue < 60)
         r = m1 + (m2 - m1) * hue / 60;
       else if (hue < 180)
@@ -6743,13 +6743,13 @@ hls_to_rgb (gdouble *h,
         r = m1 + (m2 - m1) * (240 - hue) / 60;
       else
         r = m1;
-      
+
       hue = *h;
       while (hue > 360)
         hue -= 360;
       while (hue < 0)
         hue += 360;
-      
+
       if (hue < 60)
         g = m1 + (m2 - m1) * hue / 60;
       else if (hue < 180)
@@ -6758,13 +6758,13 @@ hls_to_rgb (gdouble *h,
         g = m1 + (m2 - m1) * (240 - hue) / 60;
       else
         g = m1;
-      
+
       hue = *h - 120;
       while (hue > 360)
         hue -= 360;
       while (hue < 0)
         hue += 360;
-      
+
       if (hue < 60)
         b = m1 + (m2 - m1) * hue / 60;
       else if (hue < 180)
@@ -6773,7 +6773,7 @@ hls_to_rgb (gdouble *h,
         b = m1 + (m2 - m1) * (240 - hue) / 60;
       else
         b = m1;
-      
+
       *h = r;
       *l = g;
       *s = b;
@@ -7014,7 +7014,7 @@ meta_theme_earliest_version_with_button (MetaButtonType type)
     case META_BUTTON_TYPE_RIGHT_MIDDLE_BACKGROUND:
     case META_BUTTON_TYPE_RIGHT_RIGHT_BACKGROUND:
       return 1000;
-      
+
     case META_BUTTON_TYPE_SHADE:
     case META_BUTTON_TYPE_ABOVE:
     case META_BUTTON_TYPE_STICK:

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1142,7 +1142,7 @@ meta_color_spec_new (MetaColorSpecType type)
       break;
     }
 
-  spec = g_malloc0 (size);
+  spec = calloc (1, size);
 
   spec->type = type;
 
@@ -2984,7 +2984,7 @@ meta_draw_op_new (MetaDrawType type)
       break;
     }
 
-  op = g_malloc0 (size);
+  op = calloc (1, size);
 
   op->type = type;
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -289,7 +289,7 @@ meta_ui_remove_event_func (Display       *xdisplay,
 
   gdk_window_remove_filter (NULL, filter_func, ef);
 
-  g_free (ef);
+  free (ef);
   ef = NULL;
 }
 
@@ -331,7 +331,7 @@ meta_ui_free (MetaUI *ui)
   gdisplay = gdk_x11_lookup_xdisplay (ui->xdisplay);
   g_object_set_data (G_OBJECT (gdisplay), "meta-ui", NULL);
 
-  g_free (ui);
+  free (ui);
 }
 
 LOCAL_SYMBOL void
@@ -741,9 +741,9 @@ meta_ui_accelerator_parse (const char      *accel,
 
       gtk_accelerator_parse (replaced, NULL, keymask);
 
-      g_free (before);
-      g_free (after);
-      g_free (replaced);
+      free (before);
+      free (after);
+      free (replaced);
 
       *keysym = META_KEY_ABOVE_TAB;
       return;


### PR DESCRIPTION
This replaces a few GLib wrapper methods with direct C method calls. Through Typometer and a [window mapping test script](https://github.com/linuxmint/Cinnamon/pull/7251), I was [able to see a trend of better performance](https://docs.google.com/spreadsheets/d/1sPmE2Eod9mQ8LT0JNGAKvDTH1JIB8GsqpEZrLLAe5TA/edit?usp=sharing) using the C methods directly. While synthetic test results don't always represent normal work flows, the increase in responsiveness is noticeable during normal usage on my machine.

Note these benchmarks also use [this Cinnamon branch](https://github.com/jaszhix/Cinnamon/commits/remove-glib-wrappers).

Not seeing any regressions or memory issues introduced by this patch set so far.
