### PR TITLE
 Expose the sync method to preferences

### DIFF
--- a/clutter/clutter/clutter-main.c
+++ b/clutter/clutter/clutter-main.c
@@ -98,6 +98,7 @@ static gboolean clutter_disable_mipmap_text  = FALSE;
 static gboolean clutter_use_fuzzy_picking    = FALSE;
 static gboolean clutter_enable_accessibility = TRUE;
 static gboolean clutter_sync_to_vblank       = TRUE;
+SyncMethod clutter_sync_method               = SYNC_PRESENTATION_TIME;
 
 static guint clutter_default_fps             = 60;
 
@@ -3670,6 +3671,18 @@ gboolean
 _clutter_get_sync_to_vblank (void)
 {
   return clutter_sync_to_vblank;
+}
+
+void
+_clutter_set_sync_method (SyncMethod sync_method)
+{
+  clutter_sync_method = sync_method;
+}
+
+SyncMethod
+_clutter_get_sync_method (void)
+{
+  return clutter_sync_method;
 }
 
 void

--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -576,6 +576,9 @@ clutter_master_clock_default_class_init (ClutterMasterClockDefaultClass *klass)
 void
 clutter_master_clock_set_sync_method (SyncMethod method)
 {
+  const GSList *stages, *l;
+  ClutterStageManager *stage_manager = clutter_stage_manager_get_default ();
+
   switch (method)
     {
       case SYNC_NONE:
@@ -595,6 +598,13 @@ clutter_master_clock_set_sync_method (SyncMethod method)
     }
 
   master_clock_global->preferred_sync_method = method;
+
+  stages = stage_manager->stages;
+
+  for (l = stages; l; l = l->next)
+    {
+      _clutter_stage_clear_update_time (l->data);
+    }
 }
 
 static void

--- a/clutter/clutter/clutter-master-clock-default.c
+++ b/clutter/clutter/clutter-master-clock-default.c
@@ -595,19 +595,19 @@ clutter_master_clock_set_sync_method (SyncMethod method)
     }
 
   master_clock_global->preferred_sync_method = method;
-  master_clock_global->active_sync_method = method;
 }
 
 static void
 clutter_master_clock_default_init (ClutterMasterClockDefault *self)
 {
-  GSource *source;
+  GSource *source = clutter_clock_source_new (self);
+  SyncMethod method = _clutter_get_sync_method ();
 
-  source = clutter_clock_source_new (self);
   self->source = source;
   master_clock_global = self;
 
-  clutter_master_clock_set_sync_method (_clutter_get_sync_method ());
+  self->active_sync_method = method;
+  clutter_master_clock_set_sync_method (method);
 
   self->ensure_next_iteration = FALSE;
   self->paused = FALSE;

--- a/clutter/clutter/clutter-muffin.h
+++ b/clutter/clutter/clutter-muffin.h
@@ -66,6 +66,26 @@
 #include "deprecated/clutter-behaviour.h"
 #include "deprecated/clutter-container.h"
 
+typedef enum _SyncMethod /* In order of priority */
+{                        /* SUPPORTED  LATENCY      SMOOTHNESS             */
+  SYNC_NONE = 0,         /* Always     High         Poor                   */
+  SYNC_FALLBACK,         /* Always     Medium       Medium                 */
+  SYNC_SWAP_THROTTLING,  /* Usually    Medium-high  Medium, sometimes best */
+  SYNC_PRESENTATION_TIME /* Usually    Low          Good, sometimes best   */
+                         /* ^ As you can see SWAP_THROTTLING doesn't add much
+                              value. And it does create the the very real
+                              risk of blocking the main loop for up to 16ms
+                              at a time. So it might be a good idea to retire
+                              it in future and instead just make the backends
+                              use swap interval 0 + PRESENTATION_TIME. */
+} SyncMethod;
+
+CLUTTER_AVAILABLE_IN_MUFFIN
+SyncMethod _clutter_get_sync_method (void);
+
+CLUTTER_AVAILABLE_IN_MUFFIN
+void _clutter_set_sync_method (SyncMethod sync_method);
+
 CLUTTER_AVAILABLE_IN_MUFFIN
 void clutter_set_custom_backend_func (ClutterBackend *(* func) (void));
 
@@ -76,11 +96,11 @@ CLUTTER_AVAILABLE_IN_MUFFIN
 void            _clutter_set_sync_to_vblank     (gboolean      sync_to_vblank);
 
 CLUTTER_AVAILABLE_IN_MUFFIN
-void clutter_master_clock_set_sync_method (gint state);
+void clutter_master_clock_set_sync_method (SyncMethod method);
 
 CLUTTER_AVAILABLE_IN_MUFFIN
 void clutter_stage_x11_update_sync_state (ClutterStage *stage,
-                                          gint          state);
+                                          SyncMethod    method);
 
 CLUTTER_AVAILABLE_IN_MUFFIN
 int64_t clutter_stage_get_frame_counter (ClutterStage *stage);

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -48,6 +48,7 @@
 #include "clutter-main.h"
 #include "clutter-private.h"
 #include "clutter-stage-private.h"
