### PR TITLE
Fix unredirection for wine games, mpv

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -95,7 +95,4 @@ void meta_compositor_grab_op_end (MetaCompositor *compositor);
 void meta_compositor_set_all_obscured (MetaCompositor *compositor,
                                        gboolean        obscured);
 
-void meta_compositor_update_opacity (ClutterActor *actor,
-                                     guint8        opacity);
-
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -30,6 +30,7 @@ struct _MetaCompositor
   GList          *windows;
 
   MetaWindowActor *unredirected_window;
+  MetaWindowActor *top_window_actor;
 
   CoglContext    *context;
 

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -206,8 +206,7 @@ process_property_notify (MetaCompositor	*compositor,
   /* Check for the opacity changing */
   if (event->atom == compositor->atom_net_wm_window_opacity)
     {
-      meta_window_actor_update_opacity (window_actor, 0);
-      DEBUG_TRACE ("process_property_notify: net_wm_window_opacity\n");
+      meta_window_actor_set_opacity (window_actor, -1);
       return;
     }
 
@@ -1669,9 +1668,3 @@ meta_compositor_update_sync_state (MetaCompositor *compositor,
   clutter_stage_x11_update_sync_state (compositor->stage, state);
 }
 
-void
-meta_compositor_update_opacity (ClutterActor    *actor,
-                                guint8           opacity)
-{
-  meta_window_actor_update_opacity (META_WINDOW_ACTOR (actor), opacity);
-}

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1119,10 +1119,10 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
       while (old_stack)
         {
           old_actor = old_stack->data;
-          old_window = meta_window_actor_get_meta_window (old_actor);
+          old_window = old_actor->priv->window;
 
           if ((old_window->hidden || old_window->unmanaging) &&
-              !meta_window_actor_effect_in_progress (old_actor))
+              !old_actor->priv->effect_in_progress)
             {
               old_stack = g_list_delete_link (old_stack, old_stack);
               old_actor = NULL;
@@ -1291,7 +1291,7 @@ meta_pre_paint_func (gpointer data)
       if (expected_unredirected_window != NULL)
         {
           meta_shape_cow_for_window (compositor->display->active_screen,
-                                     meta_window_actor_get_meta_window (top_window));
+                                     top_window->priv->window);
           meta_window_actor_set_redirected (top_window, FALSE);
         }
 
@@ -1568,7 +1568,7 @@ meta_compositor_get_window_for_xwindow (Window xwindow)
 
   for (l = compositor_global->windows; l; l = l->next)
     {
-      MetaWindow *window = meta_window_actor_get_meta_window (l->data);
+      MetaWindow *window = META_WINDOW_ACTOR (l->data)->priv->window;
       if (window->xwindow == xwindow)
         return window;
     }

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -7,7 +7,7 @@
  *
  * At a high-level, a window is not-visible or visible. When a
  * window is added (with meta_compositor_add_window()) it is not visible.
- * meta_compositor_show_window() indicates a transition from not-visible to
+ * meta_window_actor_show() indicates a transition from not-visible to
  * visible. Some of the reasons for this:
  *
  * - Window newly created
@@ -15,7 +15,7 @@
  * - Window is moved to the current desktop
  * - Window was made sticky
  *
- * meta_compositor_hide_window() indicates that the window has transitioned from
+ * meta_window_actor_hide() indicates that the window has transitioned from
  * visible to not-visible. Some reasons include:
  *
  * - Window was destroyed
@@ -25,19 +25,19 @@
  *
  * Note that combinations are possible - a window might have first
  * been minimized and then moved to a different desktop. The 'effect' parameter
- * to meta_compositor_show_window() and meta_compositor_hide_window() is a hint
+ * to meta_window_actor_show() and meta_window_actor_hide() is a hint
  * as to the appropriate effect to show the user and should not
  * be considered to be indicative of a state change.
  *
  * When the active workspace is changed, meta_compositor_switch_workspace() is
- * called first, then meta_compositor_show_window() and
- * meta_compositor_hide_window() are called individually for each window
+ * called first, then meta_window_actor_show() and
+ * meta_window_actor_hide() are called individually for each window
  * affected, with an effect of META_COMP_EFFECT_NONE.
  * If hiding windows will affect the switch workspace animation, the
  * compositor needs to delay hiding the windows until the switch
  * workspace animation completes.
  *
- * meta_compositor_maximize_window() and meta_compositor_unmaximize_window()
+ * meta_window_actor_maximize() and meta_window_actor_unmaximize()
  * are transitions within the visible state. The window is resized __before__
  * the call, so it may be necessary to readjust the display based on the
  * old_rect to start the animation.
@@ -54,7 +54,6 @@
  * override-redirect windows (ie. popups and menus) which will be placed in the
  * top window group.
  */
-
 
 #include <config.h>
 
@@ -77,9 +76,6 @@
 #include <X11/extensions/shape.h>
 #include <X11/extensions/Xcomposite.h>
 #include "meta-sync-ring.h"
-
-/* #define DEBUG_TRACE g_print */
-#define DEBUG_TRACE(X)
 
 static MetaCompositor *compositor_global = NULL;
 
@@ -148,33 +144,6 @@ meta_compositor_destroy (MetaCompositor *compositor)
 }
 
 static void
-add_win (MetaWindow *window)
-{
-  meta_window_actor_new (window);
-
-  sync_actor_stacking (window->screen->display->compositor);
-}
-
-static void
-process_damage (MetaCompositor     *compositor,
-                XDamageNotifyEvent *event,
-                MetaWindow         *window)
-{
-  MetaWindowActor *window_actor;
-
-  if (window == NULL)
-    return;
-
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  if (window_actor == NULL)
-    return;
-
-  meta_window_actor_process_damage (window_actor, event);
-
-  compositor->frame_has_updated_xsurfaces = TRUE;
-}
-
-static void
 process_property_notify (MetaCompositor	*compositor,
                          XPropertyEvent *event,
                          MetaWindow     *window)
