### PR TITLE
compositor: Avoid changing pipeline/source if shadow is not being painted

### DIFF
--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -215,9 +215,7 @@ meta_shadow_paint (MetaShadow     *shadow,
   int dest_x[4];
   int dest_y[4];
   int n_x, n_y;
-
-  cogl_pipeline_set_color4ub (shadow->pipeline,
-                              opacity, opacity, opacity, opacity);
+  gboolean source_updated = FALSE;
 
   cogl_set_source (shadow->pipeline);
 
@@ -294,6 +292,17 @@ meta_shadow_paint (MetaShadow     *shadow,
             overlap = cairo_region_contains_rectangle (clip, &dest_rect);
           else
             overlap = CAIRO_REGION_OVERLAP_IN;
+
+          if (overlap == CAIRO_REGION_OVERLAP_OUT)
+            continue;
+
+          if (!source_updated)
+            {
+              cogl_pipeline_set_color4ub (shadow->pipeline,
+                                          opacity, opacity, opacity, opacity);
+              cogl_set_source (shadow->pipeline);
+              source_updated = TRUE;
+            }
 
           /* There's quite a bit of overhead from allocating a new
            * region in order to find an exact intersection and


### PR DESCRIPTION
Cherry-picked from https://github.com/gnome/mutter/commit/3c6a518d40d0ed8d04343f0780100e88f8519ed1