### PR TITLE
window: Fix incorrect tiling overlay placement

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9543,7 +9543,12 @@ update_move (MetaWindow  *window,
       if (meta_prefs_get_edge_tiling ())
         {
           if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
-            meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
+            {
+              if (window->display->desktop_effects)
+                get_outer_rect (window, &window->outer_rect);
+
+              meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
+            }
           else
             meta_screen_tile_hud_update (window->screen, TRUE, TRUE);
         }


### PR DESCRIPTION
Ref https://github.com/linuxmint/cinnamon/issues/8454

**Depends on** #437 