### PR TITLE
clutter: Fix check for keyboard a11y features

### DIFF
--- a/clutter/clutter/evdev/clutter-input-device-evdev.c
+++ b/clutter/clutter/evdev/clutter-input-device-evdev.c
@@ -1134,7 +1134,7 @@ clutter_input_device_evdev_process_kbd_a11y_event (ClutterEvent               *e
   if (event->key.flags & CLUTTER_EVENT_FLAG_INPUT_METHOD)
     goto emit_event;
 
-  if (!device_evdev->a11y_flags & CLUTTER_A11Y_KEYBOARD_ENABLED)
+  if (!(device_evdev->a11y_flags & CLUTTER_A11Y_KEYBOARD_ENABLED))
     goto emit_event;
 
   if (device_evdev->a11y_flags & CLUTTER_A11Y_MOUSE_KEYS_ENABLED)


### PR DESCRIPTION
Cherry-picked from https://github.com/gnome/mutter/commit/34ee46022e467fda89a781dd07f90061a42d984d

 https://gitlab.gnome.org/GNOME/mutter/issues/529