+#include "clutter-muffin.h"
 
 typedef struct _ClutterStageViewCoglPrivate
 {

--- a/clutter/clutter/x11/clutter-stage-x11.c
+++ b/clutter/clutter/x11/clutter-stage-x11.c
@@ -613,24 +613,24 @@ frame_cb (CoglOnscreen  *onscreen,
 
 void
 clutter_stage_x11_update_sync_state (ClutterStage *stage,
-                                     gint          state)
+                                     SyncMethod    method)
 {
   ClutterStageWindow *stage_window;
   ClutterStageX11 *stage_x11;
+  gboolean state;
 
   g_return_if_fail (stage != NULL);
-
-  if (_clutter_get_sync_to_vblank () == state)
-    return;
 
   stage_window = CLUTTER_STAGE_WINDOW (_clutter_stage_get_window (CLUTTER_STAGE (stage)));
   stage_x11 = CLUTTER_STAGE_X11 (stage_window);
 
   g_return_if_fail (stage_x11->onscreen != NULL);
 
+  state = method != SYNC_NONE;
+
   _clutter_set_sync_to_vblank (state);
   cogl_onscreen_set_swap_throttled (stage_x11->onscreen, state);
-  clutter_master_clock_set_sync_method (state);
+  clutter_master_clock_set_sync_method (method);
 }
 
 static gboolean
@@ -642,6 +642,7 @@ clutter_stage_x11_realize (ClutterStageWindow *stage_window)
   ClutterBackendX11 *backend_x11 = CLUTTER_BACKEND_X11 (backend);
   ClutterDeviceManager *device_manager;
   gfloat width, height;
+  SyncMethod sync_method = _clutter_get_sync_method();
   GError *error = NULL;
 
   clutter_actor_get_size (CLUTTER_ACTOR (stage_cogl->wrapper), &width, &height);
@@ -654,7 +655,7 @@ clutter_stage_x11_realize (ClutterStageWindow *stage_window)
   stage_x11->onscreen = cogl_onscreen_new (backend->cogl_context, width, height);
 
   cogl_onscreen_set_swap_throttled (stage_x11->onscreen,
-                                    _clutter_get_sync_to_vblank ());
+                                    sync_method != SYNC_NONE);
 
   stage_x11->frame_closure =
     cogl_onscreen_add_frame_callback (stage_x11->onscreen,

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -89,7 +89,7 @@ void meta_compositor_grab_op_end (MetaCompositor *compositor);
 void meta_check_end_modal (MetaScreen *screen);
 
 void meta_compositor_update_sync_state (MetaCompositor *compositor,
-                                        gboolean state);
+                                        MetaSyncMethod  method);
 
 void meta_compositor_grab_op_begin (MetaCompositor *compositor);
 void meta_compositor_grab_op_end (MetaCompositor *compositor);

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1542,8 +1542,8 @@ meta_compositor_get_cogl_context (void)
 
 void
 meta_compositor_update_sync_state (MetaCompositor *compositor,
-                                   gboolean state)
+                                   MetaSyncMethod  method)
 {
-  clutter_stage_x11_update_sync_state (compositor->stage, state);
+  clutter_stage_x11_update_sync_state (compositor->stage, method);
 }
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2180,6 +2180,9 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
       priv->needs_pixmap = TRUE;
       meta_window_actor_update_shape (self);
 
+      if (priv->unredirected)
+        meta_display_set_all_obscured ();
+
       clutter_actor_set_size (CLUTTER_ACTOR (self),
                               window_rect.width, window_rect.height);
     }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2030,6 +2030,17 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   return FALSE;
 }
 
