### PR TITLE
Fix monitor assignment for windows

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5362,6 +5362,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
 
   meta_window_refresh_resize_popup (window);
 
+  meta_window_update_monitor (window);
+
   /* Invariants leaving this function are:
    *   a) window->rect and frame->rect reflect the actual
    *      server-side size/pos of window->xwindow and frame->xwindow


### PR DESCRIPTION
Since #410, windows were not always assigned to the correct monitor.
This reverts the diff-chunk https://github.com/linuxmint/muffin/commit/48f669aa22c91b0056f912cbc055c7eccff848a4#diff-029d285c3238fbe60d57f513265e1723L5388 to fix it.