### PR TITLE
compositor: Fix workspace switching, improve window dragging smoothness

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -18538,18 +18538,6 @@ clutter_actor_get_last_child (ClutterActor *self)
   return self->priv->last_child;
 }
 
-/* easy way to have properly named fields instead of the dummy ones
- * we use in the public structure
- */
-typedef struct _RealActorIter
-{
-  ClutterActor *root;           /* dummy1 */
-  ClutterActor *current;        /* dummy2 */
-  gpointer padding_1;           /* dummy3 */
-  gint age;                     /* dummy4 */
-  gpointer padding_2;           /* dummy5 */
-} RealActorIter;
-
 /**
  * clutter_actor_iter_init:
  * @iter: a #ClutterActorIter

--- a/clutter/clutter/clutter-muffin.h
+++ b/clutter/clutter/clutter-muffin.h
@@ -268,6 +268,18 @@ struct _ClutterActorPrivate
   guint needs_paint_volume_update   : 1;
 };
 
+/* easy way to have properly named fields instead of the dummy ones
+ * we use in the public structure
+ */
+typedef struct _RealActorIter
+{
+  ClutterActor *root;           /* dummy1 */
+  ClutterActor *current;        /* dummy2 */
+  gpointer padding_1;           /* dummy3 */
+  gint age;                     /* dummy4 */
+  gpointer padding_2;           /* dummy5 */
+} RealActorIter;
+
 #undef __CLUTTER_H_INSIDE__
 
 #endif /* __CLUTTER_MUFFIN_H__ */

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -28,7 +28,6 @@ struct _MetaCompositor
   ClutterActor   *hidden_group;
 
   GList          *windows;
-  guint           length;
 
   MetaWindowActor *unredirected_window;
   MetaWindowActor *top_window_actor;
@@ -56,7 +55,6 @@ struct _MetaCompositor
   guint           show_redraw : 1;
   guint           debug       : 1;
   guint           no_mipmaps  : 1;
-  guint           layout;
 
   gboolean frame_has_updated_xsurfaces;
   gboolean have_x11_sync_object;

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -57,7 +57,6 @@ struct _MetaCompositor
   guint           debug       : 1;
   guint           no_mipmaps  : 1;
   guint           layout;
-  guint           grab_op_obscured_override;
 
   gboolean frame_has_updated_xsurfaces;
   gboolean have_x11_sync_object;

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -28,6 +28,7 @@ struct _MetaCompositor
   ClutterActor   *hidden_group;
 
   GList          *windows;
+  guint           length;
 
   MetaWindowActor *unredirected_window;
   MetaWindowActor *top_window_actor;
@@ -55,6 +56,8 @@ struct _MetaCompositor
   guint           show_redraw : 1;
   guint           debug       : 1;
   guint           no_mipmaps  : 1;