+static void
+fullscreen_sync_toggle (MetaWindowActor *self,
+                        gboolean state)
+{
+  if (meta_prefs_get_unredirect_fullscreen_windows () &&
+      meta_prefs_get_sync_to_vblank ())
+    {
+      clutter_stage_x11_update_sync_state (self->priv->window->display->compositor->stage, state);
+    }
+}
+
 LOCAL_SYMBOL void
 meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
 {
@@ -2040,23 +2051,25 @@ meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
   Display *xdisplay = display->xdisplay;
   Window xwin = meta_window_actor_get_x_window (self);
 
+  if (priv->unredirected != state)
+    return;
+
   meta_error_trap_push (display);
 
   if (state)
     {
       XCompositeRedirectWindow (xdisplay, xwin, CompositeRedirectManual);
+      fullscreen_sync_toggle (self, TRUE);
       priv->unredirected = FALSE;
     }
   else
     {
+      fullscreen_sync_toggle (self, FALSE);
       meta_window_actor_detach (self);
       XCompositeUnredirectWindow (xdisplay, xwin, CompositeRedirectManual);
       priv->repaint_scheduled = TRUE;
       priv->unredirected = TRUE;
     }
-
-  if (meta_prefs_get_unredirect_fullscreen_windows () && meta_prefs_get_sync_to_vblank ())
-    clutter_stage_x11_update_sync_state (display->compositor->stage, state);
 
   meta_error_trap_pop (display);
 }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2032,12 +2032,17 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
 
 static void
 fullscreen_sync_toggle (MetaWindowActor *self,
-                        gboolean state)
+                        gboolean         state)
 {
+  MetaSyncMethod method = meta_prefs_get_sync_method ();
+
   if (meta_prefs_get_unredirect_fullscreen_windows () &&
-      meta_prefs_get_sync_to_vblank ())
+      method != META_SYNC_NONE)
     {
-      clutter_stage_x11_update_sync_state (self->priv->window->display->compositor->stage, state);
+      clutter_stage_x11_update_sync_state (
+        self->priv->window->display->compositor->stage,
+        state ? method : META_SYNC_NONE
+      );
     }
 }
 

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -299,6 +299,7 @@ struct _MetaDisplay
 #define META_DISPLAY_HAS_COMPOSITE(display) ((display)->have_composite)
 #define META_DISPLAY_HAS_DAMAGE(display) ((display)->have_damage)
 #define META_DISPLAY_HAS_XFIXES(display) ((display)->have_xfixes)
+  MetaSyncMethod sync_method;
 
   guint shadows_enabled : 1;
   guint debug_button_grabs : 1;
@@ -442,7 +443,7 @@ guint meta_display_get_above_tab_keycode (MetaDisplay *display);
 
 void meta_display_notify_restart (MetaDisplay *display);
 
-void meta_display_update_sync_state (gboolean state);
+void meta_display_update_sync_state (MetaSyncMethod method);
 
 void meta_display_set_all_obscured (void);
 

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -545,6 +545,8 @@ meta_display_open (void)
 
   the_display->rebuild_keybinding_idle_id = 0;
 
+  the_display->sync_method = meta_prefs_get_sync_method();
+
   /* FIXME copy the checks from GDK probably */
   the_display->static_gravity_works = g_getenv ("MUFFIN_USE_STATIC_GRAVITY") != NULL;
   
@@ -5784,9 +5786,9 @@ meta_display_restart (MetaDisplay *display)
 }
 
 void
-meta_display_update_sync_state (gboolean state)
+meta_display_update_sync_state (MetaSyncMethod method)
 {
-  meta_compositor_update_sync_state (the_display->compositor, state);
+  meta_compositor_update_sync_state (the_display->compositor, method);
 }
 
 void

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -492,7 +492,7 @@ meta_init (void)
 
   /* Load prefs */
   meta_prefs_init ();
-  _clutter_set_sync_to_vblank(meta_prefs_get_sync_to_vblank());
+  _clutter_set_sync_method (meta_prefs_get_sync_method ());
 
   /*
    * Clutter can only be initialized after the UI.
@@ -630,8 +630,8 @@ prefs_changed_callback (MetaPreference pref,
       meta_display_set_cursor_theme (meta_prefs_get_cursor_theme (),
 				     meta_prefs_get_cursor_size ());
       break;
-    case META_PREF_SYNC_TO_VBLANK:
-      meta_display_update_sync_state (meta_prefs_get_sync_to_vblank());
+    case META_PREF_SYNC_METHOD:
+      meta_display_update_sync_state (meta_prefs_get_sync_method ());
       break;
     default:
       /* handled elsewhere or otherwise */

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -98,7 +98,7 @@ static CDesktopTitlebarScrollAction action_scroll_titlebar = C_DESKTOP_TITLEBAR_
 static gboolean dynamic_workspaces = FALSE;
 static gboolean unredirect_fullscreen_windows = FALSE;
 static gboolean desktop_effects = TRUE;
