### PR TITLE
window: Update monitor state before showing the window

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3110,6 +3110,8 @@ meta_window_show (MetaWindow *window)
 
   if (!window->visible_to_compositor)
     {
+      meta_window_update_monitor (window);
+
       window->visible_to_compositor = TRUE;
 
       MetaCompEffect effect = META_COMP_EFFECT_NONE;


### PR DESCRIPTION
This fixes windows initially having an incorrect monitor assigned.