@@ -187,7 +156,7 @@ process_property_notify (MetaCompositor	*compositor,
 
       for (l = meta_display_get_screens (compositor->display); l; l = l->next)
         {
-	  MetaScreen  *screen = l->data;
+          MetaScreen  *screen = l->data;
           if (event->window == meta_screen_get_xroot (screen))
             {
               meta_background_actor_update (screen);
@@ -199,7 +168,7 @@ process_property_notify (MetaCompositor	*compositor,
   if (window == NULL)
     return;
 
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
+  window_actor = window->compositor_private;
   if (window_actor == NULL)
     return;
 
@@ -209,8 +178,6 @@ process_property_notify (MetaCompositor	*compositor,
       meta_window_actor_set_opacity (window_actor, -1);
       return;
     }
-
-  DEBUG_TRACE ("process_property_notify: unknown\n");
 }
 
 static Window
@@ -754,10 +721,10 @@ meta_compositor_add_window (MetaCompositor    *compositor,
   MetaScreen *screen = meta_window_get_screen (window);
   MetaDisplay *display = meta_screen_get_display (screen);
 
-  DEBUG_TRACE ("meta_compositor_add_window\n");
   meta_error_trap_push (display);
 
-  add_win (window);
+  meta_window_actor_new (window);
+  sync_actor_stacking (window->screen->display->compositor);
 
   meta_error_trap_pop (display);
 }
@@ -769,8 +736,7 @@ meta_compositor_remove_window (MetaCompositor *compositor,
   MetaWindowActor         *window_actor     = NULL;
   MetaScreen *screen;
 
-  DEBUG_TRACE ("meta_compositor_remove_window\n");
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
+  window_actor = window->compositor_private;
   if (!window_actor)
     return;
 
@@ -784,36 +750,6 @@ meta_compositor_remove_window (MetaCompositor *compositor,
     }
 
   meta_window_actor_destroy (window_actor);
-}
-
-void
-meta_compositor_set_updates_frozen (MetaCompositor *compositor,
-                                    MetaWindow     *window,
-                                    gboolean        updates_frozen)
-{
-  MetaWindowActor *window_actor;
-
-  DEBUG_TRACE ("meta_compositor_set_updates_frozen\n");
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  if (!window_actor)
-    return;
-
-  meta_window_actor_set_updates_frozen (window_actor, updates_frozen);
-}
-
-void
-meta_compositor_queue_frame_drawn (MetaCompositor *compositor,
-                                   MetaWindow     *window,
-                                   gboolean        no_delay_frame)
-{
-  MetaWindowActor *window_actor;
-
-  DEBUG_TRACE ("meta_compositor_queue_frame_drawn\n");
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  if (!window_actor)
-    return;
-
-  meta_window_actor_queue_frame_drawn (window_actor, no_delay_frame);
 }
 
 static gboolean
@@ -832,18 +768,6 @@ is_grabbed_event (XEvent *event)
     }
 
   return FALSE;
-}
-
-void
-meta_compositor_window_shape_changed (MetaCompositor *compositor,
-                                      MetaWindow     *window)
-{
-  MetaWindowActor *window_actor;
-  window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  if (!window_actor)
-    return;
-
-  meta_window_actor_update_shape (window_actor);
 }
 
 /**
@@ -868,10 +792,7 @@ meta_compositor_process_event (MetaCompositor *compositor,
     }
 
   if (meta_plugin_manager_xevent_filter (compositor->plugin_mgr, event))
-    {
-      DEBUG_TRACE ("meta_compositor_process_event (filtered,window==NULL)\n");
-      return TRUE;
-    }
+    return TRUE;
 
   switch (event->type)
     {
@@ -891,10 +812,11 @@ meta_compositor_process_event (MetaCompositor *compositor,
               window = meta_display_lookup_x_window (compositor->display, xwin);
             }
 
-          DEBUG_TRACE ("meta_compositor_process_event (process_damage)\n");
-
-          if (window)
-            process_damage (compositor, (XDamageNotifyEvent *) event, window);
+          if (window && window->compositor_private)
+            {
+              meta_window_actor_process_damage (window->compositor_private, (XDamageNotifyEvent *) event);
+              compositor->frame_has_updated_xsurfaces = TRUE;
+            }
         }
       break;
     }
@@ -912,60 +834,6 @@ meta_compositor_process_event (MetaCompositor *compositor,
    * GTK+ windows in the same process, GTK+ needs the ConfigureNotify event, for example.
    */
   return FALSE;
-}
-
-void
-meta_compositor_show_window (MetaCompositor *compositor,
-			     MetaWindow	    *window,
-                             MetaCompEffect  effect)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  DEBUG_TRACE ("meta_compositor_show_window\n");
-  if (!window_actor)
-    return;
-
-  meta_window_actor_show (window_actor, effect);
-}
-
-void
-meta_compositor_hide_window (MetaCompositor *compositor,
-                             MetaWindow     *window,
-                             MetaCompEffect  effect)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  DEBUG_TRACE ("meta_compositor_hide_window\n");
-  if (!window_actor)
-    return;
-
-  meta_window_actor_hide (window_actor, effect);
-}
-
-void
-meta_compositor_maximize_window (MetaCompositor    *compositor,
-                                 MetaWindow        *window,
-				 MetaRectangle	   *old_rect,
-				 MetaRectangle	   *new_rect)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  DEBUG_TRACE ("meta_compositor_maximize_window\n");
-  if (!window_actor)
-    return;
-
-  meta_window_actor_maximize (window_actor, old_rect, new_rect);
-}
-
-void
-meta_compositor_unmaximize_window (MetaCompositor    *compositor,
-                                   MetaWindow        *window,
-				   MetaRectangle     *old_rect,
-				   MetaRectangle     *new_rect)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  DEBUG_TRACE ("meta_compositor_unmaximize_window\n");
-  if (!window_actor)
-    return;
-
-  meta_window_actor_unmaximize (window_actor, old_rect, new_rect);
 }
 
 void
@@ -999,20 +867,6 @@ meta_compositor_switch_workspace (MetaCompositor     *compositor,
       meta_finish_workspace_switch (compositor);
       meta_compositor_set_all_obscured (compositor, TRUE);
     }
-}
-
-void
-meta_compositor_tile_window (MetaCompositor    *compositor,
-                                 MetaWindow        *window,
-                               MetaRectangle     *old_rect,
-                               MetaRectangle     *new_rect)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-  DEBUG_TRACE ("meta_compositor_tile_window\n");
-  if (!window_actor)
-    return;
-
-  meta_window_actor_tile (window_actor, old_rect, new_rect);
 }
 
 static void
@@ -1096,8 +950,6 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
 {
   GList *old_stack;
 
-  DEBUG_TRACE ("meta_compositor_sync_stack\n");
-
   /* This is painful because hidden windows that we are in the process
    * of animating out of existence. They'll be at the bottom of the
    * stack of X windows, but we want to leave them in their old position
@@ -1135,7 +987,7 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
       while (stack)
         {
           stack_window = stack->data;
-          stack_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (stack_window));
+          stack_actor = META_WINDOW_ACTOR (stack_window->compositor_private);
           if (!stack_actor)
             {
               meta_verbose ("Failed to find corresponding MetaWindowActor "
@@ -1184,21 +1036,6 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
 }
 
 void
-meta_compositor_sync_window_geometry (MetaCompositor *compositor,
-				                              MetaWindow *window,
-                                      gboolean did_placement)
-{
-  MetaWindowActor *window_actor = META_WINDOW_ACTOR (meta_window_get_compositor_private (window));
-
-  DEBUG_TRACE ("meta_compositor_sync_window_geometry\n");
-
-  if (!window_actor)
-    return;
-
-  meta_window_actor_sync_actor_geometry (window_actor, did_placement);
-}
-
-void
 meta_compositor_sync_screen_size (MetaCompositor *compositor,
                                   MetaScreen	   *screen,
                                   guint		        width,
@@ -1208,8 +1045,6 @@ meta_compositor_sync_screen_size (MetaCompositor *compositor,
   Display *xdisplay;
   Window xwin;
 
-  DEBUG_TRACE ("meta_compositor_sync_screen_size\n");
-
   xdisplay = meta_display_get_xdisplay (display);
   xwin = clutter_x11_get_stage_window (CLUTTER_STAGE (compositor->stage));
 
@@ -1218,7 +1053,7 @@ meta_compositor_sync_screen_size (MetaCompositor *compositor,
   meta_background_actor_screen_size_changed (screen);
 
   meta_verbose ("Changed size for stage on screen %d to %dx%d\n",
-		meta_screen_get_screen_number (screen),
+		screen->number,
 		width, height);
 }
 

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -942,6 +942,30 @@ sync_actor_stacking (MetaCompositor *compositor)
   clutter_actor_set_child_below_sibling (parent, compositor->background_actor, NULL);
 }
 
+/*
+ * Find the top most window that is visible on the screen. The intention of
+ * this is to avoid offscreen windows that isn't actually part of the visible
+ * desktop (such as the UI frames override redirect window).
+ */
+static MetaWindowActor *
+get_top_visible_window_actor (MetaCompositor *compositor)
+{
+  GList *l;
+
+  for (l = g_list_last (compositor->windows); l; l = l->prev)
+    {
+      MetaWindowActor *actor = l->data;
+      MetaRectangle rect;
+
+      meta_window_get_input_rect (actor->priv->window, &rect);
+
+      if (meta_rectangle_overlap (&compositor->display->active_screen->rect, &rect))
+        return actor;
+    }
+
+  return NULL;
+}
+
 void
 meta_compositor_sync_stack (MetaCompositor  *compositor,
                             MetaScreen	    *screen,
@@ -1023,7 +1047,8 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
        * near the front of the other.)
        */
 
-      meta_window_actor_check_obscured (actor);
+      if (!actor->priv->unredirected)
+        meta_window_actor_check_obscured (actor);
 
       compositor->windows = g_list_prepend (compositor->windows, actor);
 
@@ -1032,6 +1057,8 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
     }
 
   sync_actor_stacking (compositor);
+
+  compositor->top_window_actor = get_top_visible_window_actor (compositor);
 }
 
 void
@@ -1102,17 +1129,18 @@ meta_pre_paint_func (gpointer data)
   GList *l;
   MetaCompositor *compositor = data;
   GSList *screens = compositor->display->screens;
