### PR TITLE
window-actor: override Clutter opacity property and method

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -95,7 +95,4 @@ void meta_compositor_grab_op_end (MetaCompositor *compositor);
 void meta_compositor_set_all_obscured (MetaCompositor *compositor,
                                        gboolean        obscured);
 
-void meta_compositor_update_opacity (ClutterActor *actor,
-                                     guint8        opacity);
-
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -206,8 +206,7 @@ process_property_notify (MetaCompositor	*compositor,
   /* Check for the opacity changing */
   if (event->atom == compositor->atom_net_wm_window_opacity)
     {
-      meta_window_actor_update_opacity (window_actor, 0);
-      DEBUG_TRACE ("process_property_notify: net_wm_window_opacity\n");
+      meta_window_actor_set_opacity (window_actor, -1);
       return;
     }
 
@@ -1669,9 +1668,3 @@ meta_compositor_update_sync_state (MetaCompositor *compositor,
   clutter_stage_x11_update_sync_state (compositor->stage, state);
 }
 
-void
-meta_compositor_update_opacity (ClutterActor    *actor,
-                                guint8           opacity)
-{
-  meta_window_actor_update_opacity (META_WINDOW_ACTOR (actor), opacity);
-}

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1119,10 +1119,10 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
       while (old_stack)
         {
           old_actor = old_stack->data;
-          old_window = meta_window_actor_get_meta_window (old_actor);
+          old_window = old_actor->priv->window;
 
           if ((old_window->hidden || old_window->unmanaging) &&
-              !meta_window_actor_effect_in_progress (old_actor))
+              !old_actor->priv->effect_in_progress)
             {
               old_stack = g_list_delete_link (old_stack, old_stack);
               old_actor = NULL;
@@ -1291,7 +1291,7 @@ meta_pre_paint_func (gpointer data)
       if (expected_unredirected_window != NULL)
         {
           meta_shape_cow_for_window (compositor->display->active_screen,
-                                     meta_window_actor_get_meta_window (top_window));
+                                     top_window->priv->window);
           meta_window_actor_set_redirected (top_window, FALSE);
         }
 
@@ -1568,7 +1568,7 @@ meta_compositor_get_window_for_xwindow (Window xwindow)
 
   for (l = compositor_global->windows; l; l = l->next)
     {
-      MetaWindow *window = meta_window_actor_get_meta_window (l->data);
+      MetaWindow *window = META_WINDOW_ACTOR (l->data)->priv->window;
       if (window->xwindow == xwindow)
         return window;
     }

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -206,7 +206,7 @@ process_property_notify (MetaCompositor	*compositor,
   /* Check for the opacity changing */
   if (event->atom == compositor->atom_net_wm_window_opacity)
     {
-      meta_window_actor_set_opacity (window_actor, -1);
+      meta_window_actor_set_opacity (window_actor, 256);
       return;
     }
 

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -49,8 +49,6 @@ void     meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
                                                 gboolean         did_placement);
 void     meta_window_actor_sync_visibility     (MetaWindowActor *self);
 void     meta_window_actor_update_shape        (MetaWindowActor *self);
-void     meta_window_actor_update_opacity      (MetaWindowActor *self,
-                                                guint8           opacity);
 void     meta_window_actor_mapped              (MetaWindowActor *self);
 void     meta_window_actor_unmapped            (MetaWindowActor *self);
 void     meta_window_actor_set_updates_frozen  (MetaWindowActor *self,
@@ -73,8 +71,6 @@ void meta_window_actor_effect_completed (MetaWindowActor *actor,
                                          gulong           event);
 
 void meta_window_actor_check_obscured (MetaWindowActor *self);
-void set_obscured (MetaWindowActor *self,
-                   gboolean         obscured);
 
 void meta_window_actor_decorated_notify (MetaWindowActor *self);
 void meta_window_actor_override_obscured_internal (MetaWindowActor *self,

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -9,6 +9,130 @@
 #include <meta/compositor-muffin.h>
 #include <clutter/clutter-muffin.h>
 
+#include "meta-shadow-factory-private.h"
+#include "meta-texture-tower.h"
+
+struct _MetaWindowActorPrivate
+{
+  MetaWindow *window;
+  Window xwindow;
+  MetaScreen *screen;
+
+  /* MetaShadowFactory only caches shadows that are actually in use;
+   * to avoid unnecessary recomputation we do two things: 1) we store
+   * both a focused and unfocused shadow for the window. If the window
+   * doesn't have different focused and unfocused shadow parameters,
+   * these will be the same. 2) when the shadow potentially changes we
+   * don't immediately unreference the old shadow, we just flag it as
+   * dirty and recompute it when we next need it (recompute_focused_shadow,
+   * recompute_unfocused_shadow.) Because of our extraction of
+   * size-invariant window shape, we'll often find that the new shadow
+   * is the same as the old shadow.
+   */
+  MetaShadow *focused_shadow;
+  MetaShadow *unfocused_shadow;
+
+  Pixmap pixmap;
+
+  Damage damage;
+
+  guint8 opacity;
+  CoglColor color;
+
+  /* If the window is shaped, a region that matches the shape */
+  cairo_region_t *shape_region;
+  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
+   * the shape region. */
+  cairo_region_t *opaque_region;
+  /* The region we should clip to when painting the shadow */
+  cairo_region_t *shadow_clip;
+
+   /* The region that is visible, used to optimize out redraws */
+  cairo_region_t *unobscured_region;
+
+  /* Extracted size-invariant shape used for shadows */
+  MetaWindowShape *shadow_shape;
+
+  gint last_width;
+  gint last_height;
+  gint last_x;
+  gint last_y;
+
+  gint freeze_count;
+
+  char *shadow_class;
+
+  gint effect_in_progress;
+
+  /* List of FrameData for recent frames */
+  GList *frames;
+
+  guint visible : 1;
+  guint argb32 : 1;
+  guint disposed : 1;
+  guint redecorating : 1;
+
+  guint needs_damage_all : 1;
+  guint received_damage : 1;
+  guint repaint_scheduled : 1;
+
+  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
+   * client message using the most recent frame in ->frames */
+  guint send_frame_messages_timer;
+  gint64 frame_drawn_time;
+  guint needs_frame_drawn : 1;
+
+  guint needs_pixmap : 1;
+  guint needs_reshape : 1;
+  guint recompute_focused_shadow : 1;
+  guint recompute_unfocused_shadow : 1;
+  guint size_changed : 1;
+  guint position_changed : 1;
+  guint updates_frozen : 1;
+
+  guint needs_destroy : 1;
+
+  guint no_shadow : 1;
+
+  guint unredirected : 1;
+
+  /* This is used to detect fullscreen windows that need to be unredirected */
+  guint full_damage_frames_count;
+  guint does_full_damage  : 1;
+
+  guint has_desat_effect : 1;
+
+  guint reshapes;
+  guint should_have_shadow : 1;
+  guint obscured : 1;
+  guint extend_obscured_timer : 1;
+  guint obscured_lock : 1;
+  guint public_obscured_lock : 1;
+  guint reset_obscured_timeout_id;
+  guint clip_shadow : 1;
+
+  guint first_frame_drawn;
+  guint first_frame_handler_queued;
+  guint first_frame_drawn_id;
+
+  /* Shaped texture */
+  MetaTextureTower *paint_tower;
+  CoglTexture *texture;
+  CoglTexture *mask_texture;
+
+  cairo_region_t *clip_region;
+
+  int tex_width, tex_height;
+
+  gint64 prev_invalidation, last_invalidation;
+  guint fast_updates;
+  guint remipmap_timeout_id;
+  gint64 earliest_remipmap;
+
+  guint create_mipmaps : 1;
+  guint mask_needs_update : 1;
+};
+
 MetaWindowActor *meta_window_actor_new (MetaWindow *window);
 
 void meta_window_actor_destroy   (MetaWindowActor *self);

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -37,6 +37,7 @@ struct _MetaWindowActorPrivate
   Damage damage;
 
   guint8 opacity;
+  guint opacity_queued;
   CoglColor color;
 
   /* If the window is shaped, a region that matches the shape */

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -114,17 +114,7 @@ struct _MetaWindowActorPrivate
 
   char *            shadow_class;
 
-  /*
-   * These need to be counters rather than flags, since more plugins
-   * can implement same effect; the practicality of stacking effects
-   * might be dubious, but we have to at least handle it correctly.
-   */
-  gint              minimize_in_progress;
-  gint              maximize_in_progress;
-  gint              unmaximize_in_progress;
-  gint              tile_in_progress;
-  gint              map_in_progress;
-  gint              destroy_in_progress;
+  gint              effect_in_progress;
 
   /* List of FrameData for recent frames */
   GList            *frames;
@@ -1939,13 +1929,7 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
 LOCAL_SYMBOL gboolean
 meta_window_actor_effect_in_progress (MetaWindowActor *self)
 {
-  MetaWindowActorPrivate *priv = self->priv;
-  return (priv->minimize_in_progress ||
-          priv->maximize_in_progress ||
-          priv->unmaximize_in_progress ||
-          priv->map_in_progress ||
-          priv->tile_in_progress ||
-          priv->destroy_in_progress);
+  return self->priv->effect_in_progress;
 }
 
 static gboolean
@@ -1976,39 +1960,18 @@ start_simple_effect (MetaWindowActor *self,
   if (!compositor->plugin_mgr)
     return FALSE;
 
-  switch (event)
-  {
-  case META_PLUGIN_MINIMIZE:
-    counter = &priv->minimize_in_progress;
-    break;
-  case META_PLUGIN_MAP:
-    counter = &priv->map_in_progress;
-    break;
-  case META_PLUGIN_DESTROY:
-    counter = &priv->destroy_in_progress;
-    break;
-  case META_PLUGIN_UNMAXIMIZE:
-  case META_PLUGIN_MAXIMIZE:
-  case META_PLUGIN_SWITCH_WORKSPACE:
-  case META_PLUGIN_TILE:
-    g_assert_not_reached ();
-    break;
-  }
-
-  g_assert (counter);
-
   use_freeze_thaw = is_freeze_thaw_effect (event);
 
   if (use_freeze_thaw)
     meta_window_actor_freeze (self);
 
-  (*counter)++;
+  priv->effect_in_progress++;
 
   if (!meta_plugin_manager_event_simple (compositor->plugin_mgr,
                                          self,
                                          event))
     {
-      (*counter)--;
+      priv->effect_in_progress--;
       if (use_freeze_thaw)
         meta_window_actor_thaw (self);
       return FALSE;
@@ -2048,63 +2011,22 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
    * that the corresponding MetaWindow may have be been destroyed.
    * In this case priv->window will == NULL */
 
+  priv->effect_in_progress--;
+
+  if (priv->effect_in_progress < 0)
+    {
+      g_warning ("Error in effects accounting (%i)", event);
+      priv->effect_in_progress = 0;
+    }
+
   switch (event)
   {
     case META_PLUGIN_MINIMIZE:
-      {
-        priv->minimize_in_progress--;
-        if (priv->minimize_in_progress < 0)
-          {
-            g_warning ("Error in minimize accounting.");
-            priv->minimize_in_progress = 0;
-          }
-      }
-      break;
     case META_PLUGIN_MAP:
-      /*
-      * Make sure that the actor is at the correct place in case
-      * the plugin fscked.
-      */
-      priv->map_in_progress--;
-      priv->position_changed = TRUE;
-      if (priv->map_in_progress < 0)
-        {
-          g_warning ("Error in map accounting.");
-          priv->map_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_DESTROY:
-      priv->destroy_in_progress--;
-
-      if (priv->destroy_in_progress < 0)
-        {
-          g_warning ("Error in destroy accounting.");
-          priv->destroy_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_UNMAXIMIZE:
-      priv->unmaximize_in_progress--;
-      if (priv->unmaximize_in_progress < 0)
-        {
-          g_warning ("Error in unmaximize accounting.");
-          priv->unmaximize_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_MAXIMIZE:
-      priv->maximize_in_progress--;
-      if (priv->maximize_in_progress < 0)
-        {
-          g_warning ("Error in maximize accounting.");
-          priv->maximize_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_TILE:
-      priv->tile_in_progress--;
-      if (priv->tile_in_progress < 0)
-        {
-          g_warning ("Error in tile accounting.");
-          priv->tile_in_progress = 0;
-        }
       break;
     case META_PLUGIN_SWITCH_WORKSPACE:
       g_assert_not_reached ();
@@ -2114,7 +2036,7 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
   if (is_freeze_thaw_effect (event))
     meta_window_actor_thaw (self);
 
-  if (!meta_window_actor_effect_in_progress (self))
+  if (!priv->effect_in_progress)
     meta_window_actor_after_effects (self);
 }
 
@@ -2302,7 +2224,7 @@ meta_window_actor_destroy (MetaWindowActor *self)
 
   priv->needs_destroy = TRUE;
 
-  if (!meta_window_actor_effect_in_progress (self))
+  if (!priv->effect_in_progress)
     clutter_actor_destroy (CLUTTER_ACTOR (self));
 }
 
@@ -2341,7 +2263,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
   if ((priv->freeze_count || priv->obscured) && !did_placement)
     return;
 
-  if (meta_window_actor_effect_in_progress (self))
+  if (priv->effect_in_progress)
     return;
 
   if (priv->size_changed)
@@ -2449,14 +2371,15 @@ meta_window_actor_maximize (MetaWindowActor    *self,
                             MetaRectangle      *old_rect,
                             MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
    * old size and position */
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->maximize_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2467,7 +2390,7 @@ meta_window_actor_maximize (MetaWindowActor    *self,
                                            new_rect->width, new_rect->height))
 
     {
-      self->priv->maximize_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }
@@ -2477,7 +2400,8 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
                               MetaRectangle     *old_rect,
                               MetaRectangle     *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -2485,7 +2409,7 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->unmaximize_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2495,7 +2419,7 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
                                            new_rect->x, new_rect->y,
                                            new_rect->width, new_rect->height))
     {
-      self->priv->unmaximize_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }
@@ -2505,7 +2429,8 @@ meta_window_actor_tile (MetaWindowActor    *self,
                         MetaRectangle      *old_rect,
                         MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -2513,7 +2438,7 @@ meta_window_actor_tile (MetaWindowActor    *self,
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->tile_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2524,7 +2449,7 @@ meta_window_actor_tile (MetaWindowActor    *self,
                                            new_rect->width, new_rect->height))
 
     {
-      self->priv->tile_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1636,7 +1636,7 @@ meta_window_actor_check_obscured (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
 
-  if (!priv->first_frame_drawn)
+  if (!priv->first_frame_drawn || priv->effect_in_progress)
     {
       if (priv->obscured)
         set_obscured (self, FALSE);

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1838,7 +1838,6 @@ start_simple_effect (MetaWindowActor *self,
 {
   MetaWindowActorPrivate *priv = self->priv;
   MetaCompositor *compositor = priv->screen->display->compositor;
-  gint *counter = NULL;
   gboolean use_freeze_thaw = FALSE;
 
   if (!compositor->plugin_mgr)
@@ -1921,7 +1920,11 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
     meta_window_actor_thaw (self);
 
   if (!priv->effect_in_progress)
-    meta_window_actor_after_effects (self);
+    {
+      if (event != META_PLUGIN_MAP)
+        priv->position_changed = TRUE;
+      meta_window_actor_after_effects (self);
+    }
 }
 
 static void

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -3359,7 +3359,7 @@ meta_window_actor_invalidate_shadow (MetaWindowActor *self)
   clutter_actor_queue_redraw (CLUTTER_ACTOR (self));
 }
 
-#define OPACITY_TYPE_CARDINAL -1
+static inline guint8 OPACITY_TYPE_CARDINAL = -1;
 
 void
 meta_window_actor_set_opacity (MetaWindowActor *self,

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -86,6 +86,8 @@ enum
 #define DEFAULT_SHADOW_X_OFFSET 0
 #define DEFAULT_SHADOW_Y_OFFSET 8
 
+static inline guint8 OPACITY_TYPE_CARDINAL = 256;
+
 static void meta_window_actor_dispose    (GObject *object);
 static void meta_window_actor_finalize   (GObject *object);
 static void meta_window_actor_constructed (GObject *object);
@@ -368,9 +370,6 @@ meta_window_actor_constructed (GObject *object)
     priv->argb32 = TRUE;
 
   priv->shape_region = cairo_region_create();
-
-  /* Opacity handling */
-  meta_window_actor_set_opacity (self, -1);
 }
 
 static void
@@ -1634,7 +1633,7 @@ set_obscured (MetaWindowActor *self,
       if (priv->opacity_queued)
         {
           priv->opacity_queued = FALSE;
-          meta_window_actor_set_opacity (self, -1);
+          meta_window_actor_set_opacity (self, 256);
         }
     }
 }
@@ -2406,6 +2405,9 @@ meta_window_actor_new (MetaWindow *window)
    * before we first paint.
    */
   compositor->windows = g_list_append (compositor->windows, self);
+
+  /* Opacity handling */
+  meta_window_actor_set_opacity (self, 256);
 
   clutter_actor_set_flags (CLUTTER_ACTOR (self), CLUTTER_ACTOR_NO_LAYOUT);
 
@@ -3358,8 +3360,6 @@ meta_window_actor_invalidate_shadow (MetaWindowActor *self)
 
   clutter_actor_queue_redraw (CLUTTER_ACTOR (self));
 }
-
-static inline guint8 OPACITY_TYPE_CARDINAL = -1;
 
 void
 meta_window_actor_set_opacity (MetaWindowActor *self,

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -26,9 +26,7 @@
 #include "xprops.h"
 
 #include "compositor-private.h"
-#include "meta-texture-tower.h"
 #include "meta-texture-rectangle.h"
-#include "meta-shadow-factory-private.h"
 #include "meta-window-actor-private.h"
 
 #include "cogl-utils.h"
@@ -62,128 +60,6 @@ enum {
 };
 
 static guint signals[LAST_SIGNAL] = {0};
-
-
-struct _MetaWindowActorPrivate
-{
-  MetaWindow       *window;
-  Window            xwindow;
-  MetaScreen       *screen;
-
-  /* MetaShadowFactory only caches shadows that are actually in use;
-   * to avoid unnecessary recomputation we do two things: 1) we store
-   * both a focused and unfocused shadow for the window. If the window
-   * doesn't have different focused and unfocused shadow parameters,
-   * these will be the same. 2) when the shadow potentially changes we
-   * don't immediately unreference the old shadow, we just flag it as
-   * dirty and recompute it when we next need it (recompute_focused_shadow,
-   * recompute_unfocused_shadow.) Because of our extraction of
-   * size-invariant window shape, we'll often find that the new shadow
-   * is the same as the old shadow.
-   */
-  MetaShadow       *focused_shadow;
-  MetaShadow       *unfocused_shadow;
-
-  Pixmap            pixmap;
-
-  Damage            damage;
-
-  guint8            opacity;
-  CoglColor         color;
-
-  /* If the window is shaped, a region that matches the shape */
-  cairo_region_t   *shape_region;
-  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
-   * the shape region. */
-  cairo_region_t   *opaque_region;
-  /* The region we should clip to when painting the shadow */
-  cairo_region_t   *shadow_clip;
-
-   /* The region that is visible, used to optimize out redraws */
-  cairo_region_t   *unobscured_region;
-
-  /* Extracted size-invariant shape used for shadows */
-  MetaWindowShape  *shadow_shape;
-
-  gint              last_width;
-  gint              last_height;
-  gint              last_x;
-  gint              last_y;
-
-  gint              freeze_count;
-
-  char *            shadow_class;
-
-  gint              effect_in_progress;
-
-  /* List of FrameData for recent frames */
-  GList            *frames;
-
-  guint             visible                : 1;
-  guint             argb32                 : 1;
-  guint             disposed               : 1;
-  guint             redecorating           : 1;
-
-  guint             needs_damage_all       : 1;
-  guint             received_damage        : 1;
-  guint             repaint_scheduled      : 1;
-
-  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
-   * client message using the most recent frame in ->frames */
-  guint             send_frame_messages_timer;
-  gint64            frame_drawn_time;
-  guint             needs_frame_drawn      : 1;
-
-  guint             needs_pixmap           : 1;
-  guint             needs_reshape          : 1;
-  guint             recompute_focused_shadow   : 1;
-  guint             recompute_unfocused_shadow : 1;
-  guint             size_changed               : 1;
-  guint             position_changed           : 1;
-  guint             updates_frozen         : 1;
-
-  guint             needs_destroy     : 1;
-
-  guint             no_shadow              : 1;
-
-  guint             unredirected           : 1;
-
-  /* This is used to detect fullscreen windows that need to be unredirected */
-  guint             full_damage_frames_count;
-  guint             does_full_damage  : 1;
-
-  guint             has_desat_effect : 1;
-
-  guint             reshapes;
-  guint             should_have_shadow : 1;
-  guint             obscured : 1;
-  guint             extend_obscured_timer : 1;
-  guint             obscured_lock : 1;
-  guint             public_obscured_lock : 1;
-  guint             reset_obscured_timeout_id;
-  guint             clip_shadow : 1;
-
-  guint             first_frame_drawn;
-  guint             first_frame_handler_queued;
-  guint             first_frame_drawn_id;
-
-  /* Shaped texture */
-  MetaTextureTower *paint_tower;
-  CoglTexture *texture;
-  CoglTexture *mask_texture;
-
-  cairo_region_t *clip_region;
-
-  int tex_width, tex_height;
-
-  gint64 prev_invalidation, last_invalidation;
-  guint fast_updates;
-  guint remipmap_timeout_id;
-  gint64 earliest_remipmap;
-
-  guint create_mipmaps : 1;
-  guint mask_needs_update : 1;
-};
 
 typedef struct _FrameData FrameData;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1644,7 +1644,7 @@ meta_window_actor_check_obscured (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
 
-  if (!priv->first_frame_drawn || priv->effect_in_progress)
+  if (!priv->first_frame_drawn)
     {
       if (priv->obscured)
         set_obscured (self, FALSE);

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -3380,9 +3380,9 @@ meta_window_actor_set_opacity (MetaWindowActor *self,
       Window xwin = priv->window->xwindow;
       gulong value;
 
-      if (meta_prop_get_cardinal (display, xwin,
-                                  compositor->atom_net_wm_window_opacity,
-                                  &value))
+      if (meta_prop_get_cardinal_with_atom_type (display, xwin,
+                                                 compositor->atom_net_wm_window_opacity,
+                                                 XA_CARDINAL, &value))
         {
           opacity = (guint8)((gfloat)value * 255.0 / ((gfloat)0xffffffff));
         }

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -89,11 +89,13 @@ meta_window_group_cull_out (MetaWindowGroup *group,
 
           if (clutter_actor_get_paint_opacity (CLUTTER_ACTOR (window_actor)) == 0xff)
             {
-              cairo_region_t *obscured_region = meta_window_actor_get_obscured_region (window_actor);
-              if (obscured_region)
+              MetaWindowActorPrivate *priv = window_actor->priv;
+              cairo_region_t *obscured_region = NULL;
+
+              if (priv->opaque_region && priv->pixmap && priv->opacity == 0xff)
                 {
-                  cairo_region_subtract (unobscured_region, obscured_region);
-                  cairo_region_subtract (clip_region, obscured_region);
+                  cairo_region_subtract (unobscured_region, priv->opaque_region);
+                  cairo_region_subtract (clip_region, priv->opaque_region);
                 }
             }
 
@@ -223,7 +225,7 @@ meta_window_group_paint (ClutterActor *actor)
   if (has_unredirected_window)
     {
       cairo_rectangle_int_t unredirected_rect;
-      MetaWindow *window = meta_window_actor_get_meta_window (compositor->unredirected_window);
+      MetaWindow *window = compositor->unredirected_window->priv->window;
 
       unredirected_rect.x = window->outer_rect.x;
       unredirected_rect.y = window->outer_rect.y;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4334,11 +4334,11 @@ LOCAL_SYMBOL void
 meta_window_adjust_opacity (MetaWindow   *window,
                             gboolean      increase)
 {
-  ClutterActor *actor = CLUTTER_ACTOR (window->compositor_private);
+  MetaWindowActor *actor = META_WINDOW_ACTOR (window->compositor_private);
 
   gint current_opacity, new_opacity;
 
-  current_opacity = clutter_actor_get_opacity (actor);
+  current_opacity = meta_window_actor_get_opacity (actor);
 
   if (increase) {
     new_opacity = MIN (current_opacity + OPACITY_STEP, 255);
@@ -4346,17 +4346,14 @@ meta_window_adjust_opacity (MetaWindow   *window,
     new_opacity = MAX (current_opacity - OPACITY_STEP, MAX (0, meta_prefs_get_min_win_opacity ()));
   }
 
-  if (new_opacity != current_opacity) {
-    meta_compositor_update_opacity (actor, (guint8) new_opacity);
-  }
+  if (new_opacity != current_opacity)
+    meta_window_actor_set_opacity (actor, (guint8) new_opacity);
 }
 
 void
 meta_window_reset_opacity (MetaWindow *window)
 {
-    ClutterActor *actor = CLUTTER_ACTOR (window->compositor_private);
-
-    clutter_actor_set_opacity (actor, 255);
+  meta_window_actor_set_opacity (META_WINDOW_ACTOR (window->compositor_private), 255);
 }
 
 static gboolean

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -616,16 +616,6 @@ meta_prop_get_window (MetaDisplay *display,
   return window_from_results (&results, window_p);
 }
 
-LOCAL_SYMBOL gboolean
-meta_prop_get_cardinal (MetaDisplay   *display,
-                        Window         xwindow,
-                        Atom           xatom,
-                        gulong        *cardinal_p)
-{
-  return meta_prop_get_cardinal_with_atom_type (display, xwindow, xatom,
-                                                XA_CARDINAL, cardinal_p);
-}
-
 static gboolean
 cardinal_with_atom_type_from_results (GetPropertyResults *results,
                                       Atom                prop_type,

--- a/src/core/xprops.h
+++ b/src/core/xprops.h
@@ -111,10 +111,6 @@ gboolean meta_prop_get_window        (MetaDisplay   *display,
                                       Window         xwindow,
                                       Atom           xatom,
                                       Window        *window_p);
-gboolean meta_prop_get_cardinal      (MetaDisplay   *display,
-                                      Window         xwindow,
-                                      Atom           xatom,
-                                      gulong        *cardinal_p);
 gboolean meta_prop_get_cardinal_with_atom_type (MetaDisplay   *display,
                                                 Window         xwindow,
                                                 Atom           xatom,

--- a/src/meta/meta-window-actor.h
+++ b/src/meta/meta-window-actor.h
@@ -65,6 +65,9 @@ ClutterActor *     meta_window_actor_get_texture          (MetaWindowActor *self
 gboolean           meta_window_actor_is_override_redirect (MetaWindowActor *self);
 gboolean       meta_window_actor_showing_on_its_workspace (MetaWindowActor *self);
 gboolean       meta_window_actor_is_destroyed (MetaWindowActor *self);
+void           meta_window_actor_set_opacity  (MetaWindowActor *self,
+                                               guint8           opacity);
+guint8 meta_window_actor_get_opacity (MetaWindowActor *self);
 cairo_surface_t * meta_window_actor_get_image (MetaWindowActor       *self,
                                                cairo_rectangle_int_t *clip);
 void meta_window_actor_set_obscured (MetaWindowActor *self,


### PR DESCRIPTION
This restores actor opacity management without relying on a signal.

- Merges `maybe_desaturate_window` into `meta_window_actor_set_opacity`.
- Only propagates to clutter if the opacity changes.
- Scrolling on title bars opacifies windows unlike the version of this patch from #437.

Ref https://github.com/linuxmint/cinnamon/issues/8454