-static gboolean sync_to_vblank = TRUE;
+static MetaSyncMethod sync_method = META_SYNC_PRESENTATION_TIME;
 static gboolean threaded_swap = TRUE;
 static gboolean send_frame_timings = TRUE;
 static gboolean application_based = FALSE;
@@ -295,6 +295,13 @@ static MetaEnumPreference preferences_enum[] =
       },
       &background_transition,
     },
+    {
+      { "sync-method",
+        SCHEMA_MUFFIN,
+        META_PREF_SYNC_METHOD,
+      },
+      &sync_method,
+    },
     { { NULL, 0, 0 }, NULL },
   };
 
@@ -355,13 +362,6 @@ static MetaBoolPreference preferences_bool[] =
         META_PREF_DESKTOP_EFFECTS,
       },
       &desktop_effects,
-    },
-    {
-      { "sync-to-vblank",
-        SCHEMA_MUFFIN,
-        META_PREF_SYNC_TO_VBLANK,
-      },
-      &sync_to_vblank,
     },
     {
       { "threaded-swap",
@@ -1777,10 +1777,10 @@ meta_prefs_get_desktop_effects (void)
   return desktop_effects;
 }
 
-gboolean
-meta_prefs_get_sync_to_vblank (void)
+MetaSyncMethod
+meta_prefs_get_sync_method (void)
 {
-  return sync_to_vblank;
+  return sync_method;
 }
 
 gboolean
@@ -1930,8 +1930,8 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_UNREDIRECT_FULLSCREEN_WINDOWS:
       return "UNREDIRECT_FULLSCREEN_WINDOWS";
 
-    case META_PREF_SYNC_TO_VBLANK:
-      return "SYNC_TO_VBLANK";
+    case META_PREF_SYNC_METHOD:
+      return "SYNC_METHOD";
 
     case META_PREF_THREADED_SWAP:
       return "THREADED_SWAP";

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -454,4 +454,12 @@ typedef enum
   META_BACKGROUND_TRANSITION_BLEND
 } MetaBackgroundTransition;
 
+typedef enum
+{
+  META_SYNC_NONE = 0,
+  META_SYNC_FALLBACK,
+  META_SYNC_SWAP_THROTTLING,
+  META_SYNC_PRESENTATION_TIME
+} MetaSyncMethod;
+
 #endif

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -53,7 +53,7 @@ typedef enum
   META_PREF_DYNAMIC_WORKSPACES,
   META_PREF_UNREDIRECT_FULLSCREEN_WINDOWS,
   META_PREF_DESKTOP_EFFECTS,
-  META_PREF_SYNC_TO_VBLANK,
+  META_PREF_SYNC_METHOD,
   META_PREF_THREADED_SWAP,
   META_PREF_SEND_FRAME_TIMINGS,
   META_PREF_APPLICATION_BASED,
@@ -119,7 +119,7 @@ int                         meta_prefs_get_num_workspaces     (void);
 gboolean                    meta_prefs_get_workspace_cycle    (void);
 gboolean                    meta_prefs_get_dynamic_workspaces (void);
 gboolean                    meta_prefs_get_unredirect_fullscreen_windows (void);
-gboolean                    meta_prefs_get_sync_to_vblank (void);
+MetaSyncMethod              meta_prefs_get_sync_method (void);
 gboolean                    meta_prefs_get_threaded_swap (void);
 gboolean                    meta_prefs_get_send_frame_timings (void);
 gboolean                    meta_prefs_get_application_based  (void);

--- a/src/org.cinnamon.muffin.gschema.xml.in
+++ b/src/org.cinnamon.muffin.gschema.xml.in
@@ -1,4 +1,11 @@
 <schemalist>
+  <enum id="sync_method">
+    <value value="0" nick="none"/>
+    <value value="1" nick="fallback"/>
+    <value value="2" nick="swap_throttling"/>
+    <value value="3" nick="presentation_time"/>
+  </enum>
+
   <enum id="placement_type">
     <value value="0" nick="automatic"/>
     <value value="1" nick="pointer"/>
@@ -72,6 +79,12 @@
       <_description>
         Determines whether or not VBLANK is enabled.
       </_description>
+    </key>
+
+    <key name="sync-method" enum="sync_method">
+      <default>'presentation_time'</default>
+      <_summary>Sync method</_summary>
+      <_description>The method used by Muffin to provide VSync.</_description>
     </key>
 
     <key name="threaded-swap" type="b">


### PR DESCRIPTION
Our version of Clutter master clock has a few ways to handle frame timing with sync. This PR exposes them to settings so we can expand the best scenario for people on a wider variety of hardware.

Thanks to Daniel van Vugt for providing the original master clock code.

This includes conflicting bug fix PR #451.