### PR TITLE
screen: Ensure monitors update on monitor change

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3065,7 +3065,12 @@ meta_screen_resize (MetaScreen *screen,
       MetaWindow *window = tmp->data;
 
       if (window->screen == screen)
-        meta_window_update_for_monitors_changed (window);
+        {
+          meta_window_update_for_monitors_changed (window);
+
+          if (!window->override_redirect)
+            meta_window_update_monitor (window);
+        }
     }
 
   g_free (old_monitor_infos);


### PR DESCRIPTION
Addresses the same issue as #438, but more selectively calls `meta_window_update_monitor`.