+  guint           layout;
+  guint           grab_op_obscured_override;
 
   gboolean frame_has_updated_xsurfaces;
   gboolean have_x11_sync_object;

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1523,8 +1523,6 @@ meta_compositor_set_all_obscured (MetaCompositor *compositor,
 void
 meta_compositor_grab_op_begin (MetaCompositor *compositor)
 {
-  MetaWindow *grab_window = compositor->display->grab_window;
-
   // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
   // but causes windows to flicker in and out of view sporadically on some configurations
   // while dragging windows when one window is open. Make sure it is disabled during the grab.

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1520,75 +1520,6 @@ meta_compositor_set_all_obscured (MetaCompositor *compositor,
     meta_window_actor_override_obscured_internal (l->data, obscured);
 }
 
-static gboolean
-on_move_throttled (MetaCompositor *compositor)
-{
-  MetaWindow *grab_window = compositor->display->grab_window;
-  const MetaMonitorInfo *old_monitor;
-
-  if (!grab_window || compositor->display->grab_op == META_GRAB_OP_NONE)
-    return FALSE;
-
-  old_monitor = grab_window->monitor;
-
-  if (!old_monitor)
-    return FALSE;
-
-  meta_window_update_outer_rect (grab_window);
-  grab_window->monitor = meta_screen_get_monitor_for_rect (grab_window->screen, &grab_window->outer_rect);
-
-  if (grab_window->monitor != old_monitor)
-    determine_optimization_strategy_for_grab (compositor, grab_window, FALSE);
-
-  return TRUE;
-}
-
-static void
-determine_optimization_strategy_for_grab (MetaCompositor *compositor,
-                                          MetaWindow     *grab_window,
-                                          gboolean        from_grab)
-{
-  /* Typically MetaWindowActor tries to only paint windows when the user can see them,
-     and lets  everything paint when we're unsure if a window can be exposed unpainted.
-     However, in some cases we can estimate if that is possible, and if not, then no need
-     to disable the optimization. This improves the smoothness of window dragging if we're
-     able to not worry about windows being exposed. */
-  GList *grab_window_item = g_list_find (compositor->windows, grab_window->compositor_private);
-  GList *l;
-  gboolean grab_op_obscured_override = TRUE;
-
-  /* Start from the grab window and iterate in reverse so we are only
-     checking windows potentially underneath. */
-  for (l = grab_window_item; l; l = l->prev)
-    {
-      MetaWindow *prev_window = META_WINDOW_ACTOR (l->data)->priv->window;
-
-      /* Only windows on the same monitor can be underneath the grab window. */
-      if (prev_window->monitor != grab_window->monitor)
-        continue;
-
-      /* If the window is maximized, on the same monitor, and underneath, then we don't
-         need to disable the obscured optimization. The maximized window underneath cannot
-         be fully obscured. This only works per-monitor however, so this function
-         will be called on window monitor change. */
-      if (META_WINDOW_MAXIMIZED (prev_window))
-        {
-          grab_op_obscured_override = FALSE;
-          break;
-        }
-    }
-
-  if (grab_op_obscured_override)
-    meta_compositor_set_all_obscured (compositor, FALSE);
-  else if (!from_grab && grab_op_obscured_override != compositor->grab_op_obscured_override)
-    meta_compositor_set_all_obscured (compositor, TRUE);
-
-  if (from_grab)
-    g_timeout_add_full (1000, 500, (GSourceFunc) on_move_throttled, compositor, NULL);
-
-  compositor->grab_op_obscured_override = grab_op_obscured_override;
-}
-
 void
 meta_compositor_grab_op_begin (MetaCompositor *compositor)
 {
@@ -1597,13 +1528,13 @@ meta_compositor_grab_op_begin (MetaCompositor *compositor)
   // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
   // but causes windows to flicker in and out of view sporadically on some configurations
   // while dragging windows when one window is open. Make sure it is disabled during the grab.
-  if (compositor->length < 2)
+  if (compositor->length < 4)
     {
       compositor->layout = TRUE;
       clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
     }
 
-  determine_optimization_strategy_for_grab (compositor, grab_window, TRUE);
+  meta_compositor_set_all_obscured (compositor, FALSE);
 }
 
 void
@@ -1617,11 +1548,7 @@ meta_compositor_grab_op_end (MetaCompositor *compositor)
       clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
     }
 
-  if (compositor->grab_op_obscured_override)
-    {
-      compositor->grab_op_obscured_override = FALSE;
-      meta_compositor_set_all_obscured (compositor, TRUE);
-    }
+  meta_compositor_set_all_obscured (compositor, TRUE);
 
   meta_window_update_rects (window);
   meta_window_update_monitor (window);

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1081,7 +1081,6 @@ meta_compositor_sync_stack (MetaCompositor  *compositor,
   sync_actor_stacking (compositor);
 
   compositor->top_window_actor = get_top_visible_window_actor (compositor);
-  compositor->length = g_list_length (compositor->windows);
 }
 
 void
@@ -1525,13 +1524,8 @@ meta_compositor_grab_op_begin (MetaCompositor *compositor)
 {
   // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
   // but causes windows to flicker in and out of view sporadically on some configurations
-  // while dragging windows when one window is open. Make sure it is disabled during the grab.
-  if (compositor->length < 4)
-    {
-      compositor->layout = TRUE;
-      clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-    }
-
+  // while dragging windows. Make sure it is disabled during the grab.
+  clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
   meta_compositor_set_all_obscured (compositor, FALSE);
 }
 
@@ -1540,11 +1534,7 @@ meta_compositor_grab_op_end (MetaCompositor *compositor)
 {
   MetaWindow *window = compositor->display->grab_window;
 
-  if (compositor->layout)
-    {
-      compositor->layout = FALSE;
-      clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-    }
+  clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 
   meta_compositor_set_all_obscured (compositor, TRUE);
 

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1413,7 +1413,7 @@ meta_compositor_show_tile_preview (MetaCompositor *compositor,
                                    int            tile_monitor_number,
                                    guint          snap_queued)
 {
-  meta_window_update_rects (window);
+  meta_window_update_outer_rect (window);
   meta_plugin_manager_show_tile_preview (compositor->plugin_mgr,
                                           window, tile_rect, tile_monitor_number,
                                           snap_queued);
@@ -1550,7 +1550,7 @@ meta_compositor_grab_op_end (MetaCompositor *compositor)
 
   meta_compositor_set_all_obscured (compositor, TRUE);
 
-  meta_window_update_rects (window);
+  meta_window_update_outer_rect (window);
   meta_window_update_monitor (window);
 }
 

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -185,9 +185,6 @@ cairo_region_t *meta_window_actor_get_obscured_region (MetaWindowActor *self);
 
 void meta_window_actor_set_clip_region         (MetaWindowActor *self,
                                                 cairo_region_t  *clip_region);
-void meta_window_actor_set_clip_region_beneath (MetaWindowActor *self,
-                                                cairo_region_t  *clip_region);
-void meta_window_actor_reset_visible_regions      (MetaWindowActor *self);
 
 void meta_window_actor_set_unobscured_region      (MetaWindowActor *self,
                                                    cairo_region_t  *unobscured_region);

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -89,6 +89,7 @@ struct _MetaWindowActorPrivate
   guint recompute_unfocused_shadow : 1;
   guint size_changed : 1;
   guint position_changed : 1;
+  guint geometry_changed : 1;
   guint updates_frozen : 1;
 
   guint needs_destroy : 1;

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1138,7 +1138,7 @@ meta_window_actor_queue_relayout (ClutterActor *actor)
 {
   MetaWindowActorPrivate *priv = META_WINDOW_ACTOR (actor)->priv;
 
-  if (priv->window->display->grab_window == priv->window)
+  if (priv->size_changed || priv->position_changed)
     CLUTTER_ACTOR_CLASS (meta_window_actor_parent_class)->queue_relayout (actor);
 }
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2157,7 +2157,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
   if (priv->size_changed || !priv->first_frame_drawn)
     {
       if (!priv->window->has_shape || !priv->first_frame_handler_queued)
-      meta_window_update_client_area_rect (priv->window);
+        meta_window_update_client_area_rect (priv->window);
 
       priv->needs_pixmap = TRUE;
       meta_window_actor_update_shape (self);
@@ -3000,7 +3000,7 @@ process_shape_region (MetaWindowActor *self)
   g_clear_pointer (&priv->shadow_shape, meta_window_shape_unref);
   g_clear_pointer (&priv->opaque_region, cairo_region_destroy);
 
-  client_area = &window->client_area;
+  client_area = window->client_area;
 
   if (has_frame)
     region = meta_window_get_frame_bounds (window);

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1138,8 +1138,11 @@ meta_window_actor_queue_relayout (ClutterActor *actor)
 {
   MetaWindowActorPrivate *priv = META_WINDOW_ACTOR (actor)->priv;
 
-  if (priv->size_changed || priv->position_changed)
-    CLUTTER_ACTOR_CLASS (meta_window_actor_parent_class)->queue_relayout (actor);
+  if (priv->geometry_changed)
+    {
+      priv->geometry_changed = FALSE;
+      CLUTTER_ACTOR_CLASS (meta_window_actor_parent_class)->queue_relayout (actor);
+    }
 }
 
 static gboolean
@@ -2086,7 +2089,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
   if (priv->last_width != window_rect->width ||
       priv->last_height != window_rect->height)
     {
-      priv->size_changed = TRUE;
+      priv->size_changed = priv->geometry_changed = TRUE;
     }
 
   priv->last_width = window_rect->width;
@@ -2095,7 +2098,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
   if (priv->last_x != window_rect->x ||
       priv->last_y != window_rect->y)
     {
-      priv->position_changed = TRUE;
+      priv->position_changed = priv->geometry_changed = TRUE;
       priv->last_x = window_rect->x;
       priv->last_y = window_rect->y;
     }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1208,7 +1208,7 @@ meta_window_actor_has_shadow (MetaWindowActor *self)
    * window appearing on an adjacent window */
   if ((((window->maximized_horizontally ? META_MAXIMIZE_HORIZONTAL : 0) |
       (window->maximized_vertically ? META_MAXIMIZE_VERTICAL : 0)) == (META_MAXIMIZE_HORIZONTAL | META_MAXIMIZE_VERTICAL)) ||
-      priv->window->fullscreen)
+      window->fullscreen)
     return FALSE;
 
   /* Don't shadow tiled windows of any type */
@@ -1220,7 +1220,7 @@ meta_window_actor_has_shadow (MetaWindowActor *self)
    * Always put a shadow around windows with a frame - This should override
    * the restriction about not putting a shadow around ARGB windows.
    */
-  if (window && window->frame)
+  if (window->frame)
     return TRUE;
 
   /*

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1145,32 +1145,6 @@ meta_window_actor_queue_relayout (ClutterActor *actor)
 }
 
 static gboolean
-is_move_resize (MetaWindowActor *self)
-{
-  MetaDisplay *display = self->priv->window->display;
-  MetaGrabOp op = display->grab_op;
-
-  if (op == META_GRAB_OP_NONE)
-    return FALSE;
-
-  switch (op)
-    {
-      case META_GRAB_OP_MOVING:
-      case META_GRAB_OP_RESIZING_SE:
-      case META_GRAB_OP_RESIZING_S:
-      case META_GRAB_OP_RESIZING_SW:
-      case META_GRAB_OP_RESIZING_N:
-      case META_GRAB_OP_RESIZING_NE:
-      case META_GRAB_OP_RESIZING_NW:
-      case META_GRAB_OP_RESIZING_W:
-      case META_GRAB_OP_RESIZING_E:
-        return TRUE;
-      default:
-        return FALSE;
-    }
-}
-
-static gboolean
 meta_window_actor_get_paint_volume (ClutterActor       *actor,
                                     ClutterPaintVolume *volume)
 {
@@ -1180,7 +1154,7 @@ meta_window_actor_get_paint_volume (ClutterActor       *actor,
   if (priv->obscured)
     return FALSE;
 
-  if (!priv->should_have_shadow || !is_move_resize (self))
+  if (!priv->should_have_shadow || priv->window->display->grab_op == META_GRAB_OP_NONE)
     return clutter_paint_volume_set_from_allocation (volume, actor);
 
   if (priv->focused_shadow != NULL || priv->unfocused_shadow != NULL)

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2507,56 +2507,6 @@ meta_window_actor_set_clip_region (MetaWindowActor *self,
     priv->clip_region = NULL;
 }
 
-/**
- * meta_window_actor_set_clip_region_beneath:
- * @self: a #MetaWindowActor
- * @visible_region: the region of the screen that isn't completely
- *  obscured beneath the main window texture.
- *
- * Provides a hint as to what areas need to be drawn *beneath*
- * the main window texture.  This is the relevant visible region
- * when drawing the shadow, properly accounting for areas of the
- * shadow hid by the window itself. This will be set before painting
- * then unset afterwards.
- */
-void
-meta_window_actor_set_clip_region_beneath (MetaWindowActor *self,
-                                           cairo_region_t  *clip_region)
-{
-  MetaWindowActorPrivate *priv = self->priv;
-
-  if (!priv->should_have_shadow)
-    return;
-
-  gboolean appears_focused = priv->window->display->focus_window == priv->window;
-
-  if (appears_focused ? priv->focused_shadow : priv->unfocused_shadow)
-    {
-      g_clear_pointer (&priv->shadow_clip, cairo_region_destroy);
-      priv->shadow_clip = cairo_region_copy (clip_region);
-
-      if (priv->clip_shadow)
-        cairo_region_subtract (priv->shadow_clip,
-                               priv->shape_region);
-    }
-}
-
-/**
- * meta_window_actor_reset_visible_regions:
- * @self: a #MetaWindowActor
- *
- * Unsets the regions set by meta_window_actor_reset_visible_region() and
- * meta_window_actor_reset_visible_region_beneath()
- */
-LOCAL_SYMBOL void
-meta_window_actor_reset_visible_regions (MetaWindowActor *self)
-{
-  MetaWindowActorPrivate *priv = self->priv;
-
-  meta_window_actor_set_clip_region (self, NULL);
-  g_clear_pointer (&priv->shadow_clip, cairo_region_destroy);
-}
-
 static void
 meta_window_actor_set_create_mipmaps (MetaWindowActor *self,
                                       gboolean         create_mipmaps)

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -29,9 +29,44 @@ struct _MetaWindowGroup
 
 G_DEFINE_TYPE (MetaWindowGroup, meta_window_group, CLUTTER_TYPE_ACTOR);
 
+static gboolean
+iter_prev (ClutterActorIter  *iter,
+           ClutterActor     **child)
+{
+  RealActorIter *ri = (RealActorIter *) iter;
+
+  if (ri->current == NULL)
+    ri->current = ri->root->priv->last_child;
+  else
+    ri->current = ri->current->priv->prev_sibling;
+
+  if (child != NULL)
+    *child = ri->current;
+
+  return ri->current != NULL;
+}
+
+static gboolean
+iter_next (ClutterActorIter  *iter,
+           ClutterActor     **child)
+{
+  RealActorIter *ri = (RealActorIter *) iter;
+
+  if (ri->current == NULL)
+    ri->current = ri->root->priv->first_child;
+  else
+    ri->current = ri->current->priv->next_sibling;
+
+  if (child != NULL)
+    *child = ri->current;
+
+  return ri->current != NULL;
+}
+
 static void
 meta_window_group_cull_out (MetaWindowGroup *group,
                             ClutterActor    *unredirected_window,
+                            MetaCompositor  *compositor,
                             gboolean         has_unredirected_window,
                             cairo_region_t  *unobscured_region,
                             cairo_region_t  *clip_region)
@@ -44,13 +79,15 @@ meta_window_group_cull_out (MetaWindowGroup *group,
    * and subtract the opaque area of each window out of the visible
    * region that we pass to the windows below.
    */
-  clutter_actor_iter_init (&iter, actor);
-  while (clutter_actor_iter_prev (&iter, &child))
-    {
-      if (!CLUTTER_ACTOR_IS_VISIBLE (child))
-        continue;
+  RealActorIter *ri = (RealActorIter *) &iter;
+  ri->root = actor;
+  ri->current = NULL;
+  ri->age = actor->priv->age;
 
-      if (has_unredirected_window && child == unredirected_window)
+  while (iter_prev (&iter, &child))
+    {
+      if (!CLUTTER_ACTOR_IS_VISIBLE (child) ||
+          (has_unredirected_window && child == unredirected_window))
         continue;
 
       /* If an actor has effects applied, then that can change the area
@@ -69,37 +106,63 @@ meta_window_group_cull_out (MetaWindowGroup *group,
        * as well for the same reason, but omitted for simplicity in the
        * hopes that no-one will do that.
        */
-      if (clutter_actor_has_effects (child))
+      if (child->priv->effects)
         continue;
 
       if (META_IS_WINDOW_ACTOR (child))
         {
           MetaWindowActor *window_actor = META_WINDOW_ACTOR (child);
+          MetaWindowActorPrivate *priv = window_actor->priv;
           int x, y;
 
-          if (!meta_actor_is_untransformed (CLUTTER_ACTOR (window_actor), &x, &y))
+          if (!meta_actor_is_untransformed (child, &x, &y))
             continue;
 
           /* Temporarily move to the coordinate system of the actor */
           cairo_region_translate (unobscured_region, - x, - y);
-          cairo_region_translate (clip_region, - x, - y);
 
-          meta_window_actor_set_unobscured_region (window_actor, unobscured_region);
-          meta_window_actor_set_clip_region (window_actor, clip_region);
+          if (priv->unobscured_region)
+            cairo_region_destroy (priv->unobscured_region);
+          priv->unobscured_region = cairo_region_copy (unobscured_region);
 
-          if (clutter_actor_get_paint_opacity (CLUTTER_ACTOR (window_actor)) == 0xff)
+          if (priv->obscured)
             {
-              MetaWindowActorPrivate *priv = window_actor->priv;
-              cairo_region_t *obscured_region = NULL;
-
-              if (priv->opaque_region && priv->pixmap && priv->opacity == 0xff)
-                {
-                  cairo_region_subtract (unobscured_region, priv->opaque_region);
-                  cairo_region_subtract (clip_region, priv->opaque_region);
-                }
+              cairo_region_translate (unobscured_region, x, y);
+              continue;
             }
 
-          meta_window_actor_set_clip_region_beneath (window_actor, clip_region);
+          cairo_region_translate (clip_region, - x, - y);
+
+          if (cairo_region_equal (priv->clip_region, clip_region))
+            {
+              cairo_region_translate (unobscured_region, x, y);
+              cairo_region_translate (clip_region, x, y);
+              continue;
+            }
+
+          if (priv->clip_region)
+            cairo_region_destroy (priv->clip_region);
+          priv->clip_region = cairo_region_copy (clip_region);
+
+          if (priv->opaque_region && priv->pixmap && priv->opacity == 0xff)
+            {
+              cairo_region_subtract (unobscured_region, priv->opaque_region);
+              cairo_region_subtract (clip_region, priv->opaque_region);
+            }
+
+          if (priv->should_have_shadow)
+            {
+              gboolean appears_focused = priv->window->display->focus_window == priv->window;
+
+              if (appears_focused ? priv->focused_shadow : priv->unfocused_shadow)
+                {
+                  g_clear_pointer (&priv->shadow_clip, cairo_region_destroy);
+                  priv->shadow_clip = cairo_region_copy (clip_region);
+
+                  if (priv->clip_shadow)
+                    cairo_region_subtract (priv->shadow_clip, priv->shape_region);
+                }
+            }
 
           cairo_region_translate (unobscured_region, x, y);
           cairo_region_translate (clip_region, x, y);
@@ -130,13 +193,19 @@ meta_window_group_reset_culling (MetaWindowGroup *group)
   /* Now that we are done painting, unset the visible regions (they will
    * mess up painting clones of our actors)
    */
-  clutter_actor_iter_init (&iter, actor);
-  while (clutter_actor_iter_next (&iter, &child))
+  RealActorIter *ri = (RealActorIter *) &iter;
+  ri->root = actor;
+  ri->current = NULL;
+  ri->age = actor->priv->age;
+
+  while (iter_next (&iter, &child))
     {
       if (META_IS_WINDOW_ACTOR (child))
         {
           MetaWindowActor *window_actor = META_WINDOW_ACTOR (child);
-          meta_window_actor_reset_visible_regions (window_actor);
+
+          g_clear_pointer (&window_actor->priv->clip_region, cairo_region_destroy);
+          g_clear_pointer (&window_actor->priv->shadow_clip, cairo_region_destroy);
         }
       else if (META_IS_BACKGROUND_ACTOR (child))
         {
@@ -151,30 +220,15 @@ meta_window_group_paint (ClutterActor *actor)
 {
   cairo_region_t *clip_region;
   cairo_region_t *unobscured_region;
-  ClutterActorIter iter;
-  ClutterActor *child;
   cairo_rectangle_int_t visible_rect, clip_rect;
   int paint_x_offset, paint_y_offset;
   int paint_x_origin, paint_y_origin;
   int actor_x_origin, actor_y_origin;
-  int screen_width, screen_height;
 
   MetaWindowGroup *window_group = META_WINDOW_GROUP (actor);
   MetaCompositor *compositor = window_group->screen->display->compositor;
   ClutterActor *stage = CLUTTER_STAGE (compositor->stage);
-  meta_screen_get_size (window_group->screen, &screen_width, &screen_height);
-
-  /* Start off by treating all windows as completely unobscured, so damage anywhere
-   * in a window queues redraws, but confine it more below. */
-  clutter_actor_iter_init (&iter, actor);
-  while (clutter_actor_iter_next (&iter, &child))
-    {
-      if (META_IS_WINDOW_ACTOR (child))
-        {
-          MetaWindowActor *window_actor = META_WINDOW_ACTOR (child);
-          meta_window_actor_set_unobscured_region (window_actor, NULL);
-        }
-    }
+  MetaRectangle *screen_rect = &window_group->screen->rect;
 
   /* Normally we expect an actor to be drawn at it's position on the screen.
    * However, if we're inside the paint of a ClutterClone, that won't be the
@@ -190,8 +244,8 @@ meta_window_group_paint (ClutterActor *actor)
    * on the stage.
    */
   if (!meta_actor_painting_untransformed (cogl_get_draw_framebuffer (),
-                                          screen_width,
-                                          screen_height,
+                                          screen_rect->width,
+                                          screen_rect->height,
                                           &paint_x_origin,
                                           &paint_y_origin) ||
       !meta_actor_is_untransformed (actor, &actor_x_origin, &actor_y_origin))
@@ -204,8 +258,8 @@ meta_window_group_paint (ClutterActor *actor)
   paint_y_offset = paint_y_origin - actor_y_origin;
 
   visible_rect.x = visible_rect.y = 0;
-  visible_rect.width = clutter_actor_get_width (stage);
-  visible_rect.height = clutter_actor_get_height (stage);
+  visible_rect.width = screen_rect->width;
+  visible_rect.height = screen_rect->height;
 
   unobscured_region = cairo_region_create_rectangle (&visible_rect);
 
@@ -237,6 +291,7 @@ meta_window_group_paint (ClutterActor *actor)
 
   meta_window_group_cull_out (window_group,
                               CLUTTER_ACTOR (compositor->unredirected_window),
+                              compositor,
                               has_unredirected_window,
                               unobscured_region,
                               clip_region);

--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -198,16 +198,15 @@ meta_rectangle_area (const MetaRectangle *rect)
  */
 gboolean
 meta_rectangle_intersect (const MetaRectangle *src1,
-			  const MetaRectangle *src2,
-			  MetaRectangle *dest)
+                          const MetaRectangle *src2,
+                          MetaRectangle *dest)
 {
   int dest_x, dest_y;
   int dest_w, dest_h;
   int return_val;
 
-  g_return_val_if_fail (src1 != NULL, FALSE);
-  g_return_val_if_fail (src2 != NULL, FALSE);
-  g_return_val_if_fail (dest != NULL, FALSE);
+  if (!src1 || !src2 || !dest)
+    g_warn_if_reached ();
 
   return_val = FALSE;
 

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3071,7 +3071,7 @@ meta_screen_resize (MetaScreen *screen,
 
       if (window->screen == screen)
         {
-          meta_window_update_rects (window);
+          meta_window_update_outer_rect (window);
           meta_window_update_for_monitors_changed (window);
 
           if (!window->override_redirect)

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -2142,7 +2142,7 @@ meta_screen_get_monitor_for_rect (MetaScreen    *screen,
   best_monitor = 0;
   monitor_score = -1;
 
-  rect_area = meta_rectangle_area (rect);
+  rect_area = rect->width * rect->height;
   for (i = 0; i < screen->n_monitor_infos; i++)
     {
       gboolean result;
@@ -2154,12 +2154,17 @@ meta_screen_get_monitor_for_rect (MetaScreen    *screen,
           result = meta_rectangle_intersect (&screen->monitor_infos[i].rect,
                                              rect,
                                              &dest);
-          cur = meta_rectangle_area (&dest);
+          cur = dest.width * dest.height;
         }
       else
         {
-          result = meta_rectangle_contains_rect (&screen->monitor_infos[i].rect,
-                                                 rect);
+          MetaRectangle *outer_rect = &screen->monitor_infos[i].rect;
+
+          result = (rect->x >= outer_rect->x &&
+                    rect->y >= outer_rect->y &&
+                    rect->x + rect->width  <= outer_rect->x + outer_rect->width &&
+                    rect->y + rect->height <= outer_rect->y + outer_rect->height);
+
           cur = rect_area;
         }
 

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -458,7 +458,7 @@ struct _MetaWindow
    */
   MetaRectangle rect;
   MetaRectangle outer_rect;
-  cairo_rectangle_int_t client_area;
+  cairo_rectangle_int_t *client_area;
 
   gboolean has_custom_frame_extents;
   GtkBorder custom_frame_extents;

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -791,8 +791,8 @@ void meta_window_recalc_features    (MetaWindow *window);
 void meta_window_recalc_window_type (MetaWindow *window);
 
 void meta_window_frame_size_changed (MetaWindow *window);
-void meta_window_update_rects (MetaWindow *window);
-void meta_window_update_outer_rect (MetaWindow *window);
+void meta_window_update_client_area_rect (const MetaWindow *window);
+void meta_window_update_outer_rect (const MetaWindow *window);
 
 void meta_window_stack_just_below (MetaWindow *window,
                                    MetaWindow *below_this_one);

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -792,6 +792,7 @@ void meta_window_recalc_window_type (MetaWindow *window);
 
 void meta_window_frame_size_changed (MetaWindow *window);
 void meta_window_update_rects (MetaWindow *window);
+void meta_window_update_outer_rect (MetaWindow *window);
 
 void meta_window_stack_just_below (MetaWindow *window,
                                    MetaWindow *below_this_one);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -147,9 +147,6 @@ static unsigned int get_mask_from_snap_keysym (MetaWindow *window);
 static void update_edge_constraints (MetaWindow *window);
 static void update_gtk_edge_constraints (MetaWindow *window);
 
-static void get_outer_rect (const MetaWindow *window,
-                            MetaRectangle    *rect);
-
 /* Idle handlers for the three queues (run with meta_later_add()). The
  * "data" parameter in each case will be a GINT_TO_POINTER of the
  * index into the queue arrays to use.
@@ -3641,7 +3638,7 @@ meta_window_get_all_monitors (MetaWindow *window, gsize *length)
   else
     {
       if (window->fullscreen)
-        get_outer_rect (window, &window->outer_rect);
+        meta_window_update_outer_rect (window);
 
       window_rect = window->outer_rect;
     }
@@ -5590,7 +5587,7 @@ meta_window_move_to_monitor (MetaWindow  *window,
 
   meta_window_move_between_rects (window, &old_area, &new_area);
 
-  meta_window_update_rects (window);
+  meta_window_update_outer_rect (window);
   meta_window_update_monitor (window);
 }
 
@@ -5888,10 +5885,11 @@ meta_window_get_outer_rect (const MetaWindow *window,
   *rect = window->outer_rect;
 }
 
-static void
-get_outer_rect (const MetaWindow *window,
-                MetaRectangle    *rect)
+void
+meta_window_update_outer_rect (const MetaWindow *window)
 {
+  MetaRectangle *rect = &window->outer_rect;
+
   if (window->frame)
     {
       MetaFrameBorders borders;
@@ -5934,10 +5932,11 @@ meta_window_get_client_area_rect (const MetaWindow      *window,
   *rect = window->client_area;
 }
 
-static void
-get_client_area_rect (const MetaWindow      *window,
-                      cairo_rectangle_int_t *rect)
+void
+meta_window_update_client_area_rect (const MetaWindow *window)
 {
+  cairo_rectangle_int_t *rect = &window->client_area;
+
   if (window->frame)
     {
       rect->x = window->frame->child_x;
@@ -8409,25 +8408,13 @@ recalc_window_type (MetaWindow *window)
 }
 
 void
-meta_window_update_rects (MetaWindow *window)
-{
-  get_outer_rect (window, &window->outer_rect);
-  get_client_area_rect (window, &window->client_area);
-}
-
-void
-meta_window_update_outer_rect (MetaWindow *window)
-{
-  get_outer_rect (window, &window->outer_rect);
-}
-
-void
 meta_window_frame_size_changed (MetaWindow *window)
 {
   if (window->frame)
     meta_frame_clear_cached_borders (window->frame);
 
-  meta_window_update_rects (window);
+  meta_window_update_outer_rect (window);
+  meta_window_update_client_area_rect (window);
 }
 
 static void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -247,6 +247,7 @@ meta_window_finalize (GObject *object)
 
   meta_icon_cache_free (&window->icon_cache);
 
+  free (window->client_area);
   g_free (window->sm_client_id);
   g_free (window->wm_client_machine);
   g_free (window->startup_id);
@@ -1124,6 +1125,8 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   window->rect.y = attrs->y;
   window->rect.width = attrs->width;
   window->rect.height = attrs->height;
+
+  window->client_area = g_new (cairo_rectangle_int_t, 1);
 
   /* And border width, size_hints are the "request" */
   window->border_width = attrs->border_width;
@@ -5929,13 +5932,13 @@ void
 meta_window_get_client_area_rect (const MetaWindow      *window,
                                   cairo_rectangle_int_t *rect)
 {
-  *rect = window->client_area;
+  rect = window->client_area;
 }
 
 void
 meta_window_update_client_area_rect (const MetaWindow *window)
 {
-  cairo_rectangle_int_t *rect = &window->client_area;
+  cairo_rectangle_int_t *rect = window->client_area;
 
   if (window->frame)
     {

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8416,6 +8416,12 @@ meta_window_update_rects (MetaWindow *window)
 }
 
 void
+meta_window_update_outer_rect (MetaWindow *window)
+{
+  get_outer_rect (window, &window->outer_rect);
+}
+
+void
 meta_window_frame_size_changed (MetaWindow *window)
 {
   if (window->frame)

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3120,6 +3120,8 @@ meta_window_show (MetaWindow *window)
 
   if (!window->visible_to_compositor)
     {
+      meta_window_update_outer_rect (window);
+      meta_window_update_client_area_rect (window);
       meta_window_update_monitor (window);
 
       window->visible_to_compositor = TRUE;

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -415,6 +415,12 @@ void meta_frame_borders_clear (MetaFrameBorders *self);
   (ycoord) >= (rect).y &&                   \
   (ycoord) <  ((rect).y + (rect).height))
 
+#define POINT_IN_RECT_POINTER(xcoord, ycoord, rect) \
+ ((xcoord) >= (rect)->x &&                   \
+  (xcoord) <  ((rect)->x + (rect)->width) &&  \
+  (ycoord) >= (rect)->y &&                   \
+  (ycoord) <  ((rect)->y + (rect)->height))
+
 /*
  * Layers a window can be in.
  * These MUST be in the order of stacking.

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2292,13 +2292,10 @@ get_control (MetaFrames *frames,
   MetaWindow *window;
   gboolean has_vert, has_horiz, has_left, has_right, has_bottom, has_top;
   gboolean has_north_resize;
-  cairo_rectangle_int_t client;
 
   window = frame->meta_window;
 
-  client = window->client_area;
-
-  if (POINT_IN_RECT (x, y, client))
+  if (POINT_IN_RECT_POINTER (x, y, window->client_area))
     return META_FRAME_CONTROL_CLIENT_AREA;
 
   if (POINT_IN_RECT (x, y, frame->fgeom.close_rect.clickable))


### PR DESCRIPTION
- Fixes the workspace switching animation.
- Fixes windows not appearing after workspacing switching.
- Fixes artifacts on CSD Firefox windows.
- Stores the client area rect as a pointer in order to reduce memory allocation.
- Removes some redundant setters in MetaWindowActor, that were used in MetaWindowGroup's paint function.
- Guards against duplicate clip region propagation, so less CPU time is spent on windows with shadows.