### PR TITLE
window-actor: Only toggle sync for fullscreen apps while redirected

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2264,6 +2264,17 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   return FALSE;
 }
 
+static void
+fullscreen_sync_toggle (MetaWindowActor *self,
+                        gboolean state)
+{
+  if (meta_prefs_get_unredirect_fullscreen_windows () &&
+      meta_prefs_get_sync_to_vblank ())
+    {
+      clutter_stage_x11_update_sync_state (self->priv->window->display->compositor->stage, state);
+    }
+}
+
 LOCAL_SYMBOL void
 meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
 {
@@ -2274,23 +2285,25 @@ meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
   Display *xdisplay = display->xdisplay;
   Window xwin = meta_window_actor_get_x_window (self);
 
+  if (priv->unredirected != state)
+    return;
+
   meta_error_trap_push (display);
 
   if (state)
     {
       XCompositeRedirectWindow (xdisplay, xwin, CompositeRedirectManual);
+      fullscreen_sync_toggle (self, TRUE);
       priv->unredirected = FALSE;
     }
   else
     {
+      fullscreen_sync_toggle (self, FALSE);
       meta_window_actor_detach (self);
       XCompositeUnredirectWindow (xdisplay, xwin, CompositeRedirectManual);
       priv->repaint_scheduled = TRUE;
       priv->unredirected = TRUE;
     }
-
-  if (meta_prefs_get_unredirect_fullscreen_windows () && meta_prefs_get_sync_to_vblank ())
-    clutter_stage_x11_update_sync_state (display->compositor->stage, state);
 
   meta_error_trap_pop (display);
 }


### PR DESCRIPTION
This fixes an issue with windows freezing in some situations. To reproduce, disable unredirection for fullscreen windows, and launch cinnamon-screensaver with d-feet (Session Bus -> org.cinnamon.ScreenSaver -> SetActive). This doesn't reproduce in normal situations for me, but @itzexor has run into it on amdgpu.