### PR TITLE
window: Cache the outer, client rects

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -724,14 +724,11 @@ meta_shape_cow_for_window (MetaScreen *screen,
       XserverRegion output_region;
       XRectangle screen_rect, window_bounds;
       int width, height;
-      MetaRectangle rect;
 
-      meta_window_get_outer_rect (metaWindow, &rect);
-
-      window_bounds.x = rect.x;
-      window_bounds.y = rect.y;
-      window_bounds.width = rect.width;
-      window_bounds.height = rect.height;
+      window_bounds.x = metaWindow->outer_rect.x;
+      window_bounds.y = metaWindow->outer_rect.y;
+      window_bounds.width = metaWindow->outer_rect.width;
+      window_bounds.height = metaWindow->outer_rect.height;
 
       meta_screen_get_size (screen, &width, &height);
       screen_rect.x = 0;

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2250,13 +2250,10 @@ meta_window_actor_process_damage (MetaWindowActor    *self,
 
   if (meta_window_is_fullscreen (priv->window) && g_list_last (compositor->windows)->data == self)
     {
-      MetaRectangle window_rect;
-      meta_window_get_outer_rect (priv->window, &window_rect);
-
       if (event->area.x == 0 &&
           event->area.y == 0 &&
-          window_rect.width == event->area.width &&
-          window_rect.height == event->area.height)
+          priv->window->outer_rect.width == event->area.width &&
+          priv->window->outer_rect.height == event->area.height)
         priv->full_damage_frames_count++;
       else
         priv->full_damage_frames_count = 0;

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -8,7 +8,7 @@
 #include <gdk/gdk.h> /* for gdk_rectangle_intersect() */
 
 #include <core/screen-private.h>
-
+#include <core/window-private.h>
 #include "clutter-utils.h"
 #include "compositor-private.h"
 #include "meta-window-actor-private.h"
@@ -277,7 +277,10 @@ meta_window_group_paint (ClutterActor *actor)
       cairo_rectangle_int_t unredirected_rect;
       MetaWindow *window = meta_window_actor_get_meta_window (compositor->unredirected_window);
 
-      meta_window_get_outer_rect (window, (MetaRectangle *)&unredirected_rect);
+      unredirected_rect.x = window->outer_rect.x;
+      unredirected_rect.y = window->outer_rect.y;
+      unredirected_rect.width = window->outer_rect.width;
+      unredirected_rect.height = window->outer_rect.height;
       cairo_region_subtract_rectangle (unobscured_region, &unredirected_rect);
       cairo_region_subtract_rectangle (clip_region, &unredirected_rect);
     }

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -830,20 +830,19 @@ constrain_maximization (MetaWindow         *window,
         GList *tmp = window->screen->active_workspace->snapped_windows;
         GSList *snapped_windows_as_struts = NULL;
         while (tmp) {
-            if (tmp->data == window || META_WINDOW (tmp->data)->minimized ||
-                meta_window_get_monitor (window) != meta_window_get_monitor (META_WINDOW (tmp->data))) {
-                tmp = tmp->next;
-                continue;
-            }
-            MetaStrut *strut = g_slice_new0 (MetaStrut);
-            MetaSide side;
-            MetaRectangle rect;
-            meta_window_get_outer_rect (META_WINDOW (tmp->data), &rect);
-            side = meta_window_get_tile_side (META_WINDOW (tmp->data));
-            strut->rect = rect;
-            strut->side = side;
-            snapped_windows_as_struts = g_slist_prepend (snapped_windows_as_struts, strut);
-            tmp = tmp->next;
+          MetaWindow *tmp_window = META_WINDOW (tmp->data);
+          if (tmp->data == window || tmp_window->minimized ||
+              meta_window_get_monitor (window) != meta_window_get_monitor (tmp_window)) {
+              tmp = tmp->next;
+              continue;
+          }
+          MetaStrut *strut = g_slice_new0 (MetaStrut);
+          MetaSide side;
+          side = meta_window_get_tile_side (tmp_window);
+          strut->rect = tmp_window->outer_rect;
+          strut->side = side;
+          snapped_windows_as_struts = g_slist_prepend (snapped_windows_as_struts, strut);
+          tmp = tmp->next;
         }
 
         target_size = info->current;
@@ -908,7 +907,7 @@ constrain_tiling (MetaWindow         *window,
 {
   MetaRectangle target_size;
   MetaRectangle min_size, max_size;
-  MetaRectangle actual_position;
+  MetaRectangle actual_position = window->outer_rect;
   gboolean hminbad, vminbad;
   gboolean horiz_equal, vert_equal;
   gboolean constraint_already_satisfied;
@@ -927,8 +926,6 @@ constrain_tiling (MetaWindow         *window,
     meta_window_get_current_tile_area (window, &target_size);
   else
     return TRUE;
-
-  meta_window_get_outer_rect (window, &actual_position);
 
   if (window->custom_snap_size) {
       switch (window->tile_mode) {

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -990,9 +990,12 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
         {
           MetaRectangle *new_rect;
           new_rect = g_new (MetaRectangle, 1);
-          meta_window_get_outer_rect (cur_window, new_rect);
+          new_rect->x = cur_window->outer_rect.x;
+          new_rect->y = cur_window->outer_rect.y;
+          new_rect->width = cur_window->outer_rect.width;
+          new_rect->height = cur_window->outer_rect.height;
           obscuring_windows = g_slist_prepend (obscuring_windows, new_rect);
-          window_stacking = 
+          window_stacking =
             g_slist_prepend (window_stacking, GINT_TO_POINTER (stack_position));
         }
 
@@ -1013,9 +1016,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
   cur_window_iter = stacked_windows;
   while (cur_window_iter != NULL)
     {
-      MetaRectangle  cur_rect;
       MetaWindow    *cur_window = cur_window_iter->data;
-      meta_window_get_outer_rect (cur_window, &cur_rect);
 
       /* Check if we want to use this window's edges for edge
        * resistance (note that dock edges are considered screen edges
@@ -1032,7 +1033,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
            * is offscreen (we also don't care about parts of edges covered
            * by other windows or DOCKS, but that's handled below).
            */
-          meta_rectangle_intersect (&cur_rect, 
+          meta_rectangle_intersect (&cur_window->outer_rect,
                                     &display->grab_screen->rect,
                                     &reduced);
 
@@ -1058,7 +1059,7 @@ compute_resistance_and_snapping_edges (MetaDisplay *display)
           new_edge->side_type = META_SIDE_LEFT;
           new_edge->edge_type = META_EDGE_WINDOW;
           new_edges = g_list_prepend (new_edges, new_edge);
-          
+
           /* Top side of this window is resistance for the bottom edge of
            * the window being moved.
            */
@@ -1156,7 +1157,7 @@ meta_window_edge_resistance_for_move (MetaWindow  *window,
   MetaRectangle old_outer, proposed_outer, new_outer;
   gboolean is_resize;
 
-  meta_window_get_outer_rect (window, &old_outer);
+  old_outer = window->outer_rect;
 
   proposed_outer = old_outer;
   proposed_outer.x += (*new_x - old_x);
@@ -1242,7 +1243,7 @@ meta_window_edge_resistance_for_resize (MetaWindow  *window,
   int proposed_outer_width, proposed_outer_height;
   gboolean is_resize;
 
-  meta_window_get_outer_rect (window, &old_outer);
+  old_outer = window->outer_rect;
   proposed_outer_width  = old_outer.width  + (*new_width  - old_width);
   proposed_outer_height = old_outer.height + (*new_height - old_height);
   meta_rectangle_resize_with_gravity (&old_outer, 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2620,7 +2620,7 @@ handle_move_to (MetaDisplay    *display,
 
   monitor = meta_screen_get_current_monitor (window->screen);
   meta_window_get_work_area_for_monitor (window, monitor, &work_area);
-  meta_window_get_outer_rect (window, &outer);
+  outer = window->outer_rect;
 
   if (direction & META_MOVE_TO_XCHANGE_FLAG) {
     new_x = work_area.x + (direction & META_MOVE_TO_RIGHT_FLAG ?
@@ -3108,7 +3108,7 @@ handle_move_to_monitor (MetaDisplay    *display,
   gint which = binding->handler->data;
   const MetaMonitorInfo *current, *new;
 
-  current = meta_screen_get_monitor_for_window (screen, window);
+  current = meta_screen_get_monitor_for_rect (screen, &window->outer_rect);
   new = meta_screen_get_monitor_neighbor (screen, current->number, which);
 
   if (new == NULL)
@@ -3142,15 +3142,12 @@ handle_raise_or_lower (MetaDisplay    *display,
 
   while (above)
     {
-      MetaRectangle tmp, win_rect, above_rect;
-      
+      MetaRectangle tmp;
+
       if (above->mapped && meta_window_should_be_showing(above))
         {
-          meta_window_get_outer_rect (window, &win_rect);
-          meta_window_get_outer_rect (above, &above_rect);
-          
           /* Check if obscured */
-          if (meta_rectangle_intersect (&win_rect, &above_rect, &tmp))
+          if (meta_rectangle_intersect (&window->outer_rect, &above->outer_rect, &tmp))
             {
               meta_window_raise (window);
               return;

--- a/src/core/place.c
+++ b/src/core/place.c
@@ -326,8 +326,8 @@ find_most_freespace (MetaWindow *window,
   frame_size_top  = borders ? borders->visible.top : 0;
 
   meta_window_get_work_area_current_monitor (focus_window, &work_area);
-  meta_window_get_outer_rect (focus_window, &avoid);
-  meta_window_get_outer_rect (window, &outer);
+  avoid = focus_window->outer_rect;
+  outer = window->outer_rect;
 
   /* Find the areas of choosing the various sides of the focus window */
   max_width  = MIN (avoid.width, outer.width);
@@ -453,7 +453,6 @@ rectangle_overlaps_some_window (MetaRectangle *rect,
   while (tmp != NULL)
     {
       MetaWindow *other = tmp->data;
-      MetaRectangle other_rect;      
 
       switch (other->type)
         {
@@ -476,9 +475,7 @@ rectangle_overlaps_some_window (MetaRectangle *rect,
         case META_WINDOW_UTILITY:
         case META_WINDOW_TOOLBAR:
         case META_WINDOW_MENU:
-          meta_window_get_outer_rect (other, &other_rect);
-          
-          if (meta_rectangle_intersect (rect, &other_rect, &dest))
+          if (meta_rectangle_intersect (rect, &other->outer_rect, &dest))
             return TRUE;
           break;
         }
@@ -653,13 +650,11 @@ find_first_fit (MetaWindow *window,
     while (tmp != NULL)
       {
         MetaWindow *w = tmp->data;
-        MetaRectangle outer_rect;
+        MetaRectangle outer_rect = w->outer_rect;
 
-        meta_window_get_outer_rect (w, &outer_rect);
-      
         rect.x = outer_rect.x;
         rect.y = outer_rect.y + outer_rect.height;
-      
+
         if (meta_rectangle_contains_rect (&work_area, &rect) &&
             !rectangle_overlaps_some_window (&rect, below_sorted))
           {
@@ -684,13 +679,11 @@ find_first_fit (MetaWindow *window,
     while (tmp != NULL)
       {
         MetaWindow *w = tmp->data;
-        MetaRectangle outer_rect;
-   
-        meta_window_get_outer_rect (w, &outer_rect);
-     
+        MetaRectangle outer_rect = w->outer_rect;
+
         rect.x = outer_rect.x + outer_rect.width;
         rect.y = outer_rect.y;
-   
+
         if (meta_rectangle_contains_rect (&work_area, &rect) &&
             !rectangle_overlaps_some_window (&rect, right_sorted))
           {
@@ -964,17 +957,15 @@ meta_window_place (MetaWindow        *window,
       !window->fullscreen)
     {
       MetaRectangle workarea;
-      MetaRectangle outer;
 
       meta_window_get_work_area_for_monitor (window,
                                              xi->number,
-                                             &workarea);      
-      meta_window_get_outer_rect (window, &outer);
-      
+                                             &workarea);
+
       /* If the window is bigger than the screen, then automaximize.  Do NOT
        * auto-maximize the directions independently.  See #419810.
        */
-      if (outer.width >= workarea.width && outer.height >= workarea.height)
+      if (window->outer_rect.width >= workarea.width && window->outer_rect.height >= workarea.height)
         {
           window->maximize_horizontally_after_placement = TRUE;
           window->maximize_vertically_after_placement = TRUE;

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -184,8 +184,6 @@ void          meta_screen_hide_hud_and_preview (MetaScreen *screen);
 const MetaMonitorInfo* meta_screen_get_current_monitor_info (MetaScreen    *screen);
 const MetaMonitorInfo* meta_screen_get_monitor_for_rect     (MetaScreen    *screen,
                                                              MetaRectangle *rect);
-const MetaMonitorInfo* meta_screen_get_monitor_for_window   (MetaScreen    *screen,
-                                                             MetaWindow    *window);
 
 
 const MetaMonitorInfo* meta_screen_get_monitor_neighbor (MetaScreen *screen,

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -2198,17 +2198,6 @@ meta_screen_get_monitor_for_rect (MetaScreen    *screen,
   return &screen->monitor_infos[best_monitor];
 }
 
-LOCAL_SYMBOL const MetaMonitorInfo*
-meta_screen_get_monitor_for_window (MetaScreen *screen,
-                                    MetaWindow *window)
-{
-  MetaRectangle window_rect;
-  
-  meta_window_get_outer_rect (window, &window_rect);
-
-  return meta_screen_get_monitor_for_rect (screen, &window_rect);
-}
-
 int
 meta_screen_get_monitor_index_for_rect (MetaScreen    *screen,
                                         MetaRectangle *rect)

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -1415,18 +1415,6 @@ meta_stack_get_below (MetaStack      *stack,
     return below;
 }
 
-static gboolean
-window_contains_point (MetaWindow *window,
-                       int         root_x,
-                       int         root_y)
-{
-  MetaRectangle rect;
-
-  meta_window_get_outer_rect (window, &rect);
-
-  return POINT_IN_RECT (root_x, root_y, rect);
-}
-
 static MetaWindow*
 get_default_focus_window (MetaStack     *stack,
                           MetaWorkspace *workspace,
@@ -1474,6 +1462,8 @@ get_default_focus_window (MetaStack     *stack,
           (workspace == NULL ||
            meta_window_located_on_workspace (window, workspace)))
         {
+          gboolean has_point = POINT_IN_RECT (root_x, root_y, window->outer_rect);
+
           if (topmost_dock == NULL &&
               window->type == META_WINDOW_DOCK)
             topmost_dock = window;
@@ -1483,15 +1473,13 @@ get_default_focus_window (MetaStack     *stack,
               if (transient_parent == NULL &&
                   not_this_one->xtransient_for != None &&
                   not_this_one->xtransient_for == window->xwindow &&
-                  (!must_be_at_point ||
-                   window_contains_point (window, root_x, root_y)))
+                  (!must_be_at_point || has_point))
                 transient_parent = window;
 
               if (topmost_in_group == NULL &&
                   not_this_one_group != NULL &&
                   not_this_one_group == meta_window_get_group (window) &&
-                  (!must_be_at_point ||
-                   window_contains_point (window, root_x, root_y)))
+                  (!must_be_at_point || has_point))
                 topmost_in_group = window;
             }
 
@@ -1501,8 +1489,7 @@ get_default_focus_window (MetaStack     *stack,
            */
           if (topmost_overall == NULL &&
               window->type != META_WINDOW_DOCK &&
-              (!must_be_at_point ||
-               window_contains_point (window, root_x, root_y)))
+              (!must_be_at_point || has_point))
             topmost_overall = window;
 
           /* We could try to bail out early here for efficiency in

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -457,6 +457,8 @@ struct _MetaWindow
    * of the top left of the inner window) as appropriate.
    */
   MetaRectangle rect;
+  MetaRectangle outer_rect;
+  cairo_rectangle_int_t client_area;
 
   gboolean has_custom_frame_extents;
   GtkBorder custom_frame_extents;

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -9,12 +9,12 @@
  * which the rest of the world is allowed to use.)
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2003, 2004 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -24,7 +24,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -110,7 +110,7 @@ typedef enum
 struct _MetaWindow
 {
   GObject parent_instance;
-  
+
   MetaDisplay *display;
   MetaScreen *screen;
   const MetaMonitorInfo *monitor;
@@ -138,10 +138,10 @@ struct _MetaWindow
 
   Pixmap wm_hints_pixmap;
   Pixmap wm_hints_mask;
-  
+
   MetaWindowType type;
   Atom type_atom;
-  
+
   /* NOTE these five are not in UTF-8, we just treat them as random
    * binary data
    */
@@ -160,20 +160,20 @@ struct _MetaWindow
   char *gtk_window_object_path;
   char *gtk_app_menu_object_path;
   char *gtk_menubar_object_path;
-  
+
   int hide_titlebar_when_maximized;
   int net_wm_pid;
-  
+
   Window xtransient_for;
   Window xgroup_leader;
   Window xclient_leader;
 
   /* Initial workspace property */
-  int initial_workspace;  
-  
+  int initial_workspace;
+
   /* Initial timestamp property */
-  guint32 initial_timestamp;  
-  
+  guint32 initial_timestamp;
+
   /* Whether this is an override redirect window or not */
   guint override_redirect : 1;
 
@@ -233,7 +233,7 @@ struct _MetaWindow
    * these monitors.  If not, this is the single monitor which the window's
    * origin is on. */
   long fullscreen_monitors[4];
-  
+
   /* Whether we're trying to constrain the window to be fully onscreen */
   guint require_fully_onscreen : 1;
 
@@ -262,7 +262,7 @@ struct _MetaWindow
    * see also unmaps_pending
    */
   guint mapped : 1;
-  
+
   /* Whether window has been hidden from view by lowering it to the bottom
    * of window stack.
    */
@@ -288,23 +288,23 @@ struct _MetaWindow
 
   /* whether an initial workspace was explicitly set */
   guint initial_workspace_set : 1;
-  
+
   /* whether an initial timestamp was explicitly set */
   guint initial_timestamp_set : 1;
-  
+
   /* whether net_wm_user_time has been set yet */
   guint net_wm_user_time_set : 1;
 
   /* whether net_wm_icon_geometry has been set */
   guint icon_geometry_set: 1;
-  
+
   /* These are the flags from WM_PROTOCOLS */
   guint take_focus : 1;
   guint delete_window : 1;
   guint net_wm_ping : 1;
   /* Globally active / No input */
   guint input : 1;
-  
+
   /* MWM hints about features of window */
   guint mwm_decorated : 1;
   guint mwm_border_only : 1;
@@ -313,7 +313,7 @@ struct _MetaWindow
   guint mwm_has_maximize_func : 1;
   guint mwm_has_move_func : 1;
   guint mwm_has_resize_func : 1;
-  
+
   /* Computed features of window */
   guint decorated : 1;
   guint border_only : 1;
@@ -325,7 +325,7 @@ struct _MetaWindow
   guint has_move_func : 1;
   guint has_resize_func : 1;
   guint has_fullscreen_func : 1;
-  
+
   /* Weird "_NET_WM_STATE_MODAL" flag */
   guint wm_state_modal : 1;
 
@@ -343,7 +343,7 @@ struct _MetaWindow
 
   /* EWHH demands attention flag */
   guint wm_state_demands_attention : 1;
-  
+
   /* this flag tracks receipt of focus_in focus_out */
   guint has_focus : 1;
 
@@ -364,15 +364,15 @@ struct _MetaWindow
 
   /* Are we in meta_window_new()? */
   guint constructing : 1;
-  
+
   /* Are we in the various queues? (Bitfield: see META_WINDOW_IS_IN_QUEUE) */
   guint is_in_queues : NUMBER_OF_QUEUES;
- 
+
   /* Used by keybindings.c */
   guint keys_grabbed : 1;     /* normal keybindings grabbed */
   guint grab_on_frame : 1;    /* grabs are on the frame */
   guint all_keys_grabbed : 1; /* AnyKey grabbed */
-  
+
   /* Set if the reason for unmanaging the window is that
    * it was withdrawn
    */
@@ -397,7 +397,7 @@ struct _MetaWindow
 
   /* icon props have changed */
   guint need_reread_icon : 1;
-  
+
   /* if TRUE, window was maximized at start of current grab op */
   guint shaken_loose : 1;
 
@@ -432,7 +432,7 @@ struct _MetaWindow
   /* alarm monitoring client's _NET_WM_SYNC_REQUEST_COUNTER */
   XSyncAlarm sync_request_alarm;
 #endif
-  
+
   /* Number of UnmapNotify that are caused by us, if
    * we get UnmapNotify with none pending then the client
    * is withdrawing the window.
@@ -448,11 +448,11 @@ struct _MetaWindow
 
   /* window that gets updated net_wm_user_time values */
   Window user_time_window;
-  
+
   /* The size we set the window to last (i.e. what we believe
    * to be its actual size on the server). The x, y are
    * the actual server-side x,y so are relative to the frame
-   * (meaning that they just hold the frame width and height) 
+   * (meaning that they just hold the frame width and height)
    * or the root window (meaning they specify the location
    * of the top left of the inner window) as appropriate.
    */
@@ -496,7 +496,7 @@ struct _MetaWindow
   /* Managed by stack.c */
   MetaStackLayer layer;
   int stack_position; /* see comment in stack.h */
-  
+
   /* Current dialog open for this window */
   int dialog_pid;
 
@@ -788,6 +788,7 @@ void meta_window_recalc_features    (MetaWindow *window);
 void meta_window_recalc_window_type (MetaWindow *window);
 
 void meta_window_frame_size_changed (MetaWindow *window);
+void meta_window_update_rects (MetaWindow *window);
 
 void meta_window_stack_just_below (MetaWindow *window,
                                    MetaWindow *below_this_one);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -149,6 +149,9 @@ static unsigned int get_mask_from_snap_keysym (MetaWindow *window);
 static void update_edge_constraints (MetaWindow *window);
 static void update_gtk_edge_constraints (MetaWindow *window);
 
+static void get_outer_rect (const MetaWindow *window,
+                            MetaRectangle    *rect);
+
 /* Idle handlers for the three queues (run with meta_later_add()). The
  * "data" parameter in each case will be a GINT_TO_POINTER of the
  * index into the queue arrays to use.
@@ -3632,6 +3635,9 @@ meta_window_get_all_monitors (MetaWindow *window, gsize *length)
     }
   else
     {
+      if (window->fullscreen)
+        get_outer_rect (window, &window->outer_rect);
+
       window_rect = window->outer_rect;
     }
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5893,6 +5893,13 @@ void
 meta_window_get_outer_rect (const MetaWindow *window,
                             MetaRectangle    *rect)
 {
+  *rect = window->outer_rect;
+}
+
+static void
+get_outer_rect (const MetaWindow *window,
+                MetaRectangle    *rect)
+{
   if (window->frame)
     {
       MetaFrameBorders borders;
@@ -5931,6 +5938,13 @@ meta_window_get_outer_rect (const MetaWindow *window,
 void
 meta_window_get_client_area_rect (const MetaWindow      *window,
                                   cairo_rectangle_int_t *rect)
+{
+  *rect = window->client_area;
+}
+
+static void
+get_client_area_rect (const MetaWindow      *window,
+                      cairo_rectangle_int_t *rect)
 {
   if (window->frame)
     {
@@ -8402,6 +8416,9 @@ meta_window_frame_size_changed (MetaWindow *window)
 {
   if (window->frame)
     meta_frame_clear_cached_borders (window->frame);
+
+  get_outer_rect (window, &window->outer_rect);
+  get_client_area_rect (window, &window->client_area);
 }
 
 static void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8403,13 +8403,19 @@ recalc_window_type (MetaWindow *window)
 }
 
 void
+meta_window_update_rects (MetaWindow *window)
+{
+  get_outer_rect (window, &window->outer_rect);
+  get_client_area_rect (window, &window->client_area);
+}
+
+void
 meta_window_frame_size_changed (MetaWindow *window)
 {
   if (window->frame)
     meta_frame_clear_cached_borders (window->frame);
 
-  get_outer_rect (window, &window->outer_rect);
-  get_client_area_rect (window, &window->client_area);
+  meta_window_update_rects (window);
 }
 
 static void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1291,7 +1291,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
 
   window->compositor_private = NULL;
 
-  window->monitor = meta_screen_get_monitor_for_window (window->screen, window);
+  window->monitor = meta_screen_get_monitor_for_rect (window->screen, &window->outer_rect);
 
   window->tile_match = NULL;
 
@@ -2234,14 +2234,12 @@ set_net_wm_state (MetaWindow *window)
 
   if (window->tile_type != META_WINDOW_TILE_TYPE_NONE)
   {
-    MetaRectangle rect;
-    meta_window_get_outer_rect (window, &rect);
     data[0] = (unsigned long) window->tile_mode;
     data[1] = (unsigned long) window->tile_type;
-    data[2] = (unsigned long) rect.x;
-    data[3] = (unsigned long) rect.y;
-    data[4] = (unsigned long) rect.width;
-    data[5] = (unsigned long) rect.height;
+    data[2] = (unsigned long) window->outer_rect.x;
+    data[3] = (unsigned long) window->outer_rect.y;
+    data[4] = (unsigned long) window->outer_rect.width;
+    data[5] = (unsigned long) window->outer_rect.height;
     data[6] = (unsigned long) window->tile_monitor_number;
     data[7] = (unsigned long) window->custom_snap_size ? 1 : 0;
 
@@ -2923,15 +2921,6 @@ window_state_on_map (MetaWindow *window,
     }
 }
 
-static gboolean
-windows_overlap (const MetaWindow *w1, const MetaWindow *w2)
-{
-  MetaRectangle w1rect, w2rect;
-  meta_window_get_outer_rect (w1, &w1rect);
-  meta_window_get_outer_rect (w2, &w2rect);
-  return meta_rectangle_overlap (&w1rect, &w2rect);
-}
-
 /* Returns whether a new window would be covered by any
  * existing window on the same workspace that is set
  * to be "above" ("always on top").  A window that is not
@@ -2959,7 +2948,7 @@ window_would_be_covered (const MetaWindow *newbie)
       if (w->wm_state_above && w != newbie)
         {
           /* We have found a window that is "above". Perhaps it overlaps. */
-          if (windows_overlap (w, newbie))
+          if (meta_rectangle_overlap (&w->outer_rect, &newbie->outer_rect))
             {
               g_list_free (windows); /* clean up... */
               return TRUE; /* yes, it does */
@@ -3072,7 +3061,7 @@ meta_window_show (MetaWindow *window)
 
       takes_focus_on_map = FALSE;
 
-      overlap = windows_overlap (window, focus_window);
+      overlap = meta_rectangle_overlap (&window->outer_rect, &focus_window->outer_rect);
 
       /* We want alt tab to go to the denied-focus window */
       ensure_mru_position_after (window, focus_window);
@@ -3573,21 +3562,19 @@ meta_window_maximize (MetaWindow        *window,
                                    saved_rect);
 
     MetaRectangle old_rect;
-    MetaRectangle new_rect;
     gboolean desktop_effects = meta_prefs_get_desktop_effects ();
 
     if (desktop_effects)
-      meta_window_get_outer_rect (window, &old_rect);
+      old_rect = window->outer_rect;
 
     meta_window_move_resize_now (window);
 
     if (desktop_effects)
       {
-        meta_window_get_outer_rect (window, &new_rect);
         meta_compositor_maximize_window (window->display->compositor,
                                         window,
                                         &old_rect,
-                                        &new_rect);
+                                        &window->outer_rect);
       }
     }
 
@@ -3645,7 +3632,7 @@ meta_window_get_all_monitors (MetaWindow *window, gsize *length)
     }
   else
     {
-      meta_window_get_outer_rect (window, &window_rect);
+      window_rect = window->outer_rect;
     }
 
   for (i = 0; i < window->screen->n_monitor_infos; i++)
@@ -3691,19 +3678,18 @@ meta_window_is_monitor_sized (MetaWindow *window)
 
   if (window->override_redirect)
     {
-      MetaRectangle window_rect, monitor_rect;
+      MetaRectangle monitor_rect;
       int screen_width, screen_height;
 
       meta_screen_get_size (window->screen, &screen_width, &screen_height);
-      meta_window_get_outer_rect (window, &window_rect);
 
-      if (window_rect.x == 0 && window_rect.y == 0 &&
-          window_rect.width == screen_width && window_rect.height == screen_height)
+      if (window->outer_rect.x == 0 && window->outer_rect.y == 0 &&
+          window->outer_rect.width == screen_width && window->outer_rect.height == screen_height)
         return TRUE;
 
       meta_screen_get_monitor_geometry (window->screen, window->monitor->number, &monitor_rect);
 
-      if (meta_rectangle_equal (&window_rect, &monitor_rect))
+      if (meta_rectangle_equal (&window->outer_rect, &monitor_rect))
         return TRUE;
     }
 
@@ -3819,7 +3805,7 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
   set_net_wm_state (window);
 
   meta_screen_tile_preview_hide (window->screen);
-  meta_window_get_outer_rect (window, &window->snapped_rect);
+  window->snapped_rect = window->outer_rect;
 }
 
 static gboolean
@@ -4010,11 +3996,11 @@ meta_window_unmaximize_internal (MetaWindow        *window,
 
       if (window->resizing_tile_type == META_WINDOW_TILE_TYPE_NONE)
         {
-          MetaRectangle old_rect, new_rect;
+          MetaRectangle old_rect;
           gboolean desktop_effects = meta_prefs_get_desktop_effects ();
 
           if (desktop_effects)
-            meta_window_get_outer_rect (window, &old_rect);
+            old_rect = window->outer_rect;
 
           meta_window_move_resize_internal (window,
                                             META_IS_MOVE_ACTION | META_IS_RESIZE_ACTION,
@@ -4026,11 +4012,10 @@ meta_window_unmaximize_internal (MetaWindow        *window,
 
           if (desktop_effects)
             {
-              meta_window_get_outer_rect (window, &new_rect);
               meta_compositor_unmaximize_window (window->display->compositor,
                                                 window,
                                                 &old_rect,
-                                                &new_rect);
+                                                &window->outer_rect);
             }
         }
       else
@@ -4895,7 +4880,7 @@ meta_window_update_monitor (MetaWindow *window)
   const MetaMonitorInfo *old;
 
   old = window->monitor;
-  window->monitor = meta_screen_get_monitor_for_window (window->screen, window);
+  window->monitor = meta_screen_get_monitor_for_rect (window->screen, &window->outer_rect);
   if (old != window->monitor)
     {
       meta_window_update_on_all_workspaces (window);
@@ -6004,7 +5989,7 @@ void
 meta_window_get_titlebar_rect (MetaWindow *window,
                                MetaRectangle *rect)
 {
-  meta_window_get_outer_rect (window, rect);
+  *rect = window->outer_rect;
 
   /* The returned rectangle is relative to the frame rect. */
   rect->x = 0;
@@ -9032,7 +9017,6 @@ meta_window_show_menu (MetaWindow *window,
 LOCAL_SYMBOL void
 meta_window_shove_titlebar_onscreen (MetaWindow *window)
 {
-  MetaRectangle  outer_rect;
   GList         *onscreen_region;
   int            horiz_amount, vert_amount;
   int            newx, newy;
@@ -9044,15 +9028,14 @@ meta_window_shove_titlebar_onscreen (MetaWindow *window)
     return;
 
   /* Get the basic info we need */
-  meta_window_get_outer_rect (window, &outer_rect);
   onscreen_region = window->screen->active_workspace->screen_region;
 
   /* Extend the region (just in case the window is too big to fit on the
    * screen), then shove the window on screen, then return the region to
    * normal.
    */
-  horiz_amount = outer_rect.width;
-  vert_amount  = outer_rect.height;
+  horiz_amount = window->outer_rect.width;
+  vert_amount  = window->outer_rect.height;
   meta_rectangle_expand_region (onscreen_region,
                                 horiz_amount,
                                 horiz_amount,
@@ -9060,15 +9043,15 @@ meta_window_shove_titlebar_onscreen (MetaWindow *window)
                                 vert_amount);
   meta_rectangle_shove_into_region(onscreen_region,
                                    FIXED_DIRECTION_X,
-                                   &outer_rect);
+                                   &window->outer_rect);
   meta_rectangle_expand_region (onscreen_region,
                                 -horiz_amount,
                                 -horiz_amount,
                                 0,
                                 -vert_amount);
 
-  newx = outer_rect.x + window->frame->child_x;
-  newy = outer_rect.y + window->frame->child_y;
+  newx = window->outer_rect.x + window->frame->child_x;
+  newy = window->outer_rect.y + window->frame->child_y;
   meta_window_move_resize (window,
                            FALSE,
                            newx,
@@ -9093,7 +9076,7 @@ meta_window_titlebar_is_onscreen (MetaWindow *window)
     return FALSE;
 
   /* Get the rectangle corresponding to the titlebar */
-  meta_window_get_outer_rect (window, &titlebar_rect);
+  titlebar_rect = window->outer_rect;
   titlebar_rect.height = window->frame->child_y;
 
   /* Run through the spanning rectangles for the screen and see if one of
@@ -9499,7 +9482,7 @@ update_move (MetaWindow  *window,
       int monitor;
 
       window->tile_mode = META_TILE_NONE;
-      wmonitor = meta_screen_get_monitor_for_window (window->screen, window);
+      wmonitor = meta_screen_get_monitor_for_rect (window->screen, &window->outer_rect);
 
       for (monitor = 0; monitor < window->screen->n_monitor_infos; monitor++)
         {
@@ -10410,8 +10393,7 @@ meta_window_get_work_area_current_monitor (MetaWindow    *window,
                                            MetaRectangle *area)
 {
   const MetaMonitorInfo *monitor = NULL;
-  monitor = meta_screen_get_monitor_for_window (window->screen,
-                                                window);
+  monitor = meta_screen_get_monitor_for_rect (window->screen, &window->outer_rect);
 
   meta_window_get_work_area_for_monitor (window,
                                          monitor->number,
@@ -10873,15 +10855,13 @@ warp_grab_pointer (MetaWindow          *window,
                    int                 *x,
                    int                 *y)
 {
-  MetaRectangle  rect;
+  MetaRectangle  rect = window->outer_rect;
   MetaDisplay   *display;
 
   display = window->display;
 
   /* We may not have done begin_grab_op yet, i.e. may not be in a grab
    */
-
-  meta_window_get_outer_rect (window, &rect);
 
   switch (grab_op)
     {
@@ -11225,7 +11205,6 @@ meta_window_get_stable_sequence (MetaWindow *window)
 void
 meta_window_set_demands_attention (MetaWindow *window)
 {
-  MetaRectangle candidate_rect, other_rect;
   GList *stack = window->screen->stack->sorted;
   MetaWindow *other_window;
   gboolean obscured = FALSE;
@@ -11246,8 +11225,6 @@ meta_window_set_demands_attention (MetaWindow *window)
     }
   else
     {
-      meta_window_get_outer_rect (window, &candidate_rect);
-
       /* The stack is sorted with the top windows first. */
 
       while (stack != NULL && stack->data != window)
@@ -11259,9 +11236,7 @@ meta_window_set_demands_attention (MetaWindow *window)
               window->on_all_workspaces ||
               other_window->workspace == window->workspace)
             {
-              meta_window_get_outer_rect (other_window, &other_rect);
-
-              if (meta_rectangle_overlap (&candidate_rect, &other_rect))
+              if (meta_rectangle_overlap (&window->outer_rect, &other_window->outer_rect))
                 {
                   obscured = TRUE;
                   break;
@@ -12033,7 +12008,6 @@ meta_window_compute_tile_match (MetaWindow *window)
   if (match)
     {
       MetaWindow *above, *bottommost, *topmost;
-      MetaRectangle above_rect, bottommost_rect, topmost_rect;
 
       if (meta_stack_windows_cmp (window->screen->stack, match, window) > 0)
         {
@@ -12046,8 +12020,6 @@ meta_window_compute_tile_match (MetaWindow *window)
           bottommost = match;
         }
 
-      meta_window_get_outer_rect (bottommost, &bottommost_rect);
-      meta_window_get_outer_rect (topmost, &topmost_rect);
       /*
        * If there's a window stacked in between which is partially visible
        * behind the topmost tile we don't consider the tiles to match.
@@ -12061,10 +12033,8 @@ meta_window_compute_tile_match (MetaWindow *window)
               meta_window_get_workspace (above) != meta_window_get_workspace (window))
             continue;
 
-          meta_window_get_outer_rect (above, &above_rect);
-
-          if (meta_rectangle_overlap (&above_rect, &bottommost_rect) &&
-              meta_rectangle_overlap (&above_rect, &topmost_rect))
+          if (meta_rectangle_overlap (&above->outer_rect, &bottommost->outer_rect) &&
+              meta_rectangle_overlap (&above->outer_rect, &topmost->outer_rect))
             return;
         }
 


### PR DESCRIPTION
Split from #410.

This caches the outer and client rects, and updates them when the window size changes. The placement of the update calls were chosen based on a [previous upstream optimization](https://github.com/linuxmint/muffin/commit/8779c27f78150970b98e5681acfb5b792d8fea35) for caching frame borders.