### PR TITLE
Revert two commits from #410

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -95,4 +95,7 @@ void meta_compositor_grab_op_end (MetaCompositor *compositor);
 void meta_compositor_set_all_obscured (MetaCompositor *compositor,
                                        gboolean        obscured);
 
+void meta_compositor_update_opacity (ClutterActor *actor,
+                                     guint8        opacity);
+
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -45,7 +45,8 @@ void meta_window_actor_get_shape_bounds (MetaWindowActor       *self,
                                           cairo_rectangle_int_t *bounds);
 
 gboolean meta_window_actor_effect_in_progress  (MetaWindowActor *self);
-
+void     meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
+                                                gboolean         did_placement);
 void     meta_window_actor_sync_visibility     (MetaWindowActor *self);
 void     meta_window_actor_update_shape        (MetaWindowActor *self);
 void     meta_window_actor_update_opacity      (MetaWindowActor *self,
@@ -75,13 +76,7 @@ void meta_window_actor_check_obscured (MetaWindowActor *self);
 void set_obscured (MetaWindowActor *self,
                    gboolean         obscured);
 
-void meta_window_actor_reset_texture (MetaWindowActor *self);
-
 void meta_window_actor_decorated_notify (MetaWindowActor *self);
-void meta_window_actor_appears_focused_notify (MetaWindowActor *self);
-void meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
-                                            gboolean         did_placement);
-
 void meta_window_actor_override_obscured_internal (MetaWindowActor *self,
                                                    gboolean         obscured);
 

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1752,8 +1752,8 @@ event_callback (XEvent   *event,
                               window->desc);
                 }
 
-              if (window->compositor_private)
-                meta_window_actor_update_shape (window->compositor_private);
+              meta_compositor_window_shape_changed (display->compositor,
+                                                    window);
             }
         }
       else

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1223,7 +1223,8 @@ meta_screen_composite_all_windows (MetaScreen *screen)
 
       meta_compositor_add_window (display->compositor, window);
       if (window->visible_to_compositor)
-        meta_window_actor_show (window->compositor_private, META_COMP_EFFECT_NONE);
+        meta_compositor_show_window (display->compositor, window,
+                                     META_COMP_EFFECT_NONE);
     }
 
   g_slist_free (windows);

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -503,7 +503,7 @@ struct _MetaWindow
   /* maintained by group.c */
   MetaGroup *group;
 
-  MetaWindowActor *compositor_private;
+  GObject *compositor_private;
 
   /* Focused window that is (directly or indirectly) attached to this one */
   MetaWindow *attached_focus_window;

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -683,8 +683,7 @@ meta_window_set_opaque_region (MetaWindow     *window,
   if (region != NULL)
     window->opaque_region = cairo_region_reference (region);
 
-  if (window->compositor_private)
-    meta_window_actor_update_shape (window->compositor_private);
+  meta_compositor_window_shape_changed (window->display->compositor, window);
 }
 
 static void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8416,11 +8416,6 @@ recalc_window_type (MetaWindow *window)
 
       if (old_decorated != window->decorated)
         g_object_notify (object, "decorated");
-        // {
-        //   if (window->compositor_private)
-        //     meta_window_actor_decorated_notify (window->compositor_private);
-        //   g_object_notify (object, "decorated");
-        // }
 
       g_object_notify (object, "window-type");
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -200,6 +200,7 @@ enum
   RAISED,
   UNMANAGED,
   SIZE_CHANGED,
+  POSITION_CHANGED,
   ICON_CHANGED,
 
   LAST_SIGNAL
@@ -611,6 +612,14 @@ meta_window_class_init (MetaWindowClass *klass)
                   G_TYPE_FROM_CLASS (object_class),
                   G_SIGNAL_RUN_LAST,
                   G_STRUCT_OFFSET (MetaWindowClass, unmanaged),
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 0);
+
+  window_signals[POSITION_CHANGED] =
+    g_signal_new ("position-changed",
+                  G_TYPE_FROM_CLASS (object_class),
+                  G_SIGNAL_RUN_LAST,
+                  0,
                   NULL, NULL, NULL,
                   G_TYPE_NONE, 0);
 
@@ -1765,7 +1774,8 @@ meta_window_unmanage (MetaWindow  *window,
   meta_display_set_all_obscured ();
 
   if (window->visible_to_compositor || meta_window_is_attached_dialog (window))
-    meta_window_actor_hide (window->compositor_private, META_COMP_EFFECT_DESTROY);
+    meta_compositor_hide_window (window->display->compositor, window,
+                                 META_COMP_EFFECT_DESTROY);
 
   meta_compositor_remove_window (window->display->compositor, window);
 
@@ -3128,7 +3138,8 @@ meta_window_show (MetaWindow *window)
           break;
         }
 
