### PR TITLE
window-actor: Use int for opacity

### DIFF
--- a/src/compositor/meta-shadow-factory-private.h
+++ b/src/compositor/meta-shadow-factory-private.h
@@ -46,7 +46,7 @@ void        meta_shadow_paint       (MetaShadow            *shadow,
                                      int                    window_y,
                                      int                    window_width,
                                      int                    window_height,
-                                     guint8                 opacity,
+                                     int                    opacity,
                                      cairo_region_t        *clip,
                                      gboolean               clip_strictly);
 void        meta_shadow_get_bounds  (MetaShadow            *shadow,

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -203,7 +203,7 @@ meta_shadow_paint (MetaShadow     *shadow,
                    int             window_y,
                    int             window_width,
                    int             window_height,
-                   guint8          opacity,
+                   int             opacity,
                    cairo_region_t *clip,
                    gboolean        clip_strictly)
 {

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -36,7 +36,7 @@ struct _MetaWindowActorPrivate
 
   Damage damage;
 
-  guint8 opacity;
+  int opacity;
   guint opacity_queued;
   CoglColor color;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -86,7 +86,7 @@ enum
 #define DEFAULT_SHADOW_X_OFFSET 0
 #define DEFAULT_SHADOW_Y_OFFSET 8
 
-static inline guint8 OPACITY_TYPE_CARDINAL = 256;
+static inline int OPACITY_TYPE_CARDINAL = 256;
 
 static void meta_window_actor_dispose    (GObject *object);
 static void meta_window_actor_finalize   (GObject *object);
@@ -193,14 +193,14 @@ meta_window_actor_class_init (MetaWindowActorClass *klass)
                                    PROP_X_WINDOW,
                                    pspec);
 
-  pspec = g_param_spec_uint ("opacity",
-                             "Opacity",
-                             "Opacity of a window actor actor",
-                             0, 255,
-                             255,
-                             G_PARAM_READWRITE |
-                             G_PARAM_STATIC_STRINGS |
-                             META_WINDOW_ACTOR_PARAM_ANIMATABLE);
+  pspec = g_param_spec_int ("opacity",
+                            "Opacity",
+                            "Opacity of a window actor actor",
+                            0, 255,
+                            255,
+                            G_PARAM_READWRITE |
+                            G_PARAM_STATIC_STRINGS |
+                            META_WINDOW_ACTOR_PARAM_ANIMATABLE);
 
   g_object_class_install_property (object_class,
                                    PROP_OPACITY,
@@ -476,7 +476,7 @@ meta_window_actor_set_property (GObject      *object,
       priv->xwindow = g_value_get_ulong (value);
       break;
     case PROP_OPACITY:
-      meta_window_actor_set_opacity (self, g_value_get_uint (value));
+      meta_window_actor_set_opacity (self, g_value_get_int (value));
       break;
     case PROP_NO_SHADOW:
       {
@@ -529,7 +529,7 @@ meta_window_actor_get_property (GObject      *object,
       g_value_set_ulong (value, priv->xwindow);
       break;
     case PROP_OPACITY:
-      g_value_set_uint (value, priv->opacity);
+      g_value_set_int (value, priv->opacity);
       break;
     case PROP_NO_SHADOW:
       g_value_set_boolean (value, priv->no_shadow);
@@ -802,7 +802,7 @@ paint_clipped_rectangle (CoglFramebuffer       *fb,
 
 static void
 texture_paint (ClutterActor *actor,
-               guint8        opacity)
+               int           opacity)
 {
   MetaWindowActor *self = META_WINDOW_ACTOR (actor);
   MetaWindowActorPrivate *priv = self->priv;
@@ -1035,7 +1035,7 @@ meta_window_actor_paint (ClutterActor *actor)
 {
   MetaWindowActor *self = META_WINDOW_ACTOR (actor);
   MetaWindowActorPrivate *priv = self->priv;
-  guint8 opacity = priv->opacity;
+  int opacity = priv->opacity;
 
   /* Disable painting of obscured windows. The window's obscured
      property will reset during move, resize, unmaximize, minimize,
@@ -3364,7 +3364,7 @@ meta_window_actor_invalidate_shadow (MetaWindowActor *self)
 
 void
 meta_window_actor_set_opacity (MetaWindowActor *self,
-                               guint8           opacity)
+                               int              opacity)
 {
   MetaWindowActorPrivate *priv = self->priv;
 
@@ -3385,7 +3385,7 @@ meta_window_actor_set_opacity (MetaWindowActor *self,
                                                  compositor->atom_net_wm_window_opacity,
                                                  XA_CARDINAL, &value))
         {
-          opacity = (guint8)((gfloat)value * 255.0 / ((gfloat)0xffffffff));
+          opacity = (int)((gfloat)value * 255.0 / ((gfloat)0xffffffff));
         }
       else
         opacity = 255;
@@ -3445,7 +3445,7 @@ meta_window_actor_set_opacity (MetaWindowActor *self,
     }
 }
 
-guint8
+int
 meta_window_actor_get_opacity (MetaWindowActor *self)
 {
   return self->priv->opacity;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4333,7 +4333,7 @@ meta_window_adjust_opacity (MetaWindow   *window,
 {
   MetaWindowActor *actor = META_WINDOW_ACTOR (window->compositor_private);
 
-  gint current_opacity, new_opacity;
+  int current_opacity, new_opacity;
 
   current_opacity = meta_window_actor_get_opacity (actor);
 
@@ -4344,7 +4344,7 @@ meta_window_adjust_opacity (MetaWindow   *window,
   }
 
   if (new_opacity != current_opacity)
-    meta_window_actor_set_opacity (actor, (guint8) new_opacity);
+    meta_window_actor_set_opacity (actor, new_opacity);
 }
 
 void

--- a/src/meta/meta-shadow-factory.h
+++ b/src/meta/meta-shadow-factory.h
@@ -49,7 +49,7 @@ struct _MetaShadowParams
   int top_fade;
   int x_offset;
   int y_offset;
-  guint8 opacity;
+  int opacity;
 };
 
 #define META_TYPE_SHADOW_FACTORY            (meta_shadow_factory_get_type ())

--- a/src/meta/meta-window-actor.h
+++ b/src/meta/meta-window-actor.h
@@ -66,8 +66,8 @@ gboolean           meta_window_actor_is_override_redirect (MetaWindowActor *self
 gboolean       meta_window_actor_showing_on_its_workspace (MetaWindowActor *self);
 gboolean       meta_window_actor_is_destroyed (MetaWindowActor *self);
 void           meta_window_actor_set_opacity  (MetaWindowActor *self,
-                                               guint8           opacity);
-guint8 meta_window_actor_get_opacity (MetaWindowActor *self);
+                                               int              opacity);
+int meta_window_actor_get_opacity (MetaWindowActor *self);
 cairo_surface_t * meta_window_actor_get_image (MetaWindowActor       *self,
                                                cairo_rectangle_int_t *clip);
 void meta_window_actor_set_obscured (MetaWindowActor *self,


### PR DESCRIPTION
This fixes an issue with #449 where client requests didn't propagate due to the max possible value for `guint8` being 255.