### PR TITLE
Replace some deprecated GDK methods

### DIFF
--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -39,6 +39,7 @@
 #include <meta/display.h>
 #include "keybindings-private.h"
 #include <meta/prefs.h>
+#include "ui.h"
 
 #ifdef HAVE_STARTUP_NOTIFICATION
 #include <libsn/sn.h>
@@ -81,10 +82,13 @@ struct _MetaDisplay
   char *name;
   Display *xdisplay;
   GdkDisplay *gdk_display;
+  GdkDevice *gdk_device;
   char *hostname;
 
   Window leader_window;
   Window timestamp_pinging_window;
+
+  MetaUI *ui;
 
   /* Pull in all the names of atoms as fields; we will intern them when the
    * class is constructed.

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -80,6 +80,7 @@ struct _MetaDisplay
   
   char *name;
   Display *xdisplay;
+  GdkDisplay *gdk_display;
   char *hostname;
 
   Window leader_window;

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -519,6 +519,8 @@ meta_display_open (void)
    */
   the_display->name = g_strdup (XDisplayName (NULL));
   the_display->xdisplay = xdisplay;
+  the_display->gdk_display = gdk_display_get_default();
+
   if (gethostname (buf, sizeof(buf)-1) == 0)
     {
       buf[sizeof(buf)-1] = '\0';

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -520,6 +520,7 @@ meta_display_open (void)
   the_display->name = g_strdup (XDisplayName (NULL));
   the_display->xdisplay = xdisplay;
   the_display->gdk_display = gdk_display_get_default();
+  the_display->gdk_device = gdk_seat_get_pointer (gdk_display_get_default_seat (the_display->gdk_display));
 
   if (gethostname (buf, sizeof(buf)-1) == 0)
     {

--- a/src/core/errors.c
+++ b/src/core/errors.c
@@ -33,7 +33,7 @@
 #include "display-private.h"
 #include <errno.h>
 #include <stdlib.h>
-#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 
 /* In GTK+-3.0, the error trapping code was significantly rewritten. The new code
  * has some neat features (like knowing automatically if a sync is needed or not
@@ -50,23 +50,23 @@
 void
 meta_error_trap_push (MetaDisplay *display)
 {
-  gdk_error_trap_push ();
+  gdk_x11_display_error_trap_push (display->gdk_display);
 }
 
 void
 meta_error_trap_pop (MetaDisplay *display)
 {
-  gdk_error_trap_pop_ignored ();
+  gdk_x11_display_error_trap_pop_ignored (display->gdk_display);
 }
 
 void
 meta_error_trap_push_with_return (MetaDisplay *display)
 {
-  gdk_error_trap_push ();
+  gdk_x11_display_error_trap_push (display->gdk_display);
 }
 
 int
 meta_error_trap_pop_with_return  (MetaDisplay *display)
 {
-  return gdk_error_trap_pop ();
+  return gdk_x11_display_error_trap_pop (display->gdk_display);
 }

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1005,7 +1005,7 @@ meta_screen_new (MetaDisplay *display,
   screen->keys_grabbed = FALSE;
   meta_screen_grab_keys (screen);
 
-  screen->ui = meta_ui_new (screen->display->xdisplay,
+  screen->ui = meta_ui_new (display,
                             screen->xscreen);
 
   screen->tile_preview_timeout_id = 0;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -30,6 +30,7 @@
 #include "menu.h"
 #include "core.h"
 #include "theme-private.h"
+#include "display-private.h"
 #include "window-private.h"
 
 #include "inlinepixbufs.h"
@@ -294,17 +295,17 @@ meta_ui_remove_event_func (Display       *xdisplay,
 }
 
 LOCAL_SYMBOL MetaUI*
-meta_ui_new (Display *xdisplay,
+meta_ui_new (MetaDisplay *display,
              Screen  *screen)
 {
   GdkDisplay *gdisplay;
   MetaUI *ui;
 
   ui = g_new0 (MetaUI, 1);
-  ui->xdisplay = xdisplay;
+  ui->xdisplay = display->xdisplay;
   ui->xscreen = screen;
 
-  gdisplay = gdk_x11_lookup_xdisplay (xdisplay);
+  gdisplay = display->gdk_display;
   g_assert (gdisplay == gdk_display_get_default ());
 
   ui->frames = meta_frames_new (XScreenNumberOfScreen (screen));

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -103,10 +103,10 @@ meta_ui_get_display (void)
  */
 
 static gboolean
-maybe_redirect_mouse_event (XEvent *xevent)
+maybe_redirect_mouse_event (MetaDisplay *display,
+                            XEvent      *xevent)
 {
   GdkDisplay *gdisplay;
-  GdkDeviceManager *gmanager;
   GdkDevice *gdevice;
   MetaUI *ui;
   GdkEvent *gevent;
@@ -141,8 +141,8 @@ maybe_redirect_mouse_event (XEvent *xevent)
         return FALSE;
     }
 
-  gdisplay = gdk_x11_lookup_xdisplay (xevent->xany.display);
-  ui = g_object_get_data (G_OBJECT (gdisplay), "meta-ui");
+  gdisplay = display->gdk_display;
+  ui = display->ui;
   if (!ui)
     return FALSE;
 
@@ -150,8 +150,7 @@ maybe_redirect_mouse_event (XEvent *xevent)
   if (gdk_window == NULL)
     return FALSE;
 
-  gmanager = gdk_display_get_device_manager (gdisplay);
-  gdevice = gdk_device_manager_get_client_pointer (gmanager);
+  gdevice = display->gdk_device;
 
   /* If GDK already thinks it has a grab, we better let it see events; this
    * is the menu-navigation case and events need to get sent to the appropriate
@@ -260,7 +259,7 @@ filter_func (GdkXEvent *xevent,
   g_return_val_if_fail (ef != NULL, GDK_FILTER_CONTINUE);
 
   if ((* ef->func) (xevent, ef->data) ||
-      maybe_redirect_mouse_event (xevent))
+      maybe_redirect_mouse_event ((MetaDisplay*)ef->data, xevent))
     return GDK_FILTER_REMOVE;
   else
     return GDK_FILTER_CONTINUE;
@@ -296,12 +295,12 @@ meta_ui_remove_event_func (Display       *xdisplay,
 
 LOCAL_SYMBOL MetaUI*
 meta_ui_new (MetaDisplay *display,
-             Screen  *screen)
+             Screen      *screen)
 {
   GdkDisplay *gdisplay;
   MetaUI *ui;
 
-  ui = g_new0 (MetaUI, 1);
+  ui = display->ui = g_new0 (MetaUI, 1);
   ui->xdisplay = display->xdisplay;
   ui->xscreen = screen;
 

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -27,6 +27,7 @@
 /* Don't include gtk.h or gdk.h here */
 #include <meta/common.h>
 #include <meta/types.h>
+#include <meta/display.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <cairo.h>
@@ -54,7 +55,7 @@ void meta_ui_remove_event_func (Display       *xdisplay,
                                 MetaEventFunc  func,
                                 gpointer       data);
 
-MetaUI* meta_ui_new (Display *xdisplay,
+MetaUI* meta_ui_new (MetaDisplay *display,
                      Screen  *screen);
 void    meta_ui_free (MetaUI *ui);
 


### PR DESCRIPTION
- Replaces `gdk_error_trap_push` with `gdk_x11_display_error_trap_push`
- Replaces `gdk_error_trap_pop` with `gdk_x11_display_error_trap_pop`
- Fetches `GdkDevice` via `gdk_seat_get_pointer`, and caches it on the MetaDisplay struct, so we're not calling the same getters repeatedly in the MetaFrames event dispatcher.

`gdk_display_get_default` will be deprecated in a future version of GTK, but isn't in 3.22. [Attempting to replace it](https://github.com/gnome/mutter/commit/d4c4d6e64d899e67cfd821e1ff869cfc181097be) caused too many issues, so better to wait on that one.