### PR TITLE
Support toggling vsync at runtime for better unredirection control

### DIFF
--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -135,6 +135,8 @@ G_DEFINE_TYPE_WITH_CODE (ClutterMasterClockDefault,
                          G_IMPLEMENT_INTERFACE (CLUTTER_TYPE_MASTER_CLOCK,
                                                 clutter_master_clock_iface_init));
 
+static ClutterMasterClockDefault *master_clock_global = NULL;
+
 /*
  * master_clock_is_running:
  * @master_clock: a #ClutterMasterClock
@@ -585,6 +587,38 @@ clutter_master_clock_default_class_init (ClutterMasterClockDefaultClass *klass)
   gobject_class->finalize = clutter_master_clock_default_finalize;
 }
 
+void
+clutter_master_clock_set_sync_method (gint state)
+{
+  SyncMethod method;
+
+  switch (state)
+    {
+      case 0:
+        method = SYNC_NONE;
+        g_message ("Sync method: NONE");
+        break;
+      case 1:
+        method = SYNC_PRESENTATION_TIME;
+        g_message ("Sync method: PRESENTATION TIME");
+        break;
+      case 2:
+        method = SYNC_FALLBACK;
+        g_message ("Sync method: FALLBACK");
+        break;
+      case 3:
+        method = SYNC_SWAP_THROTTLING;
+        g_message ("Sync method: SWAP THROTTLING");
+        break;
+      default:
+        method = SYNC_PRESENTATION_TIME;
+        g_warning ("Invalid sync state passed to clutter_master_clock_set_sync_method: %i", state);
+    }
+
+  master_clock_global->preferred_sync_method = method;
+  master_clock_global->active_sync_method = method;
+}
+
 static void
 clutter_master_clock_default_init (ClutterMasterClockDefault *self)
 {
@@ -592,11 +626,9 @@ clutter_master_clock_default_init (ClutterMasterClockDefault *self)
 
   source = clutter_clock_source_new (self);
   self->source = source;
+  master_clock_global = self;
 
-  self->preferred_sync_method = _clutter_get_sync_to_vblank () ?
-                                SYNC_PRESENTATION_TIME :
-                                SYNC_NONE;
-  self->active_sync_method = self->preferred_sync_method;
+  clutter_master_clock_set_sync_method (_clutter_get_sync_to_vblank ());
 
   self->ensure_next_iteration = FALSE;
   self->paused = FALSE;

--- a/clutter/clutter/clutter-muffin.h
+++ b/clutter/clutter/clutter-muffin.h
@@ -41,6 +41,13 @@ CLUTTER_AVAILABLE_IN_MUFFIN
 void            _clutter_set_sync_to_vblank     (gboolean      sync_to_vblank);
 
 CLUTTER_AVAILABLE_IN_MUFFIN
+void clutter_master_clock_set_sync_method (gint state);
+
+CLUTTER_AVAILABLE_IN_MUFFIN
+void clutter_stage_x11_update_sync_state (ClutterStage *stage,
+                                          gint          state);
+
+CLUTTER_AVAILABLE_IN_MUFFIN
 int64_t clutter_stage_get_frame_counter (ClutterStage *stage);
 
 CLUTTER_AVAILABLE_IN_MUFFIN

--- a/clutter/clutter/x11/clutter-stage-x11.c
+++ b/clutter/clutter/x11/clutter-stage-x11.c
@@ -611,6 +611,28 @@ frame_cb (CoglOnscreen  *onscreen,
   _clutter_stage_cogl_presented (stage_cogl, frame_event, &clutter_frame_info);
 }
 
+void
+clutter_stage_x11_update_sync_state (ClutterStage *stage,
+                                     gint          state)
+{
+  ClutterStageWindow *stage_window;
+  ClutterStageX11 *stage_x11;
+
+  g_return_if_fail (stage != NULL);
+
+  if (_clutter_get_sync_to_vblank () == state)
+    return;
+
+  stage_window = CLUTTER_STAGE_WINDOW (_clutter_stage_get_window (CLUTTER_STAGE (stage)));
+  stage_x11 = CLUTTER_STAGE_X11 (stage_window);
+
+  g_return_if_fail (stage_x11->onscreen != NULL);
+
+  _clutter_set_sync_to_vblank (state);
+  cogl_onscreen_set_swap_throttled (stage_x11->onscreen, state);
+  clutter_master_clock_set_sync_method (state);
+}
+
 static gboolean
 clutter_stage_x11_realize (ClutterStageWindow *stage_window)
 {

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -82,4 +82,7 @@ void meta_compositor_grab_op_end (MetaCompositor *compositor);
 
 void meta_check_end_modal (MetaScreen *screen);
 
+void meta_compositor_update_sync_state (MetaCompositor *compositor,
+                                        gboolean state);
+
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1619,3 +1619,10 @@ meta_compositor_grab_op_end (MetaCompositor *compositor)
 {
   clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }
+
+void
+meta_compositor_update_sync_state (MetaCompositor *compositor,
+                                   gboolean state)
+{
+  clutter_stage_x11_update_sync_state (compositor->stage, state);
+}

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1581,27 +1581,32 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
 LOCAL_SYMBOL void
 meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
 {
-  MetaWindow *metaWindow = meta_window_actor_get_meta_window (self);
-  MetaDisplay *display = meta_window_get_display (metaWindow);
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaWindow *metaWindow = priv->window;
+  MetaDisplay *display = metaWindow->display;
 
   Display *xdisplay = meta_display_get_xdisplay (display);
   Window  xwin = meta_window_actor_get_x_window (self);
 
+  meta_error_trap_push (display);
+
   if (state)
     {
-      meta_error_trap_push (display);
       XCompositeRedirectWindow (xdisplay, xwin, CompositeRedirectManual);
-      meta_error_trap_pop (display);
-      meta_window_actor_detach (self);
-      self->priv->unredirected = FALSE;
+      priv->unredirected = FALSE;
     }
   else
     {
-      meta_error_trap_push (display);
+      meta_window_actor_detach (self);
       XCompositeUnredirectWindow (xdisplay, xwin, CompositeRedirectManual);
-      meta_error_trap_pop (display);
-      self->priv->unredirected = TRUE;
+      priv->repaint_scheduled = TRUE;
+      priv->unredirected = TRUE;
     }
+
+  if (meta_prefs_get_unredirect_fullscreen_windows () && meta_prefs_get_sync_to_vblank ())
+    clutter_stage_x11_update_sync_state (display->compositor->stage, state);
+
+  meta_error_trap_pop (display);
 }
 
 LOCAL_SYMBOL void
@@ -2238,7 +2243,11 @@ meta_window_actor_process_damage (MetaWindowActor    *self,
 
   priv->received_damage = TRUE;
 
-  if (meta_window_is_fullscreen (priv->window) && g_list_last (compositor->windows)->data == self && !priv->unredirected)
+  /* Drop damage event for unredirected windows */
+  if (priv->unredirected)
+    return;
+
+  if (meta_window_is_fullscreen (priv->window) && g_list_last (compositor->windows)->data == self)
     {
       MetaRectangle window_rect;
       meta_window_get_outer_rect (priv->window, &window_rect);
@@ -2255,11 +2264,7 @@ meta_window_actor_process_damage (MetaWindowActor    *self,
         priv->does_full_damage = TRUE;
     }
 
-  /* Drop damage event for unredirected windows */
-  if (priv->unredirected)
-    return;
-
-  if (is_frozen (self))
+  if (priv->freeze_count)
     {
       /* The window is frozen due to an effect in progress: we ignore damage
        * here on the off chance that this will stop the corresponding

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -442,4 +442,6 @@ guint meta_display_get_above_tab_keycode (MetaDisplay *display);
 
 void meta_display_notify_restart (MetaDisplay *display);
 
+void meta_display_update_sync_state (gboolean state);
+
 #endif

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -5717,3 +5717,9 @@ meta_display_restart (MetaDisplay *display)
                    (GSourceFunc) meta_display_restart_internal,
                    display, NULL);
 }
+
+void
+meta_display_update_sync_state (gboolean state)
+{
+  meta_compositor_update_sync_state (the_display->compositor, state);
+}

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -630,6 +630,9 @@ prefs_changed_callback (MetaPreference pref,
       meta_display_set_cursor_theme (meta_prefs_get_cursor_theme (),
 				     meta_prefs_get_cursor_size ());
       break;
+    case META_PREF_SYNC_TO_VBLANK:
+      meta_display_update_sync_state (meta_prefs_get_sync_to_vblank());
+      break;
     default:
       /* handled elsewhere or otherwise */
       break;


### PR DESCRIPTION
This adds support for changing the vsync option without needing to restart Cinnamon, and by extension, enables us to more fully disable compositing overhead for games.

When both vsync and the option to disable compositing of fullscreen windows are both enabled, sync will be toggled on/off for fullscreen or monitor sized windows as they become redirected/unredirected.

Addresses #409