### PR TITLE
shadow-factory: Replace the changed signal with a function call

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -81,6 +81,8 @@
 /* #define DEBUG_TRACE g_print */
 #define DEBUG_TRACE(X)
 
+static MetaCompositor *compositor_global = NULL;
+
 static void
 frame_callback (ClutterStage     *stage,
                 CoglFrameEvent    event,
@@ -1367,13 +1369,12 @@ meta_post_paint_func (gpointer data)
   return TRUE;
 }
 
-static void
-on_shadow_factory_changed (MetaShadowFactory *factory,
-                           MetaCompositor    *compositor)
+void
+meta_compositor_on_shadow_factory_changed (void)
 {
   GList *l;
 
-  for (l = compositor->windows; l; l = l->next)
+  for (l = compositor_global->windows; l; l = l->next)
     meta_window_actor_invalidate_shadow (l->data);
 }
 
@@ -1408,11 +1409,6 @@ meta_compositor_new (MetaDisplay *display)
   XInternAtoms (xdisplay, atom_names, G_N_ELEMENTS (atom_names),
                 False, atoms);
 
-  g_signal_connect (meta_shadow_factory_get_default (),
-                    "changed",
-                    G_CALLBACK (on_shadow_factory_changed),
-                    compositor);
-
   compositor->atom_x_root_pixmap = atoms[0];
   compositor->atom_x_set_root = atoms[1];
   compositor->atom_net_wm_window_opacity = atoms[2];
@@ -1427,6 +1423,9 @@ meta_compositor_new (MetaDisplay *display)
                                            meta_post_paint_func,
                                            compositor,
                                            NULL);
+
+  compositor_global = compositor;
+
   return compositor;
 }
 

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -115,15 +115,6 @@ struct _MetaShadowFactoryClass
   GObjectClass parent_class;
 };
 
-enum
-{
-  CHANGED,
-
-  LAST_SIGNAL
-};
-
-static guint signals[LAST_SIGNAL] = { 0 };
-
 /* The first element in this array also defines the default parameters
  * for newly created classes */
 static MetaShadowClassInfo default_shadow_classes[] = {
@@ -443,14 +434,6 @@ meta_shadow_factory_class_init (MetaShadowFactoryClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->finalize = meta_shadow_factory_finalize;
-
-  signals[CHANGED] =
-    g_signal_new ("changed",
-                  G_TYPE_FROM_CLASS (object_class),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL, NULL,
-                  G_TYPE_NONE, 0);
 }
 
 LOCAL_SYMBOL MetaShadowFactory *
@@ -1016,7 +999,7 @@ meta_shadow_factory_set_params (MetaShadowFactory *factory,
 
   *stored_params = *params;
 
-  g_signal_emit (factory, signals[CHANGED], 0);
+  meta_compositor_on_shadow_factory_changed ();
 }
 
 /**

--- a/src/meta/meta-shadow-factory.h
+++ b/src/meta/meta-shadow-factory.h
@@ -81,4 +81,6 @@ void meta_shadow_factory_get_params (MetaShadowFactory *factory,
                                      gboolean           focused,
                                      MetaShadowParams  *params);
 
+void meta_compositor_on_shadow_factory_changed (void);
+
 #endif /* __META_SHADOW_FACTORY_H__ */


### PR DESCRIPTION
Muffin shouldn't rely on signals to callback into components that are within its own scope. Signals do not perform as well and they cause a lock to be placed on signal handler lookups