-      meta_window_actor_show (window->compositor_private, effect);
+      meta_compositor_show_window (window->display->compositor,
+                                   window, effect);
     }
 
   /* We don't want to worry about all cases from inside
@@ -3222,7 +3233,8 @@ meta_window_hide (MetaWindow *window)
           break;
         }
 
-      meta_window_actor_hide (window->compositor_private, effect);
+      meta_compositor_hide_window (window->display->compositor,
+                                   window, effect);
     }
 
   did_hide = FALSE;
@@ -3566,8 +3578,13 @@ meta_window_maximize (MetaWindow        *window,
 
     meta_window_move_resize_now (window);
 
-    if (desktop_effects && window->compositor_private)
-      meta_window_actor_maximize (window->compositor_private, &old_rect, &window->outer_rect);
+    if (desktop_effects)
+      {
+        meta_compositor_maximize_window (window->display->compositor,
+                                        window,
+                                        &old_rect,
+                                        &window->outer_rect);
+      }
     }
 
   meta_screen_tile_preview_hide (window->screen);
@@ -3780,7 +3797,10 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
       if (desktop_effects && window->compositor_private)
         {
           meta_window_get_input_rect (window, &new_rect);
-          meta_window_actor_tile (window->compositor_private, &old_rect, &new_rect);
+          meta_compositor_tile_window (window->display->compositor,
+                                      window,
+                                      &old_rect,
+                                      &new_rect);
         }
 
       if (window->frame)
@@ -4004,8 +4024,13 @@ meta_window_unmaximize_internal (MetaWindow        *window,
                                             target_rect.width,
                                             target_rect.height);
 
-          if (desktop_effects && window->compositor_private)
-            meta_window_actor_unmaximize (window->compositor_private, &old_rect, &window->outer_rect);
+          if (desktop_effects)
+            {
+              meta_compositor_unmaximize_window (window->display->compositor,
+                                                window,
+                                                &old_rect,
+                                                &window->outer_rect);
+            }
         }
       else
         {
@@ -4321,8 +4346,9 @@ meta_window_adjust_opacity (MetaWindow   *window,
     new_opacity = MAX (current_opacity - OPACITY_STEP, MAX (0, meta_prefs_get_min_win_opacity ()));
   }
 
-  if (new_opacity != current_opacity)
-    meta_window_actor_update_opacity (META_WINDOW_ACTOR (actor), (guint8) new_opacity);
+  if (new_opacity != current_opacity) {
+    meta_compositor_update_opacity (actor, (guint8) new_opacity);
+  }
 }
 
 void
@@ -4618,9 +4644,8 @@ meta_window_create_sync_request_alarm (MetaWindow *window)
         XSyncValueLow32 (init) + ((gint64)XSyncValueHigh32 (init) << 32);
 
       /* if the value is odd, the window starts off with updates frozen */
-      if (window->compositor_private)
-        meta_window_actor_set_updates_frozen (window->compositor_private,
-                                              meta_window_updates_are_frozen (window));
+      meta_compositor_set_updates_frozen (window->display->compositor, window,
+                                          meta_window_updates_are_frozen (window));
     }
   else
     {
@@ -4695,9 +4720,8 @@ sync_request_timeout (gpointer data)
    * window updates
    */
   window->sync_request_wait_serial = 0;
-  if (window->compositor_private)
-    meta_window_actor_set_updates_frozen (window->compositor_private,
-                                          meta_window_updates_are_frozen (window));
+  meta_compositor_set_updates_frozen (window->display->compositor, window,
+                                      meta_window_updates_are_frozen (window));
 
   if (window == window->display->grab_window &&
       meta_grab_op_is_resizing (window->display->grab_op))
@@ -4758,8 +4782,8 @@ send_sync_request (MetaWindow *window)
                                                    sync_request_timeout,
                                                    window);
 
-  meta_window_actor_set_updates_frozen (window->compositor_private,
-                                        meta_window_updates_are_frozen (window));
+  meta_compositor_set_updates_frozen (window->display->compositor, window,
+                                      meta_window_updates_are_frozen (window));
 }
 #endif
 