-  MetaWindowActor *top_window;
+  MetaWindowActor *top_window_actor = NULL;
   MetaWindowActor *expected_unredirected_window = NULL;
 
   if (compositor->windows == NULL)
     return TRUE;
 
-  top_window = g_list_last (compositor->windows)->data;
+  top_window_actor = compositor->top_window_actor;
 
-  if (meta_window_actor_should_unredirect (top_window) &&
+  if (top_window_actor &&
+      meta_window_actor_should_unredirect (top_window_actor) &&
       compositor->disable_unredirect_count == 0)
-    expected_unredirected_window = top_window;
+    expected_unredirected_window = top_window_actor;
 
   if (compositor->unredirected_window != expected_unredirected_window)
     {
@@ -1125,8 +1153,8 @@ meta_pre_paint_func (gpointer data)
       if (expected_unredirected_window != NULL)
         {
           meta_shape_cow_for_window (compositor->display->active_screen,
-                                     top_window->priv->window);
-          meta_window_actor_set_redirected (top_window, FALSE);
+                                     top_window_actor->priv->window);
+          meta_window_actor_set_redirected (top_window_actor, FALSE);
         }
 
       compositor->unredirected_window = expected_unredirected_window;

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -733,10 +733,9 @@ void
 meta_compositor_remove_window (MetaCompositor *compositor,
                                MetaWindow     *window)
 {
-  MetaWindowActor         *window_actor     = NULL;
+  MetaWindowActor *window_actor = window->compositor_private;
   MetaScreen *screen;
 
-  window_actor = window->compositor_private;
   if (!window_actor)
     return;
 

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -49,8 +49,6 @@ void     meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
                                                 gboolean         did_placement);
 void     meta_window_actor_sync_visibility     (MetaWindowActor *self);
 void     meta_window_actor_update_shape        (MetaWindowActor *self);
-void     meta_window_actor_update_opacity      (MetaWindowActor *self,
-                                                guint8           opacity);
 void     meta_window_actor_mapped              (MetaWindowActor *self);
 void     meta_window_actor_unmapped            (MetaWindowActor *self);
 void     meta_window_actor_set_updates_frozen  (MetaWindowActor *self,
@@ -73,8 +71,6 @@ void meta_window_actor_effect_completed (MetaWindowActor *actor,
                                          gulong           event);
 
 void meta_window_actor_check_obscured (MetaWindowActor *self);
-void set_obscured (MetaWindowActor *self,
-                   gboolean         obscured);
 
 void meta_window_actor_decorated_notify (MetaWindowActor *self);
 void meta_window_actor_override_obscured_internal (MetaWindowActor *self,

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -9,6 +9,130 @@
 #include <meta/compositor-muffin.h>
 #include <clutter/clutter-muffin.h>
 
+#include "meta-shadow-factory-private.h"
+#include "meta-texture-tower.h"
+
+struct _MetaWindowActorPrivate
+{
+  MetaWindow *window;
+  Window xwindow;
+  MetaScreen *screen;
+
+  /* MetaShadowFactory only caches shadows that are actually in use;
+   * to avoid unnecessary recomputation we do two things: 1) we store
+   * both a focused and unfocused shadow for the window. If the window
+   * doesn't have different focused and unfocused shadow parameters,
+   * these will be the same. 2) when the shadow potentially changes we
+   * don't immediately unreference the old shadow, we just flag it as
+   * dirty and recompute it when we next need it (recompute_focused_shadow,
+   * recompute_unfocused_shadow.) Because of our extraction of
+   * size-invariant window shape, we'll often find that the new shadow
+   * is the same as the old shadow.
+   */
+  MetaShadow *focused_shadow;
+  MetaShadow *unfocused_shadow;
+
+  Pixmap pixmap;
+
+  Damage damage;
+
+  guint8 opacity;
+  CoglColor color;
+
+  /* If the window is shaped, a region that matches the shape */
+  cairo_region_t *shape_region;
+  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
+   * the shape region. */
+  cairo_region_t *opaque_region;
+  /* The region we should clip to when painting the shadow */
+  cairo_region_t *shadow_clip;
+
+   /* The region that is visible, used to optimize out redraws */
+  cairo_region_t *unobscured_region;
+
+  /* Extracted size-invariant shape used for shadows */
+  MetaWindowShape *shadow_shape;
+
+  gint last_width;
+  gint last_height;
+  gint last_x;
+  gint last_y;
+
+  gint freeze_count;
+
+  char *shadow_class;
+
+  gint effect_in_progress;
+
+  /* List of FrameData for recent frames */
+  GList *frames;
+
+  guint visible : 1;
+  guint argb32 : 1;
+  guint disposed : 1;
+  guint redecorating : 1;
+
+  guint needs_damage_all : 1;
+  guint received_damage : 1;
+  guint repaint_scheduled : 1;
+
+  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
+   * client message using the most recent frame in ->frames */
+  guint send_frame_messages_timer;
+  gint64 frame_drawn_time;
+  guint needs_frame_drawn : 1;
+
+  guint needs_pixmap : 1;
+  guint needs_reshape : 1;
+  guint recompute_focused_shadow : 1;
+  guint recompute_unfocused_shadow : 1;
+  guint size_changed : 1;
+  guint position_changed : 1;
+  guint updates_frozen : 1;
+
+  guint needs_destroy : 1;
+
+  guint no_shadow : 1;
+
+  guint unredirected : 1;
+
+  /* This is used to detect fullscreen windows that need to be unredirected */
+  guint full_damage_frames_count;
+  guint does_full_damage  : 1;
+
+  guint has_desat_effect : 1;
+
+  guint reshapes;
+  guint should_have_shadow : 1;
+  guint obscured : 1;
+  guint extend_obscured_timer : 1;
+  guint obscured_lock : 1;
+  guint public_obscured_lock : 1;
+  guint reset_obscured_timeout_id;
+  guint clip_shadow : 1;
+
+  guint first_frame_drawn;
+  guint first_frame_handler_queued;
+  guint first_frame_drawn_id;
+
+  /* Shaped texture */
+  MetaTextureTower *paint_tower;
+  CoglTexture *texture;
+  CoglTexture *mask_texture;
+
+  cairo_region_t *clip_region;
+
+  int tex_width, tex_height;
+
+  gint64 prev_invalidation, last_invalidation;
+  guint fast_updates;
+  guint remipmap_timeout_id;
+  gint64 earliest_remipmap;
+
+  guint create_mipmaps : 1;
+  guint mask_needs_update : 1;
+};
+
 MetaWindowActor *meta_window_actor_new (MetaWindow *window);
 
 void meta_window_actor_destroy   (MetaWindowActor *self);

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -37,6 +37,7 @@ struct _MetaWindowActorPrivate
   Damage damage;
 
   guint8 opacity;
+  guint opacity_queued;
   CoglColor color;
 
   /* If the window is shaped, a region that matches the shape */

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -197,8 +197,9 @@ void meta_window_actor_effect_completed (MetaWindowActor *actor,
 
 void meta_window_actor_check_obscured (MetaWindowActor *self);
 
-void meta_window_actor_decorated_notify (MetaWindowActor *self);
 void meta_window_actor_override_obscured_internal (MetaWindowActor *self,
                                                    gboolean         obscured);
+
+void meta_window_actor_appears_focused_notify (MetaWindowActor *self);
 
 #endif /* META_WINDOW_ACTOR_PRIVATE_H */

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1984,7 +1984,7 @@ LOCAL_SYMBOL gboolean
 meta_window_actor_should_unredirect (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  MetaWindow *metaWindow = priv->window;
+  MetaWindow *window = priv->window;
 
   if (meta_window_actor_is_destroyed (self))
     return FALSE;
@@ -1992,27 +1992,25 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   if (priv->obscured)
     return FALSE;
 
-  if (meta_window_requested_dont_bypass_compositor (metaWindow))
+  if (window->bypass_compositor == _NET_WM_BYPASS_COMPOSITOR_HINT_OFF)
     return FALSE;
 
   if (priv->opacity != 0xff)
     return FALSE;
 
-  if (metaWindow->has_shape)
+  if (window->has_shape)
     return FALSE;
 
-  gboolean requested_bypass_compositor = meta_window_requested_bypass_compositor (metaWindow);
-
-  if (priv->argb32 && !requested_bypass_compositor)
+  if (!meta_window_is_monitor_sized (window))
     return FALSE;
 
-  if (!meta_window_is_monitor_sized (metaWindow))
-    return FALSE;
-
-  if (requested_bypass_compositor)
+  if (window->bypass_compositor == _NET_WM_BYPASS_COMPOSITOR_HINT_ON)
     return TRUE;
 
-  if (metaWindow->override_redirect)
+  if (priv->argb32)
+    return FALSE;
+
+  if (window->override_redirect)
     return TRUE;
 
   if (priv->does_full_damage && meta_prefs_get_unredirect_fullscreen_windows ())
@@ -2057,10 +2055,20 @@ meta_window_actor_destroy (MetaWindowActor *self)
 {
   MetaWindow *window;
   MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
   MetaWindowType window_type;
 
   window = priv->window;
   window_type = window->type;
+
+  if (self == compositor->top_window_actor)
+    {
+      compositor->top_window_actor = NULL;
+      compositor->windows = g_list_remove (compositor->windows, self);
+
+      meta_stack_tracker_queue_sync_stack (priv->screen->stack_tracker);
+    }
+
   window->compositor_private = NULL;
 
   if (priv->send_frame_messages_timer != 0)

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -114,17 +114,7 @@ struct _MetaWindowActorPrivate
 
   char *            shadow_class;
 
-  /*
-   * These need to be counters rather than flags, since more plugins
-   * can implement same effect; the practicality of stacking effects
-   * might be dubious, but we have to at least handle it correctly.
-   */
-  gint              minimize_in_progress;
-  gint              maximize_in_progress;
-  gint              unmaximize_in_progress;
-  gint              tile_in_progress;
-  gint              map_in_progress;
-  gint              destroy_in_progress;
+  gint              effect_in_progress;
 
   /* List of FrameData for recent frames */
   GList            *frames;
@@ -1939,13 +1929,7 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
 LOCAL_SYMBOL gboolean
 meta_window_actor_effect_in_progress (MetaWindowActor *self)
 {
-  MetaWindowActorPrivate *priv = self->priv;
-  return (priv->minimize_in_progress ||
-          priv->maximize_in_progress ||
-          priv->unmaximize_in_progress ||
-          priv->map_in_progress ||
-          priv->tile_in_progress ||
-          priv->destroy_in_progress);
+  return self->priv->effect_in_progress;
 }
 
 static gboolean
@@ -1976,39 +1960,18 @@ start_simple_effect (MetaWindowActor *self,
   if (!compositor->plugin_mgr)
     return FALSE;
 
-  switch (event)
-  {
-  case META_PLUGIN_MINIMIZE:
-    counter = &priv->minimize_in_progress;
-    break;
-  case META_PLUGIN_MAP:
-    counter = &priv->map_in_progress;
-    break;
-  case META_PLUGIN_DESTROY:
-    counter = &priv->destroy_in_progress;
-    break;
-  case META_PLUGIN_UNMAXIMIZE:
-  case META_PLUGIN_MAXIMIZE:
-  case META_PLUGIN_SWITCH_WORKSPACE:
-  case META_PLUGIN_TILE:
-    g_assert_not_reached ();
-    break;
-  }
-
-  g_assert (counter);
-
   use_freeze_thaw = is_freeze_thaw_effect (event);
 
   if (use_freeze_thaw)
     meta_window_actor_freeze (self);
 
-  (*counter)++;
+  priv->effect_in_progress++;
 
   if (!meta_plugin_manager_event_simple (compositor->plugin_mgr,
                                          self,
                                          event))
     {
-      (*counter)--;
+      priv->effect_in_progress--;
       if (use_freeze_thaw)
         meta_window_actor_thaw (self);
       return FALSE;
@@ -2048,63 +2011,22 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
    * that the corresponding MetaWindow may have be been destroyed.
    * In this case priv->window will == NULL */
 
+  priv->effect_in_progress--;
+
+  if (priv->effect_in_progress < 0)
+    {
+      g_warning ("Error in effects accounting (%i)", event);
+      priv->effect_in_progress = 0;
+    }
+
   switch (event)
   {
     case META_PLUGIN_MINIMIZE:
-      {
-        priv->minimize_in_progress--;
-        if (priv->minimize_in_progress < 0)
-          {
-            g_warning ("Error in minimize accounting.");
-            priv->minimize_in_progress = 0;
-          }
-      }
-      break;
     case META_PLUGIN_MAP:
-      /*
-      * Make sure that the actor is at the correct place in case
-      * the plugin fscked.
-      */
-      priv->map_in_progress--;
-      priv->position_changed = TRUE;
-      if (priv->map_in_progress < 0)
-        {
-          g_warning ("Error in map accounting.");
-          priv->map_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_DESTROY:
-      priv->destroy_in_progress--;
-
-      if (priv->destroy_in_progress < 0)
-        {
-          g_warning ("Error in destroy accounting.");
-          priv->destroy_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_UNMAXIMIZE:
-      priv->unmaximize_in_progress--;
-      if (priv->unmaximize_in_progress < 0)
-        {
-          g_warning ("Error in unmaximize accounting.");
-          priv->unmaximize_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_MAXIMIZE:
-      priv->maximize_in_progress--;
-      if (priv->maximize_in_progress < 0)
-        {
-          g_warning ("Error in maximize accounting.");
-          priv->maximize_in_progress = 0;
-        }
-      break;
     case META_PLUGIN_TILE:
-      priv->tile_in_progress--;
-      if (priv->tile_in_progress < 0)
-        {
-          g_warning ("Error in tile accounting.");
-          priv->tile_in_progress = 0;
-        }
       break;
     case META_PLUGIN_SWITCH_WORKSPACE:
       g_assert_not_reached ();
@@ -2114,7 +2036,7 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
   if (is_freeze_thaw_effect (event))
     meta_window_actor_thaw (self);
 
-  if (!meta_window_actor_effect_in_progress (self))
+  if (!priv->effect_in_progress)
     meta_window_actor_after_effects (self);
 }
 
@@ -2302,7 +2224,7 @@ meta_window_actor_destroy (MetaWindowActor *self)
 
   priv->needs_destroy = TRUE;
 
-  if (!meta_window_actor_effect_in_progress (self))
+  if (!priv->effect_in_progress)
     clutter_actor_destroy (CLUTTER_ACTOR (self));
 }
 
@@ -2341,7 +2263,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
   if ((priv->freeze_count || priv->obscured) && !did_placement)
     return;
 
-  if (meta_window_actor_effect_in_progress (self))
+  if (priv->effect_in_progress)
     return;
 
   if (priv->size_changed)
@@ -2449,14 +2371,15 @@ meta_window_actor_maximize (MetaWindowActor    *self,
                             MetaRectangle      *old_rect,
                             MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
    * old size and position */
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->maximize_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2467,7 +2390,7 @@ meta_window_actor_maximize (MetaWindowActor    *self,
                                            new_rect->width, new_rect->height))
 
     {
-      self->priv->maximize_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }
@@ -2477,7 +2400,8 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
                               MetaRectangle     *old_rect,
                               MetaRectangle     *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -2485,7 +2409,7 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->unmaximize_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2495,7 +2419,7 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
                                            new_rect->x, new_rect->y,
                                            new_rect->width, new_rect->height))
     {
-      self->priv->unmaximize_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }
@@ -2505,7 +2429,8 @@ meta_window_actor_tile (MetaWindowActor    *self,
                         MetaRectangle      *old_rect,
                         MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaCompositor *compositor = priv->screen->display->compositor;
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -2513,7 +2438,7 @@ meta_window_actor_tile (MetaWindowActor    *self,
   clutter_actor_set_position (CLUTTER_ACTOR (self), old_rect->x, old_rect->y);
   clutter_actor_set_size (CLUTTER_ACTOR (self), old_rect->width, old_rect->height);
 
-  self->priv->tile_in_progress++;
+  priv->effect_in_progress++;
   meta_window_actor_freeze (self);
 
   if (!compositor->plugin_mgr ||
@@ -2524,7 +2449,7 @@ meta_window_actor_tile (MetaWindowActor    *self,
                                            new_rect->width, new_rect->height))
 
     {
-      self->priv->tile_in_progress--;
+      priv->effect_in_progress--;
       meta_window_actor_thaw (self);
     }
 }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1636,7 +1636,7 @@ meta_window_actor_check_obscured (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
 
-  if (!priv->first_frame_drawn)
+  if (!priv->first_frame_drawn || priv->effect_in_progress)
     {
       if (priv->obscured)
         set_obscured (self, FALSE);

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1838,7 +1838,6 @@ start_simple_effect (MetaWindowActor *self,
 {
   MetaWindowActorPrivate *priv = self->priv;
   MetaCompositor *compositor = priv->screen->display->compositor;
-  gint *counter = NULL;
   gboolean use_freeze_thaw = FALSE;
 
   if (!compositor->plugin_mgr)
@@ -1921,7 +1920,11 @@ meta_window_actor_effect_completed (MetaWindowActor *self,
     meta_window_actor_thaw (self);
 
   if (!priv->effect_in_progress)
-    meta_window_actor_after_effects (self);
+    {
+      if (event != META_PLUGIN_MAP)
+        priv->position_changed = TRUE;
+      meta_window_actor_after_effects (self);
+    }
 }
 
 static void

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -3359,7 +3359,7 @@ meta_window_actor_invalidate_shadow (MetaWindowActor *self)
   clutter_actor_queue_redraw (CLUTTER_ACTOR (self));
 }
 
-#define OPACITY_TYPE_CARDINAL -1
+static inline guint8 OPACITY_TYPE_CARDINAL = -1;
 
 void
 meta_window_actor_set_opacity (MetaWindowActor *self,

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -26,9 +26,7 @@
 #include "xprops.h"
 
 #include "compositor-private.h"
-#include "meta-texture-tower.h"
 #include "meta-texture-rectangle.h"
-#include "meta-shadow-factory-private.h"
 #include "meta-window-actor-private.h"
 
 #include "cogl-utils.h"
@@ -62,128 +60,6 @@ enum {
 };
 
 static guint signals[LAST_SIGNAL] = {0};
-
-
-struct _MetaWindowActorPrivate
-{
-  MetaWindow       *window;
-  Window            xwindow;
-  MetaScreen       *screen;
-
-  /* MetaShadowFactory only caches shadows that are actually in use;
-   * to avoid unnecessary recomputation we do two things: 1) we store
-   * both a focused and unfocused shadow for the window. If the window
-   * doesn't have different focused and unfocused shadow parameters,
-   * these will be the same. 2) when the shadow potentially changes we
-   * don't immediately unreference the old shadow, we just flag it as
-   * dirty and recompute it when we next need it (recompute_focused_shadow,
-   * recompute_unfocused_shadow.) Because of our extraction of
-   * size-invariant window shape, we'll often find that the new shadow
-   * is the same as the old shadow.
-   */
-  MetaShadow       *focused_shadow;
-  MetaShadow       *unfocused_shadow;
-
-  Pixmap            pixmap;
-
-  Damage            damage;
-
-  guint8            opacity;
-  CoglColor         color;
-
-  /* If the window is shaped, a region that matches the shape */
-  cairo_region_t   *shape_region;
-  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
-   * the shape region. */
-  cairo_region_t   *opaque_region;
-  /* The region we should clip to when painting the shadow */
-  cairo_region_t   *shadow_clip;
-
-   /* The region that is visible, used to optimize out redraws */
-  cairo_region_t   *unobscured_region;
-
-  /* Extracted size-invariant shape used for shadows */
-  MetaWindowShape  *shadow_shape;
-
-  gint              last_width;
-  gint              last_height;
-  gint              last_x;
-  gint              last_y;
-
-  gint              freeze_count;
-
-  char *            shadow_class;
-
-  gint              effect_in_progress;
-
-  /* List of FrameData for recent frames */
-  GList            *frames;
-
-  guint             visible                : 1;
-  guint             argb32                 : 1;
-  guint             disposed               : 1;
-  guint             redecorating           : 1;
-
-  guint             needs_damage_all       : 1;
-  guint             received_damage        : 1;
-  guint             repaint_scheduled      : 1;
-
-  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
-   * client message using the most recent frame in ->frames */
-  guint             send_frame_messages_timer;
-  gint64            frame_drawn_time;
-  guint             needs_frame_drawn      : 1;
-
-  guint             needs_pixmap           : 1;
-  guint             needs_reshape          : 1;
-  guint             recompute_focused_shadow   : 1;
-  guint             recompute_unfocused_shadow : 1;
-  guint             size_changed               : 1;
-  guint             position_changed           : 1;
-  guint             updates_frozen         : 1;
-
-  guint             needs_destroy     : 1;
-
-  guint             no_shadow              : 1;
-
-  guint             unredirected           : 1;
-
-  /* This is used to detect fullscreen windows that need to be unredirected */
-  guint             full_damage_frames_count;
-  guint             does_full_damage  : 1;
-
-  guint             has_desat_effect : 1;
-
-  guint             reshapes;
-  guint             should_have_shadow : 1;
-  guint             obscured : 1;
-  guint             extend_obscured_timer : 1;
-  guint             obscured_lock : 1;
-  guint             public_obscured_lock : 1;
-  guint             reset_obscured_timeout_id;
-  guint             clip_shadow : 1;
-
-  guint             first_frame_drawn;
-  guint             first_frame_handler_queued;
-  guint             first_frame_drawn_id;
-
-  /* Shaped texture */
-  MetaTextureTower *paint_tower;
-  CoglTexture *texture;
-  CoglTexture *mask_texture;
-
-  cairo_region_t *clip_region;
-
-  int tex_width, tex_height;
-
-  gint64 prev_invalidation, last_invalidation;
-  guint fast_updates;
-  guint remipmap_timeout_id;
-  gint64 earliest_remipmap;
-
-  guint create_mipmaps : 1;
-  guint mask_needs_update : 1;
-};
 
 typedef struct _FrameData FrameData;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -3380,9 +3380,9 @@ meta_window_actor_set_opacity (MetaWindowActor *self,
       Window xwin = priv->window->xwindow;
       gulong value;
 
-      if (meta_prop_get_cardinal (display, xwin,
-                                  compositor->atom_net_wm_window_opacity,
-                                  &value))
+      if (meta_prop_get_cardinal_with_atom_type (display, xwin,
+                                                 compositor->atom_net_wm_window_opacity,
+                                                 XA_CARDINAL, &value))
         {
           opacity = (guint8)((gfloat)value * 255.0 / ((gfloat)0xffffffff));
         }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -281,11 +281,9 @@ meta_window_actor_init (MetaWindowActor *self)
 }
 
 static void
-window_decorated_notify (MetaWindow *mw,
-                         GParamSpec *arg1,
-                         gpointer    data)
+window_decorated_notify (MetaWindow *mw)
 {
-  MetaWindowActor *self = META_WINDOW_ACTOR (data);
+  MetaWindowActor *self = META_WINDOW_ACTOR (mw->compositor_private);
   MetaWindowActorPrivate *priv = self->priv;
   MetaFrame *frame = mw->frame;
   MetaScreen *screen = priv->screen;
@@ -323,27 +321,15 @@ window_decorated_notify (MetaWindow *mw,
                                 XDamageReportBoundingBox);
 }
 
-static void
-window_appears_focused_notify (MetaWindow *mw,
-                               GParamSpec *arg1,
-                               gpointer    data)
+void
+meta_window_actor_appears_focused_notify (MetaWindowActor *self)
 {
-  MetaWindowActor *self = META_WINDOW_ACTOR (data);
   MetaWindowActorPrivate *priv = self->priv;
 
   if (priv->obscured)
     set_obscured (self, FALSE);
 
   clutter_actor_queue_redraw (CLUTTER_ACTOR (self));
-}
-
-static void
-window_position_changed (MetaWindow *mw,
-                         gpointer    data)
-{
-  MetaWindowActor *self = META_WINDOW_ACTOR (meta_window_get_compositor_private (mw));
-
-  g_signal_emit (self, signals[POSITION_CHANGED], 0); // Compatibility
 }
 
 static void
@@ -405,8 +391,6 @@ meta_window_actor_dispose (GObject *object)
       g_source_remove (priv->reset_obscured_timeout_id);
       priv->reset_obscured_timeout_id = 0;
   }
-
-  meta_window_set_position_changed_callback (priv->window, NULL);
 
   if (priv->first_frame_drawn_id)
     {
@@ -481,9 +465,6 @@ meta_window_actor_set_property (GObject      *object,
 
         g_signal_connect_object (priv->window, "notify::decorated",
                                  G_CALLBACK (window_decorated_notify), self, 0);
-        g_signal_connect_object (priv->window, "notify::appears-focused",
-                                 G_CALLBACK (window_appears_focused_notify), self, 0);
-        meta_window_set_position_changed_callback (priv->window, window_position_changed);
       }
       break;
     case PROP_META_SCREEN:
@@ -2080,7 +2061,7 @@ meta_window_actor_destroy (MetaWindowActor *self)
 
   window = priv->window;
   window_type = window->type;
-  meta_window_set_compositor_private (window, NULL);
+  window->compositor_private = NULL;
 
   if (priv->send_frame_messages_timer != 0)
     {
@@ -2360,11 +2341,11 @@ meta_window_actor_new (MetaWindow *window)
 
   meta_verbose ("add window: Meta %p, xwin 0x%x\n", window, (guint)top_window);
 
-  self = g_object_new (META_TYPE_WINDOW_ACTOR,
-                       "meta-window",         window,
-                       "x-window",            top_window,
-                       "meta-screen",         screen,
-                       NULL);
+  self = window->compositor_private = g_object_new (META_TYPE_WINDOW_ACTOR,
+                                                    "meta-window",   window,
+                                                    "x-window",      top_window,
+                                                    "meta-screen",   screen,
+                                                    NULL);
 
   priv = self->priv;
 
@@ -2386,9 +2367,6 @@ meta_window_actor_new (MetaWindow *window)
 
   meta_window_actor_sync_actor_geometry (self, priv->window->placed);
 
-  /* Hang our compositor window state off the MetaWindow for fast retrieval */
-  meta_window_set_compositor_private (window, G_OBJECT (self));
-
   if (window->type == META_WINDOW_DND)
     window_group = compositor->window_group;
   else if (window->layer == META_LAYER_OVERRIDE_REDIRECT)
@@ -2406,6 +2384,9 @@ meta_window_actor_new (MetaWindow *window)
    * before we first paint.
    */
   compositor->windows = g_list_append (compositor->windows, self);
+
+  /* Opacity handling */
+  meta_window_actor_set_opacity (self, -1);
 
   clutter_actor_set_flags (CLUTTER_ACTOR (self), CLUTTER_ACTOR_NO_LAYOUT);
 
@@ -3433,12 +3414,11 @@ meta_window_actor_set_opacity (MetaWindowActor *self,
         }
       else
         {
-          /* This is will tend to get called fairly often - opening new windows, various
+          /* This will tend to get called fairly often - opening new windows, various
              events on the window, like minimizing... but it's inexpensive - if the ClutterActor
              priv->effects is NULL, it simply returns.  By default cinnamon and muffin add no
              other effects except the special case of dimmed windows (attached modal dialogs), which
              isn't a frequent occurrence. */
-
           clutter_actor_remove_effect_by_name (actor, "desaturate-for-transparency");
           priv->has_desat_effect = FALSE;
         }

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -89,11 +89,13 @@ meta_window_group_cull_out (MetaWindowGroup *group,
 
           if (clutter_actor_get_paint_opacity (CLUTTER_ACTOR (window_actor)) == 0xff)
             {
-              cairo_region_t *obscured_region = meta_window_actor_get_obscured_region (window_actor);
-              if (obscured_region)
+              MetaWindowActorPrivate *priv = window_actor->priv;
+              cairo_region_t *obscured_region = NULL;
+
+              if (priv->opaque_region && priv->pixmap && priv->opacity == 0xff)
                 {
-                  cairo_region_subtract (unobscured_region, obscured_region);
-                  cairo_region_subtract (clip_region, obscured_region);
+                  cairo_region_subtract (unobscured_region, priv->opaque_region);
+                  cairo_region_subtract (clip_region, priv->opaque_region);
                 }
             }
 
@@ -223,7 +225,7 @@ meta_window_group_paint (ClutterActor *actor)
   if (has_unredirected_window)
     {
       cairo_rectangle_int_t unredirected_rect;
-      MetaWindow *window = meta_window_actor_get_meta_window (compositor->unredirected_window);
+      MetaWindow *window = compositor->unredirected_window->priv->window;
 
       unredirected_rect.x = window->outer_rect.x;
       unredirected_rect.y = window->outer_rect.y;

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1752,8 +1752,8 @@ event_callback (XEvent   *event,
                               window->desc);
                 }
 
-              meta_compositor_window_shape_changed (display->compositor,
-                                                    window);
+              if (window->compositor_private)
+                meta_window_actor_update_shape (window->compositor_private);
             }
         }
       else

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1222,9 +1222,8 @@ meta_screen_composite_all_windows (MetaScreen *screen)
       MetaWindow *window = tmp->data;
 
       meta_compositor_add_window (display->compositor, window);
-      if (window->visible_to_compositor)
-        meta_compositor_show_window (display->compositor, window,
-                                     META_COMP_EFFECT_NONE);
+      if (window->visible_to_compositor && window->compositor_private)
+        meta_window_actor_show (window->compositor_private, META_COMP_EFFECT_NONE);
     }
 
   g_slist_free (windows);

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -503,7 +503,7 @@ struct _MetaWindow
   /* maintained by group.c */
   MetaGroup *group;
 
-  GObject *compositor_private;
+  MetaWindowActor *compositor_private;
 
   /* Focused window that is (directly or indirectly) attached to this one */
   MetaWindow *attached_focus_window;
@@ -515,6 +515,7 @@ struct _MetaWindow
   guint bypass_compositor;
 
   MetaWindowCallback position_changed_callback;
+  MetaWindowCallback decorated_callback;
 };
 
 struct _MetaWindowClass

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -675,15 +675,13 @@ static void
 meta_window_set_opaque_region (MetaWindow     *window,
                                cairo_region_t *region)
 {
-  if (cairo_region_equal (window->opaque_region, region))
-    return;
-
   g_clear_pointer (&window->opaque_region, cairo_region_destroy);
 
   if (region != NULL)
     window->opaque_region = cairo_region_reference (region);
 
-  meta_compositor_window_shape_changed (window->display->compositor, window);
+  if (window->compositor_private)
+    meta_window_actor_update_shape (window->compositor_private);
 }
 
 static void
@@ -735,7 +733,8 @@ reload_opaque_region (MetaWindow    *window,
     }
 
  out:
-  meta_window_set_opaque_region (window, opaque_region);
+  if (!cairo_region_equal (window->opaque_region, opaque_region))
+    meta_window_set_opaque_region (window, opaque_region);
   cairo_region_destroy (opaque_region);
 }
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4334,11 +4334,11 @@ LOCAL_SYMBOL void
 meta_window_adjust_opacity (MetaWindow   *window,
                             gboolean      increase)
 {
-  ClutterActor *actor = CLUTTER_ACTOR (window->compositor_private);
+  MetaWindowActor *actor = META_WINDOW_ACTOR (window->compositor_private);
 
   gint current_opacity, new_opacity;
 
-  current_opacity = clutter_actor_get_opacity (actor);
+  current_opacity = meta_window_actor_get_opacity (actor);
 
   if (increase) {
     new_opacity = MIN (current_opacity + OPACITY_STEP, 255);
@@ -4346,17 +4346,14 @@ meta_window_adjust_opacity (MetaWindow   *window,
     new_opacity = MAX (current_opacity - OPACITY_STEP, MAX (0, meta_prefs_get_min_win_opacity ()));
   }
 
-  if (new_opacity != current_opacity) {
-    meta_compositor_update_opacity (actor, (guint8) new_opacity);
-  }
+  if (new_opacity != current_opacity)
+    meta_window_actor_set_opacity (actor, (guint8) new_opacity);
 }
 
 void
 meta_window_reset_opacity (MetaWindow *window)
 {
-    ClutterActor *actor = CLUTTER_ACTOR (window->compositor_private);
-
-    clutter_actor_set_opacity (actor, 255);
+  meta_window_actor_set_opacity (META_WINDOW_ACTOR (window->compositor_private), 255);
 }
 
 static gboolean

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1773,9 +1773,9 @@ meta_window_unmanage (MetaWindow  *window,
 
   meta_display_set_all_obscured ();
 
-  if (window->visible_to_compositor || meta_window_is_attached_dialog (window))
-    meta_compositor_hide_window (window->display->compositor, window,
-                                 META_COMP_EFFECT_DESTROY);
+  if (window->compositor_private &&
+      (window->visible_to_compositor || meta_window_is_attached_dialog (window)))
+    meta_window_actor_hide (window->compositor_private, META_COMP_EFFECT_DESTROY);
 
   meta_compositor_remove_window (window->display->compositor, window);
 
@@ -3138,8 +3138,8 @@ meta_window_show (MetaWindow *window)
           break;
         }
 
-      meta_compositor_show_window (window->display->compositor,
-                                   window, effect);
+      if (window->compositor_private)
+        meta_window_actor_show (window->compositor_private, effect);
     }
 
   /* We don't want to worry about all cases from inside
@@ -3233,8 +3233,8 @@ meta_window_hide (MetaWindow *window)
           break;
         }
 
-      meta_compositor_hide_window (window->display->compositor,
-                                   window, effect);
+      if (window->compositor_private)
+        meta_window_actor_hide (window->compositor_private, effect);
     }
 
   did_hide = FALSE;
@@ -3578,12 +3578,11 @@ meta_window_maximize (MetaWindow        *window,
 
     meta_window_move_resize_now (window);
 
-    if (desktop_effects)
+    if (desktop_effects && window->compositor_private)
       {
-        meta_compositor_maximize_window (window->display->compositor,
-                                        window,
-                                        &old_rect,
-                                        &window->outer_rect);
+        meta_window_actor_maximize (window->compositor_private,
+                                    &old_rect,
+                                    &window->outer_rect);
       }
     }
 
@@ -3797,10 +3796,7 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
       if (desktop_effects && window->compositor_private)
         {
           meta_window_get_input_rect (window, &new_rect);
-          meta_compositor_tile_window (window->display->compositor,
-                                      window,
-                                      &old_rect,
-                                      &new_rect);
+          meta_window_actor_tile (window->compositor_private, &old_rect, &new_rect);
         }
 
       if (window->frame)
@@ -4024,12 +4020,11 @@ meta_window_unmaximize_internal (MetaWindow        *window,
                                             target_rect.width,
                                             target_rect.height);
 
-          if (desktop_effects)
+          if (desktop_effects && window->compositor_private)
             {
-              meta_compositor_unmaximize_window (window->display->compositor,
-                                                window,
-                                                &old_rect,
-                                                &window->outer_rect);
+              meta_window_actor_unmaximize (window->compositor_private,
+                                            &old_rect,
+                                            &window->outer_rect);
             }
         }
       else
@@ -4641,8 +4636,9 @@ meta_window_create_sync_request_alarm (MetaWindow *window)
         XSyncValueLow32 (init) + ((gint64)XSyncValueHigh32 (init) << 32);
 
       /* if the value is odd, the window starts off with updates frozen */
-      meta_compositor_set_updates_frozen (window->display->compositor, window,
-                                          meta_window_updates_are_frozen (window));
+      if (window->compositor_private)
+        meta_window_actor_set_updates_frozen (window->compositor_private,
+                                              meta_window_updates_are_frozen (window));
     }
   else
     {
@@ -4717,8 +4713,9 @@ sync_request_timeout (gpointer data)
    * window updates
    */
   window->sync_request_wait_serial = 0;
-  meta_compositor_set_updates_frozen (window->display->compositor, window,
-                                      meta_window_updates_are_frozen (window));
+  if (window->compositor_private)
+    meta_window_actor_set_updates_frozen (window->compositor_private,
+                                          meta_window_updates_are_frozen (window));
 
   if (window == window->display->grab_window &&
       meta_grab_op_is_resizing (window->display->grab_op))
@@ -4779,8 +4776,9 @@ send_sync_request (MetaWindow *window)
                                                    sync_request_timeout,
                                                    window);
 
-  meta_compositor_set_updates_frozen (window->display->compositor, window,
-                                      meta_window_updates_are_frozen (window));
+  if (window->compositor_private)
+    meta_window_actor_set_updates_frozen (window->compositor_private,
+                                          meta_window_updates_are_frozen (window));
 }
 #endif
 
@@ -5364,33 +5362,19 @@ meta_window_move_resize_internal (MetaWindow          *window,
   else if (is_user_action)
     save_user_window_placement (window);
 
-  if (need_move_frame || need_move_client)
-    {
-      if (window->position_changed_callback != NULL)
-        (window->position_changed_callback) (window);
-    }
+  if (window->compositor_private && (need_move_frame || need_move_client))
+    g_signal_emit_by_name (window->compositor_private, "position-changed");
 
   if (need_resize_client)
     g_signal_emit (window, window_signals[SIZE_CHANGED], 0);
 
-  if (need_move_frame || need_resize_frame ||
+  if (window->compositor_private &&
+      (need_move_frame || need_resize_frame ||
       need_move_client || need_resize_client ||
-      did_placement)
+      did_placement))
     {
-      int newx, newy;
-      meta_window_get_position (window, &newx, &newy);
-      meta_topic (META_DEBUG_GEOMETRY,
-                  "New size/position %d,%d %dx%d (user %d,%d %dx%d)\n",
-                  newx, newy, window->rect.width, window->rect.height,
-                  window->user_rect.x, window->user_rect.y,
-                  window->user_rect.width, window->user_rect.height);
-      meta_compositor_sync_window_geometry (window->display->compositor,
-                                            window,
-                                            did_placement);
-    }
-  else
-    {
-      meta_topic (META_DEBUG_GEOMETRY, "Size/position not modified\n");
+      meta_window_actor_sync_actor_geometry (window->compositor_private,
+                                             did_placement);
     }
 
   meta_window_refresh_resize_popup (window);
@@ -5726,13 +5710,13 @@ meta_window_configure_notify (MetaWindow      *window,
   /* Whether an override-redirect window is considered fullscreen depends
    * on its geometry.
    */
-  if (window->override_redirect)
-    meta_screen_queue_check_fullscreen (window->screen);
+  meta_screen_queue_check_fullscreen (window->screen);
 
   if (!event->override_redirect && !event->send_event)
     meta_warning ("Unhandled change of windows override redirect status\n");
 
-  meta_compositor_sync_window_geometry (window->display->compositor, window, FALSE);
+  if (window->compositor_private)
+    meta_window_actor_sync_actor_geometry (window->compositor_private, FALSE);
 }
 
 LOCAL_SYMBOL void
@@ -7439,10 +7423,14 @@ meta_window_appears_focused_changed (MetaWindow *window)
   set_net_wm_state (window);
   meta_window_frame_size_changed (window);
 
-  g_object_notify (G_OBJECT (window), "appears-focused");
-
   if (window->frame)
     meta_frame_queue_draw (window->frame);
+
+  clutter_threads_add_idle_full (100,
+                                (GSourceFunc) meta_window_actor_appears_focused_notify,
+                                window->compositor_private, NULL);
+
+  g_object_notify (G_OBJECT (window), "appears-focused");
 }
 
 /**
@@ -10142,8 +10130,9 @@ meta_window_update_sync_request_counter (MetaWindow *window,
     }
 
   window->sync_request_serial = new_counter_value;
-  meta_compositor_set_updates_frozen (window->display->compositor, window,
-                                      meta_window_updates_are_frozen (window));
+  if (window->compositor_private)
+    meta_window_actor_set_updates_frozen (window->compositor_private,
+                                          meta_window_updates_are_frozen (window));
 
   if (window == window->display->grab_window &&
       meta_grab_op_is_resizing (window->display->grab_op) &&
@@ -10174,9 +10163,8 @@ meta_window_update_sync_request_counter (MetaWindow *window,
    */
   window->disable_sync = FALSE;
 
-  if (needs_frame_drawn)
-    meta_compositor_queue_frame_drawn (window->display->compositor, window,
-                                       no_delay_frame);
+  if (needs_frame_drawn && window->compositor_private)
+    meta_window_actor_queue_frame_drawn (window->compositor_private, no_delay_frame);
 }
 #endif /* HAVE_XSYNC */
 
@@ -11680,15 +11668,7 @@ meta_window_get_compositor_private (MetaWindow *window)
 {
   if (!window)
     return NULL;
-  return window->compositor_private;
-}
-
-void
-meta_window_set_compositor_private (MetaWindow *window, GObject *priv)
-{
-  if (!window)
-    return;
-  window->compositor_private = priv;
+  return G_OBJECT (window->compositor_private);
 }
 
 const char *
@@ -12411,23 +12391,5 @@ meta_window_get_icon_name (MetaWindow *window)
     g_return_val_if_fail (META_IS_WINDOW (window), NULL);
 
     return window->theme_icon_name;
-}
-
-/**
- * meta_window_set_position_changed_callback:
- * @window: a #MetaWindow
- * @callback (scope notified): callback
- * @user_data (closure): user data
- * @data_destroy: a #GDestroyNotify
- *
- * Sets the callback which will be invoked on position change.
- */
-void
-meta_window_set_position_changed_callback (MetaWindow        *window,
-                                           MetaWindowCallback callback,
-                                           gpointer           user_data,
-                                           GDestroyNotify     data_destroy)
-{
-  window->position_changed_callback = callback;
 }
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3689,18 +3689,20 @@ meta_window_is_monitor_sized (MetaWindow *window)
 
   if (window->override_redirect)
     {
-      MetaRectangle monitor_rect;
-      int screen_width, screen_height;
+      MetaScreen *screen = window->screen;
+      MetaRectangle *outer_rect = &window->outer_rect;
 
-      meta_screen_get_size (window->screen, &screen_width, &screen_height);
-
-      if (window->outer_rect.x == 0 && window->outer_rect.y == 0 &&
-          window->outer_rect.width == screen_width && window->outer_rect.height == screen_height)
+      if (outer_rect->x == 0 && outer_rect->y == 0 &&
+          outer_rect->width == screen->rect.width &&
+          outer_rect->height == screen->rect.height)
         return TRUE;
 
-      meta_screen_get_monitor_geometry (window->screen, window->monitor->number, &monitor_rect);
+      MetaRectangle *monitor_rect = &window->monitor->rect;
 
-      if (meta_rectangle_equal (&window->outer_rect, &monitor_rect))
+      if (monitor_rect->width == outer_rect->width &&
+          monitor_rect->height == outer_rect->height &&
+          monitor_rect->x == outer_rect->x &&
+          monitor_rect->y == outer_rect->y)
         return TRUE;
     }
 

--- a/src/meta/compositor.h
+++ b/src/meta/compositor.h
@@ -45,7 +45,7 @@
  *   shown or hidden immediately.
  *
  * Indicates the appropriate effect to show the user for
- * meta_compositor_show_window() and meta_compositor_hide_window()
+ * meta_window_actor_show() and meta_window_actor_hide()
  */
 typedef enum
 {
@@ -63,9 +63,6 @@ void meta_compositor_manage_screen   (MetaCompositor *compositor,
                                       MetaScreen     *screen);
 void meta_compositor_unmanage_screen (MetaCompositor *compositor,
                                       MetaScreen     *screen);
-
-void meta_compositor_window_shape_changed (MetaCompositor *compositor,
-                                           MetaWindow     *window);
 
 gboolean meta_compositor_process_event (MetaCompositor *compositor,
                                         XEvent         *event,
@@ -113,36 +110,11 @@ void meta_compositor_add_window    (MetaCompositor *compositor,
 void meta_compositor_remove_window (MetaCompositor *compositor,
                                     MetaWindow     *window);
 
-void meta_compositor_show_window       (MetaCompositor      *compositor,
-                                        MetaWindow          *window,
-                                        MetaCompEffect       effect);
-void meta_compositor_hide_window       (MetaCompositor      *compositor,
-                                        MetaWindow          *window,
-                                        MetaCompEffect       effect);
 void meta_compositor_switch_workspace  (MetaCompositor      *compositor,
                                         MetaScreen          *screen,
                                         MetaWorkspace       *from,
                                         MetaWorkspace       *to,
                                         MetaMotionDirection  direction);
-
-void meta_compositor_maximize_window   (MetaCompositor      *compositor,
-                                        MetaWindow          *window,
-                                        MetaRectangle       *old_rect,
-                                        MetaRectangle       *new_rect);
-void meta_compositor_unmaximize_window (MetaCompositor      *compositor,
-                                        MetaWindow          *window,
-                                        MetaRectangle       *old_rect,
-                                        MetaRectangle       *new_rect);
-
-void meta_compositor_sync_window_geometry (MetaCompositor *compositor,
-                                           MetaWindow     *window,
-                                           gboolean        did_placement);
-void meta_compositor_set_updates_frozen   (MetaCompositor *compositor,
-                                           MetaWindow     *window,
-                                           gboolean        updates_frozen);
-void meta_compositor_queue_frame_drawn    (MetaCompositor *compositor,
-                                           MetaWindow     *window,
-                                           gboolean        no_delay_frame);
 
 void meta_compositor_sync_stack                (MetaCompositor *compositor,
                                                 MetaScreen     *screen,
@@ -154,11 +126,6 @@ void meta_compositor_sync_screen_size          (MetaCompositor *compositor,
 
 void meta_compositor_flash_screen              (MetaCompositor *compositor,
                                                 MetaScreen     *screen);
-
-void meta_compositor_tile_window       (MetaCompositor      *compositor,
-                                        MetaWindow          *window,
-                                        MetaRectangle       *old_rect,
-                                        MetaRectangle       *new_rect);
 
 void meta_compositor_show_tile_preview (MetaCompositor  *compositor,
                                         MetaScreen      *screen,

--- a/src/meta/meta-window-actor.h
+++ b/src/meta/meta-window-actor.h
@@ -65,6 +65,9 @@ ClutterActor *     meta_window_actor_get_texture          (MetaWindowActor *self
 gboolean           meta_window_actor_is_override_redirect (MetaWindowActor *self);
 gboolean       meta_window_actor_showing_on_its_workspace (MetaWindowActor *self);
 gboolean       meta_window_actor_is_destroyed (MetaWindowActor *self);
+void           meta_window_actor_set_opacity  (MetaWindowActor *self,
+                                               guint8           opacity);
+guint8 meta_window_actor_get_opacity (MetaWindowActor *self);
 cairo_surface_t * meta_window_actor_get_image (MetaWindowActor       *self,
                                                cairo_rectangle_int_t *clip);
 void meta_window_actor_set_obscured (MetaWindowActor *self,

--- a/src/meta/window.h
+++ b/src/meta/window.h
@@ -130,7 +130,6 @@ void meta_window_change_workspace (MetaWindow    *window,
 void meta_window_stick (MetaWindow  *window);
 void meta_window_unstick (MetaWindow  *window);
 GObject *meta_window_get_compositor_private (MetaWindow *window);
-void meta_window_set_compositor_private (MetaWindow *window, GObject *priv);
 void meta_window_configure_notify (MetaWindow *window, XConfigureEvent *event);
 const char *meta_window_get_role (MetaWindow *window);
 MetaStackLayer meta_window_get_layer (MetaWindow *window);


### PR DESCRIPTION
a008357f5126e8d337b5e30716b052cf4153357c

This makes our unredirection heuristic closer to mutter's, and fixes detection of the topmost window.

Adapted from

GNOME/mutter@2e99963
GNOME/mutter@3caefd8
GNOME/mutter@b1587f0

Based on #449, #454 to avoid issues.

Closes #400 