### PR TITLE
clutter-stage: Remove unused variable, double assignment

### DIFF
--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1464,8 +1464,6 @@ _clutter_stage_do_pick_on_view (ClutterStage     *stage,
   float viewport_offset_x;
   float viewport_offset_y;
 
-  priv = stage->priv;
-
   context = _clutter_context_get_default ();
   fb_scale = clutter_stage_view_get_scale (view);
   clutter_stage_view_get_layout (view, &view_layout);

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -962,10 +962,7 @@ clutter_stage_cogl_get_dirty_pixel (ClutterStageWindow *stage_window,
       ClutterStageViewCogl *view_cogl = CLUTTER_STAGE_VIEW_COGL (view);
       ClutterStageViewCoglPrivate *view_priv =
         clutter_stage_view_cogl_get_instance_private (view_cogl);
-      cairo_rectangle_int_t view_layout;
       cairo_rectangle_int_t *fb_damage;
-
-      clutter_stage_view_get_layout (view, &view_layout);
 
       fb_damage = &view_priv->damage_history[DAMAGE_HISTORY (view_priv->damage_index - 1)];
       *x = fb_damage->x / fb_scale;


### PR DESCRIPTION
Cherry-picked from https://gitlab.gnome.org/GNOME/mutter/merge_requests/402