### PR TITLE
Avoid getting context from Clutter in frequently called functions

### DIFF
--- a/src/compositor/cogl-utils.h
+++ b/src/compositor/cogl-utils.h
@@ -25,6 +25,7 @@
 
 #include <cogl/cogl.h>
 #include <clutter/clutter.h>
+#include <compositor/compositor-private.h>
 
 CoglTexture * meta_create_color_texture_4ub (guint8           red,
                                              guint8           green,

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -62,6 +62,8 @@ struct _MetaCompositor
 /* Wait 2ms after vblank before starting to draw next frame */
 #define META_SYNC_DELAY 0
 
+CoglContext * meta_compositor_get_cogl_context (void);
+
 void meta_switch_workspace_completed (MetaScreen    *screen);
 
 gboolean meta_begin_modal_for_plugin (MetaScreen       *screen,

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1619,6 +1619,12 @@ meta_compositor_grab_op_end (MetaCompositor *compositor)
   clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
+CoglContext *
+meta_compositor_get_cogl_context (void)
+{
+  return compositor_global->context;
+}
+
 void
 meta_compositor_update_sync_state (MetaCompositor *compositor,
                                    gboolean state)

--- a/src/compositor/meta-sync-ring.c
+++ b/src/compositor/meta-sync-ring.c
@@ -158,6 +158,8 @@ check_gl_extensions (void)
   cogl_display = cogl_context_get_display (cogl_context);
   cogl_renderer = cogl_display_get_renderer (cogl_display);
 
+  meta_cogl_hardware_supports_npot_sizes ();
+
   switch (cogl_renderer_get_driver (cogl_renderer))
     {
     case COGL_DRIVER_GL3:

--- a/src/compositor/meta-texture-tower.c
+++ b/src/compositor/meta-texture-tower.c
@@ -366,11 +366,9 @@ texture_tower_create_texture (MetaTextureTower *tower,
   if ((!is_power_of_two (width) || !is_power_of_two (height)) &&
       meta_texture_rectangle_check (tower->textures[level - 1]))
     {
-      ClutterBackend *backend = clutter_get_default_backend ();
-      CoglContext *context = clutter_backend_get_cogl_context (backend);
       CoglTextureRectangle *texture_rectangle;
 
-      texture_rectangle = cogl_texture_rectangle_new_with_size (context, width, height);
+      texture_rectangle = cogl_texture_rectangle_new_with_size (meta_compositor_get_cogl_context (), width, height);
       tower->textures[level] = COGL_TEXTURE (texture_rectangle);
     }
   else
@@ -416,9 +414,7 @@ texture_tower_revalidate (MetaTextureTower *tower,
 
   if (!tower->pipeline_template)
     {
-      CoglContext *ctx =
-        clutter_backend_get_cogl_context (clutter_get_default_backend ());
-      tower->pipeline_template = cogl_pipeline_new (ctx);
+      tower->pipeline_template = cogl_pipeline_new (meta_compositor_get_cogl_context ());
       cogl_pipeline_set_blend (tower->pipeline_template, "RGBA = ADD (SRC_COLOR, 0)", NULL);
     }
 


### PR DESCRIPTION
Split from #410.

This reduces calls to `clutter_get_default_backend`, which calls `_clutter_context_get_default`, and causes a synchronous lock to be placed on ClutterContext - this isn't necessary for Muffin's configuration.

Initially tried to repurpose the static pointer in cogl-utils.c, but this resulted in a massive memory leak. This adds a getter to MetaCompositor and uses its reference instead.

Also makes hardware_supports_npot_sizes public so it can only be called once when GL extensions are checked.