### PR TITLE
clutter-actor: Keep is_dirty unchanged for culled actors

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -3956,12 +3956,12 @@ clutter_actor_paint (ClutterActor *self)
                   pick_mode == CLUTTER_PICK_NONE))
     _clutter_actor_draw_paint_volume (self);
 
-done:
   /* If we make it here then the actor has run through a complete
      paint run including all the effects so it's no longer dirty */
   if (pick_mode == CLUTTER_PICK_NONE)
     priv->is_dirty = FALSE;
 
+done:
   if (clip_set)
     {
       CoglFramebuffer *fb = _clutter_stage_get_active_framebuffer (stage);


### PR DESCRIPTION
Cherry-picked from https://github.com/gnome/mutter/commit/ee507d9ab2b2f277447976c3f5ddc55375fef1eb

https://gitlab.gnome.org/GNOME/mutter/merge_requests/511