@@ -5343,19 +5367,29 @@ meta_window_move_resize_internal (MetaWindow          *window,
   else if (is_user_action)
     save_user_window_placement (window);
 
-  if (window->compositor_private && (need_move_frame || need_move_client))
-    g_signal_emit_by_name (window->compositor_private, "position-changed");
+  if (need_move_frame || need_move_client)
+    {
+      if (window->position_changed_callback != NULL)
+        (window->position_changed_callback) (window);
+    }
 
   if (need_resize_client)
     g_signal_emit (window, window_signals[SIZE_CHANGED], 0);
 
-  if (window->compositor_private &&
-      (need_move_frame || need_resize_frame ||
+  if (need_move_frame || need_resize_frame ||
       need_move_client || need_resize_client ||
-      did_placement))
+      did_placement)
     {
-      meta_window_actor_sync_actor_geometry (window->compositor_private,
-                                             did_placement);
+      int newx, newy;
+      meta_window_get_position (window, &newx, &newy);
+      meta_topic (META_DEBUG_GEOMETRY,
+                  "New size/position %d,%d %dx%d (user %d,%d %dx%d)\n",
+                  newx, newy, window->rect.width, window->rect.height,
+                  window->user_rect.x, window->user_rect.y,
+                  window->user_rect.width, window->user_rect.height);
+      meta_compositor_sync_window_geometry (window->display->compositor,
+                                            window,
+                                            did_placement);
     }
   else
     {
@@ -5701,8 +5735,7 @@ meta_window_configure_notify (MetaWindow      *window,
   if (!event->override_redirect && !event->send_event)
     meta_warning ("Unhandled change of windows override redirect status\n");
 
-  if (window->compositor_private)
-    meta_window_actor_sync_actor_geometry (window->compositor_private, FALSE);
+  meta_compositor_sync_window_geometry (window->display->compositor, window, FALSE);
 }
 
 LOCAL_SYMBOL void
@@ -7409,7 +7442,6 @@ meta_window_appears_focused_changed (MetaWindow *window)
   set_net_wm_state (window);
   meta_window_frame_size_changed (window);
 
-  meta_window_actor_appears_focused_notify (window->compositor_private);
   g_object_notify (G_OBJECT (window), "appears-focused");
 
   if (window->frame)
@@ -7609,13 +7641,16 @@ meta_window_notify_focus (MetaWindow *window,
               !meta_prefs_get_raise_on_click())
             meta_display_ungrab_focus_window_button (window->display, window);
 
+          g_signal_emit (window, window_signals[FOCUS], 0);
+          g_object_notify (G_OBJECT (window->display), "focus-window");
+
           if (!window->attached_focus_window)
             meta_window_appears_focused_changed (window);
 
           meta_window_propagate_focus_appearance (window, TRUE);
 
-          g_signal_emit (window, window_signals[FOCUS], 0);
-          g_object_notify (G_OBJECT (window->display), "focus-window");
+          // g_signal_emit (window, window_signals[FOCUS], 0);
+          // g_object_notify (G_OBJECT (window->display), "focus-window");
         }
     }
   else if (event->type == FocusOut ||
@@ -8380,11 +8415,12 @@ recalc_window_type (MetaWindow *window)
       g_object_freeze_notify (object);
 
       if (old_decorated != window->decorated)
-        {
-          if (window->compositor_private)
-            meta_window_actor_decorated_notify (window->compositor_private);
-          g_object_notify (object, "decorated");
-        }
+        g_object_notify (object, "decorated");
+        // {
+        //   if (window->compositor_private)
+        //     meta_window_actor_decorated_notify (window->compositor_private);
+        //   g_object_notify (object, "decorated");
+        // }
 
       g_object_notify (object, "window-type");
 
@@ -10114,8 +10150,8 @@ meta_window_update_sync_request_counter (MetaWindow *window,
     }
 
   window->sync_request_serial = new_counter_value;
-  meta_window_actor_set_updates_frozen (window->compositor_private,
-                                        meta_window_updates_are_frozen (window));
+  meta_compositor_set_updates_frozen (window->display->compositor, window,
+                                      meta_window_updates_are_frozen (window));
 
   if (window == window->display->grab_window &&
       meta_grab_op_is_resizing (window->display->grab_op) &&
@@ -10147,7 +10183,8 @@ meta_window_update_sync_request_counter (MetaWindow *window,
   window->disable_sync = FALSE;
 
   if (needs_frame_drawn)
-    meta_window_actor_queue_frame_drawn (window->compositor_private, no_delay_frame);
+    meta_compositor_queue_frame_drawn (window->display->compositor, window,
+                                       no_delay_frame);
 }
 #endif /* HAVE_XSYNC */
 
@@ -11651,7 +11688,15 @@ meta_window_get_compositor_private (MetaWindow *window)
 {
   if (!window)
     return NULL;
-  return G_OBJECT (window->compositor_private);
+  return window->compositor_private;
+}
+
+void
+meta_window_set_compositor_private (MetaWindow *window, GObject *priv)
+{
+  if (!window)
+    return;
+  window->compositor_private = priv;
 }
 
 const char *
@@ -12375,3 +12420,22 @@ meta_window_get_icon_name (MetaWindow *window)
 
     return window->theme_icon_name;
 }
+
+/**
+ * meta_window_set_position_changed_callback:
+ * @window: a #MetaWindow
+ * @callback (scope notified): callback
+ * @user_data (closure): user data
+ * @data_destroy: a #GDestroyNotify
+ *
+ * Sets the callback which will be invoked on position change.
+ */
+void
+meta_window_set_position_changed_callback (MetaWindow        *window,
+                                           MetaWindowCallback callback,
+                                           gpointer           user_data,
+                                           GDestroyNotify     data_destroy)
+{
+  window->position_changed_callback = callback;
+}
+

--- a/src/meta/compositor.h
+++ b/src/meta/compositor.h
@@ -45,7 +45,7 @@
  *   shown or hidden immediately.
  *
  * Indicates the appropriate effect to show the user for
- * meta_window_actor_show() and meta_window_actor_hide()
+ * meta_compositor_show_window() and meta_compositor_hide_window()
  */
 typedef enum
 {
@@ -63,6 +63,9 @@ void meta_compositor_manage_screen   (MetaCompositor *compositor,
                                       MetaScreen     *screen);
 void meta_compositor_unmanage_screen (MetaCompositor *compositor,
                                       MetaScreen     *screen);
+
+void meta_compositor_window_shape_changed (MetaCompositor *compositor,
+                                           MetaWindow     *window);
 
 gboolean meta_compositor_process_event (MetaCompositor *compositor,
                                         XEvent         *event,
@@ -110,11 +113,36 @@ void meta_compositor_add_window    (MetaCompositor *compositor,
 void meta_compositor_remove_window (MetaCompositor *compositor,
                                     MetaWindow     *window);
 
+void meta_compositor_show_window       (MetaCompositor      *compositor,
+                                        MetaWindow          *window,
+                                        MetaCompEffect       effect);
+void meta_compositor_hide_window       (MetaCompositor      *compositor,
+                                        MetaWindow          *window,
+                                        MetaCompEffect       effect);
 void meta_compositor_switch_workspace  (MetaCompositor      *compositor,
                                         MetaScreen          *screen,
                                         MetaWorkspace       *from,
                                         MetaWorkspace       *to,
                                         MetaMotionDirection  direction);
+
+void meta_compositor_maximize_window   (MetaCompositor      *compositor,
+                                        MetaWindow          *window,
+                                        MetaRectangle       *old_rect,
+                                        MetaRectangle       *new_rect);
+void meta_compositor_unmaximize_window (MetaCompositor      *compositor,
+                                        MetaWindow          *window,
+                                        MetaRectangle       *old_rect,
+                                        MetaRectangle       *new_rect);
+
+void meta_compositor_sync_window_geometry (MetaCompositor *compositor,
+                                           MetaWindow     *window,
+                                           gboolean        did_placement);
+void meta_compositor_set_updates_frozen   (MetaCompositor *compositor,
+                                           MetaWindow     *window,
+                                           gboolean        updates_frozen);
+void meta_compositor_queue_frame_drawn    (MetaCompositor *compositor,
+                                           MetaWindow     *window,
+                                           gboolean        no_delay_frame);
 
 void meta_compositor_sync_stack                (MetaCompositor *compositor,
                                                 MetaScreen     *screen,
@@ -126,6 +154,11 @@ void meta_compositor_sync_screen_size          (MetaCompositor *compositor,
 
 void meta_compositor_flash_screen              (MetaCompositor *compositor,
                                                 MetaScreen     *screen);
+
+void meta_compositor_tile_window       (MetaCompositor      *compositor,
+                                        MetaWindow          *window,
+                                        MetaRectangle       *old_rect,
+                                        MetaRectangle       *new_rect);
 
 void meta_compositor_show_tile_preview (MetaCompositor  *compositor,
                                         MetaScreen      *screen,
@@ -146,6 +179,6 @@ void meta_compositor_show_hud_preview (MetaCompositor   *compositor,
 void meta_compositor_hide_hud_preview (MetaCompositor   *compositor,
                                        MetaScreen       *screen);
 
-void meta_compositor_toggle_send_frame_timings (void);
+void meta_compositor_toggle_send_frame_timings (MetaScreen *screen);
 
 #endif /* META_COMPOSITOR_H */

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -130,6 +130,7 @@ void meta_window_change_workspace (MetaWindow    *window,
 void meta_window_stick (MetaWindow  *window);
 void meta_window_unstick (MetaWindow  *window);
 GObject *meta_window_get_compositor_private (MetaWindow *window);
+void meta_window_set_compositor_private (MetaWindow *window, GObject *priv);
 void meta_window_configure_notify (MetaWindow *window, XConfigureEvent *event);
 const char *meta_window_get_role (MetaWindow *window);
 MetaStackLayer meta_window_get_layer (MetaWindow *window);


### PR DESCRIPTION
Reverts:
990e8fab6e752ec17f97ae30aa1a7d47a87a8343
6eeb70bd8d680535eeed547070e9abfcef6f528d

This fixes Skyrim (and probably other Wine games).

I'm still not exactly sure what caused this, but once I have a better idea I will clean these up for another PR.

Ref https://github.com/linuxmint/cinnamon/issues/8454