### PR TITLE
window: Cache icons if the size is <= icon_size, return a GdkPixbuf

### DIFF
--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -134,6 +134,8 @@ struct _MetaWindow
 
   GdkPixbuf *icon;
   MetaIconCache icon_cache;
+  int icon_size;
+
   Pixmap wm_hints_pixmap;
   Pixmap wm_hints_mask;
   

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -197,7 +197,6 @@ gboolean meta_window_can_resize (MetaWindow *window);
 gboolean meta_window_can_tile (MetaWindow *window, MetaTileMode mode);
 gboolean meta_window_tile (MetaWindow *window, MetaTileMode mode, gboolean snap);
 const char *meta_window_get_icon_name (MetaWindow *window);
-gboolean meta_window_create_icon (MetaWindow *window,
-                                  int         width,
-                                  int         height);
+GdkPixbuf *meta_window_create_icon (MetaWindow *window,
+                                    int         size);
 #endif


### PR DESCRIPTION
This prevents a new icon pixmap from being created on every meta_window_create_icon call.

Returning a pixbuf allows us to skip the GI prop system entirely and gives Cinnamon the icon as quickly as possible.

Requires https://github.com/linuxmint/Cinnamon/pull/8370