### PR TITLE
Add MetaPrefsState struct for retrieving the prefs state without function invocation

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -535,7 +535,7 @@ LOCAL_SYMBOL void
 meta_compositor_toggle_send_frame_timings (MetaScreen *screen)
 {
   MetaCompositor *compositor = screen->display->compositor;
-  if (meta_prefs_get_send_frame_timings())
+  if (*compositor->display->prefs->send_frame_timings)
     {
       g_signal_connect_after (CLUTTER_STAGE (compositor->stage), "presented",
                               G_CALLBACK (frame_callback), compositor);

--- a/src/compositor/meta-background-actor.c
+++ b/src/compositor/meta-background-actor.c
@@ -41,6 +41,7 @@
 #include "compositor-private.h"
 #include <meta/errors.h>
 #include "meta-background-actor-private.h"
+#include <core/screen-private.h>
 
 #define FADE_DURATION 1500
 
@@ -216,7 +217,7 @@ set_texture_on_actor (MetaBackgroundActor *self)
   if (priv->transition_running)
     cancel_transitions (self);
 
-  background_transition = meta_prefs_get_background_transition();
+  background_transition = *priv->background->screen->display->prefs->background_transition;
 
   if (background_transition == META_BACKGROUND_TRANSITION_NONE)
   {

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1989,7 +1989,7 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   if (window->override_redirect)
     return TRUE;
 
-  if (priv->does_full_damage && meta_prefs_get_unredirect_fullscreen_windows ())
+  if (priv->does_full_damage && *window->display->prefs->unredirect_fullscreen_windows)
     return TRUE;
 
   return FALSE;
@@ -1999,13 +1999,14 @@ static void
 fullscreen_sync_toggle (MetaWindowActor *self,
                         gboolean         state)
 {
-  MetaSyncMethod method = meta_prefs_get_sync_method ();
+  MetaWindowActorPrivate *priv = self->priv;
+  MetaSyncMethod method = *priv->window->display->prefs->sync_method;
 
-  if (meta_prefs_get_unredirect_fullscreen_windows () &&
+  if (*priv->window->display->prefs->unredirect_fullscreen_windows &&
       method != META_SYNC_NONE)
     {
       clutter_stage_x11_update_sync_state (
-        self->priv->window->display->compositor->stage,
+        priv->window->display->compositor->stage,
         state ? method : META_SYNC_NONE
       );
     }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -282,6 +282,8 @@ meta_window_actor_init (MetaWindowActor *self)
   priv->first_frame_drawn_id = 0;
   priv->first_frame_handler_queued = FALSE;
   priv->first_frame_drawn = FALSE;
+
+  priv->visible = FALSE;
 }
 
 static void

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -1488,7 +1488,7 @@ constrain_titlebar_visible (MetaWindow         *window,
   int bottom_amount;
   int horiz_amount_offscreen, vert_amount_offscreen;
   int horiz_amount_onscreen,  vert_amount_onscreen;
-  int scale = meta_prefs_get_ui_scale ();
+  int scale = *window->display->prefs->ui_scale;
 
   if (priority > PRIORITY_TITLEBAR_VISIBLE)
     return TRUE;
@@ -1576,7 +1576,7 @@ constrain_partially_onscreen (MetaWindow         *window,
   int top_amount, bottom_amount;
   int horiz_amount_offscreen, vert_amount_offscreen;
   int horiz_amount_onscreen,  vert_amount_onscreen;
-  int scale = meta_prefs_get_ui_scale ();
+  int scale = *window->display->prefs->ui_scale;
 
   if (priority > PRIORITY_PARTIALLY_VISIBLE_ON_WORKAREA)
     return TRUE;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -208,8 +208,8 @@ lower_window_and_transients (MetaWindow *window,
 
   meta_window_foreach_transient (window, lower_window_and_transients, NULL);
 
-  if (meta_prefs_get_focus_mode () == C_DESKTOP_FOCUS_MODE_CLICK &&
-      meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->focus_mode == C_DESKTOP_FOCUS_MODE_CLICK &&
+      *window->display->prefs->raise_on_click)
     {
       /* Move window to the back of the focusing workspace's MRU list.
        * Do extra sanity checks to avoid possible race conditions.
@@ -352,7 +352,7 @@ meta_core_maximize (Display *xdisplay,
 
   meta_screen_hide_hud_and_preview (window->screen);
 
-  if (meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->raise_on_click)
     meta_window_raise (window);
 
   meta_window_maximize (window, 
@@ -367,7 +367,7 @@ meta_core_toggle_maximize_vertically (Display *xdisplay,
 
   meta_screen_hide_hud_and_preview (window->screen);
 
-  if (meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->raise_on_click)
     meta_window_raise (window);
 
   if (META_WINDOW_MAXIMIZED_VERTICALLY (window))
@@ -386,7 +386,7 @@ meta_core_toggle_maximize_horizontally (Display *xdisplay,
 
   meta_screen_hide_hud_and_preview (window->screen);
 
-  if (meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->raise_on_click)
     meta_window_raise (window);
 
   if (META_WINDOW_MAXIMIZED_HORIZONTALLY (window))
@@ -422,7 +422,7 @@ meta_core_unmaximize (Display *xdisplay,
 {
   MetaWindow *window = meta_core_get_window (xdisplay, frame_xwindow);
 
-  if (meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->raise_on_click)
     meta_window_raise (window);
 
   meta_window_unmaximize (window,
@@ -553,7 +553,7 @@ meta_core_show_window_menu (Display *xdisplay,
 
   meta_screen_hide_hud_and_preview (window->screen);
 
-  if (meta_prefs_get_raise_on_click ())
+  if (*window->display->prefs->raise_on_click)
     meta_window_raise (window);
   meta_window_focus (window, timestamp);
 

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -309,6 +309,7 @@ struct _MetaDisplay
   guint shadows_enabled : 1;
   guint debug_button_grabs : 1;
   guint desktop_effects : 1;
+  MetaPrefsState *prefs;
 };
 
 struct _MetaDisplayClass

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -308,6 +308,7 @@ struct _MetaDisplay
 
   guint shadows_enabled : 1;
   guint debug_button_grabs : 1;
+  guint desktop_effects : 1;
 };
 
 struct _MetaDisplayClass

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -546,6 +546,8 @@ meta_display_open (void)
   the_display->allow_terminal_deactivation = TRUE; /* Only relevant for when a
                                                   terminal has the focus */
 
+  the_display->desktop_effects = meta_prefs_get_desktop_effects ();
+
   the_display->rebuild_keybinding_idle_id = 0;
 
   the_display->sync_method = meta_prefs_get_sync_method();

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -348,7 +348,7 @@ apply_edge_resistance (MetaWindow                *window,
   const int TIMEOUT_RESISTANCE_LENGTH_MS_SCREEN   =   0;
 
   /* Edge resistance can be disabled in gettings. */
-  if (!meta_prefs_get_edge_resistance_window ())
+  if (!(*window->display->prefs->edge_resistance_window))
     return new_pos;
 
   /* Quit if no movement was specified */

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1831,16 +1831,17 @@ handle_workspace_shift (MetaWindow *window,
   MetaWorkspace *target_workspace;
   guint motion = META_MOTION_LEFT;
   gboolean should_handle = FALSE;
+  gboolean invert_workspace_flip = *window->display->prefs->invert_workspace_flip;
 
   if (keysym == XK_Left || keysym == XK_KP_Left)
     {
-      motion = meta_prefs_get_invert_flip_direction () ? META_MOTION_RIGHT : META_MOTION_LEFT;
+      motion = invert_workspace_flip ? META_MOTION_RIGHT : META_MOTION_LEFT;
       should_handle = TRUE;
     }
   else
   if (keysym == XK_Right || keysym == XK_KP_Right)
     {
-      motion = meta_prefs_get_invert_flip_direction () ? META_MOTION_LEFT : META_MOTION_RIGHT;
+      motion = invert_workspace_flip ? META_MOTION_LEFT : META_MOTION_RIGHT;
       should_handle = TRUE;
     }
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -633,6 +633,9 @@ prefs_changed_callback (MetaPreference pref,
     case META_PREF_SYNC_METHOD:
       meta_display_update_sync_state (meta_prefs_get_sync_method ());
       break;
+    case META_PREF_DESKTOP_EFFECTS:
+      meta_get_display ()->desktop_effects = meta_prefs_get_desktop_effects ();
+      break;
     default:
       /* handled elsewhere or otherwise */
       break;

--- a/src/core/place.c
+++ b/src/core/place.c
@@ -763,8 +763,8 @@ meta_window_place (MetaWindow        *window,
     case META_WINDOW_OVERRIDE_OTHER:
       goto done_no_constraints;
     }
-  
-  if (meta_prefs_get_disable_workarounds () ||
+
+  if (*window->display->prefs->disable_workarounds ||
       (parent != NULL && parent->type == META_WINDOW_DESKTOP))
     {
       switch (window->type)
@@ -929,7 +929,7 @@ meta_window_place (MetaWindow        *window,
 
   
   /* Placement based on pointer position */
-  placement_mode = meta_prefs_get_placement_mode();
+  placement_mode = *window->display->prefs->placement_mode;
 
   if (placement_mode == META_PLACEMENT_MODE_POINTER ||
       placement_mode == META_PLACEMENT_MODE_MANUAL)

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -940,7 +940,6 @@ MetaPrefsState*
 meta_prefs_get_default_state (void)
 {
   MetaPrefsState *prefs_state = g_new0 (MetaPrefsState, 1);
-  unsigned int snap_modifier[2];
 
   prefs_state->use_system_font = &use_system_font;
   prefs_state->titlebar_font = titlebar_font;
@@ -982,7 +981,6 @@ meta_prefs_get_default_state (void)
   prefs_state->edge_tiling = &edge_tiling;
   prefs_state->edge_resistance_window = &edge_resistance_window;
   prefs_state->force_fullscreen = &force_fullscreen;
-  prefs_state->snap_modifier = *snap_modifier;
   prefs_state->button_layout = &button_layout;
   prefs_state->workspaces_only_on_primary = &workspaces_only_on_primary;
   prefs_state->legacy_snap = &legacy_snap;

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -932,6 +932,68 @@ update_ui_scale (GdkScreen *screen, gpointer data)
   ui_scale = MAX (g_value_get_int (&value), 1); // Never let it be 0;
 }
 
+/**
+ * meta_prefs_get_default_state: (skip)
+ *
+ */
+MetaPrefsState*
+meta_prefs_get_default_state (void)
+{
+  MetaPrefsState *prefs_state = g_new0 (MetaPrefsState, 1);
+  unsigned int snap_modifier[2];
+
+  prefs_state->use_system_font = &use_system_font;
+  prefs_state->titlebar_font = titlebar_font;
+  prefs_state->mouse_button_mods = &mouse_button_mods;
+  prefs_state->mouse_button_zoom_mods = &mouse_button_zoom_mods;
+  prefs_state->mouse_zoom_enabled = &mouse_zoom_enabled;
+  prefs_state->focus_mode = &focus_mode;
+  prefs_state->focus_new_windows = &focus_new_windows;
+  prefs_state->raise_on_click = &raise_on_click;
+  prefs_state->attach_modal_dialogs = &attach_modal_dialogs;
+  prefs_state->ignore_hide_titlebar_when_maximized = &ignore_hide_titlebar_when_maximized;
+  prefs_state->current_theme = current_theme;
+  prefs_state->workspace_names = workspace_names;
+  prefs_state->num_workspaces = &num_workspaces;
+  prefs_state->workspace_cycle = &workspace_cycle;
+  prefs_state->action_double_click_titlebar = &action_double_click_titlebar;
+  prefs_state->action_middle_click_titlebar = &action_middle_click_titlebar;
+  prefs_state->action_right_click_titlebar = &action_right_click_titlebar;
+  prefs_state->action_scroll_titlebar = &action_scroll_titlebar;
+  prefs_state->dynamic_workspaces = &dynamic_workspaces;
+  prefs_state->unredirect_fullscreen_windows = &unredirect_fullscreen_windows;
+  prefs_state->desktop_effects = &desktop_effects;
+  prefs_state->sync_method = &sync_method;
+  prefs_state->threaded_swap = &threaded_swap;
+  prefs_state->send_frame_timings = &send_frame_timings;
+  prefs_state->application_based = &application_based;
+  prefs_state->disable_workarounds = &disable_workarounds;
+  prefs_state->auto_raise = &auto_raise;
+  prefs_state->auto_raise_delay = &auto_raise_delay;
+  prefs_state->gnome_animations = &gnome_animations;
+  prefs_state->cursor_theme = cursor_theme;
+  prefs_state->cursor_size = &cursor_size;
+  prefs_state->draggable_border_width = &draggable_border_width;
+  prefs_state->tile_hud_threshold = &tile_hud_threshold;
+  prefs_state->resize_threshold = &resize_threshold;
+  prefs_state->ui_scale = &ui_scale;
+  prefs_state->min_window_opacity = &min_window_opacity;
+  prefs_state->resize_with_right_button = &resize_with_right_button;
+  prefs_state->edge_tiling = &edge_tiling;
+  prefs_state->edge_resistance_window = &edge_resistance_window;
+  prefs_state->force_fullscreen = &force_fullscreen;
+  prefs_state->snap_modifier = *snap_modifier;
+  prefs_state->button_layout = &button_layout;
+  prefs_state->workspaces_only_on_primary = &workspaces_only_on_primary;
+  prefs_state->legacy_snap = &legacy_snap;
+  prefs_state->invert_workspace_flip = &invert_workspace_flip;
+  prefs_state->tile_maximize = &tile_maximize;
+  prefs_state->placement_mode = &placement_mode;
+  prefs_state->background_transition = &background_transition;
+
+  return prefs_state;
+}
+
 
 /****************************************************************************/
 /* Initialisation.                                                          */

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1262,7 +1262,7 @@ prefs_changed_callback (MetaPreference pref,
 
   if ((pref == META_PREF_NUM_WORKSPACES ||
        pref == META_PREF_DYNAMIC_WORKSPACES) &&
-      !meta_prefs_get_dynamic_workspaces ())
+      !(*screen->display->prefs->dynamic_workspaces))
     {
       /* GSettings doesn't provide timestamps, but luckily update_num_workspaces
        * often doesn't need it...
@@ -1605,7 +1605,7 @@ meta_screen_remove_workspace (MetaScreen *screen, MetaWorkspace *workspace,
 
   set_number_of_spaces_hint (screen, new_num);
 
-  if (!meta_prefs_get_dynamic_workspaces ())
+  if (!(*screen->display->prefs->dynamic_workspaces))
     meta_prefs_set_num_workspaces (new_num);
 
   update_net_desktop_layout (screen, new_num);
@@ -1666,7 +1666,7 @@ meta_screen_append_new_workspace (MetaScreen *screen, gboolean activate,
 
   set_number_of_spaces_hint (screen, new_num);
 
-  if (!meta_prefs_get_dynamic_workspaces ())
+  if (!(*screen->display->prefs->dynamic_workspaces))
     meta_prefs_set_num_workspaces (new_num);
 
   update_net_desktop_layout (screen, new_num);
@@ -1694,7 +1694,7 @@ update_num_workspaces (MetaScreen *screen,
   MetaWorkspace *last_remaining;
   gboolean need_change_space;
 
-  new_num = meta_prefs_get_num_workspaces ();
+  new_num = *screen->display->prefs->num_workspaces;
 
   g_assert (new_num > 0);
 

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -1240,7 +1240,7 @@ meta_set_normal_hints (MetaWindow *window,
   int minw, minh, maxw, maxh;   /* min/max width/height                      */
   int basew, baseh, winc, hinc; /* base width/height, width/height increment */
 
-  ui_scale = meta_prefs_get_ui_scale ();
+  ui_scale = *window->display->prefs->ui_scale;
 
   /* Save the last ConfigureRequest, which we put here.
    * Values here set in the hints are supposed to
@@ -1718,7 +1718,7 @@ reload_gtk_hide_titlebar_when_maximized (MetaWindow    *window,
   gboolean requested_value = FALSE;
   gboolean current_value = window->hide_titlebar_when_maximized;
 
-  if (meta_prefs_get_ignore_hide_titlebar_when_maximized ())
+  if (*window->display->prefs->ignore_hide_titlebar_when_maximized)
     {
       return;
     }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -875,7 +875,7 @@ meta_window_should_attach_to_parent (MetaWindow *window)
 {
   MetaWindow *parent;
 
-  if (!meta_prefs_get_attach_modal_dialogs () ||
+  if (!(*window->display->prefs->attach_modal_dialogs) ||
       window->type != META_WINDOW_MODAL_DIALOG)
     return FALSE;
 
@@ -1792,7 +1792,7 @@ meta_window_unmanage (MetaWindow  *window,
 
   window->unmanaging = TRUE;
 
-  if (meta_prefs_get_attach_modal_dialogs ())
+  if (*window->display->prefs->attach_modal_dialogs)
     {
       GList *attached_children = NULL, *iter;
 
@@ -2051,7 +2051,7 @@ should_be_on_all_workspaces (MetaWindow *window)
   return
     window->on_all_workspaces_requested ||
     window->override_redirect ||
-    (meta_prefs_get_workspaces_only_on_primary () &&
+    (*window->display->prefs->workspaces_only_on_primary &&
      !meta_window_is_on_primary_monitor (window));
 }
 
@@ -2541,7 +2541,7 @@ idle_calc_showing (gpointer data)
       tmp = tmp->next;
     }
 
-  if (meta_prefs_get_focus_mode () != C_DESKTOP_FOCUS_MODE_CLICK)
+  if ((*first_window->display->prefs->focus_mode) != C_DESKTOP_FOCUS_MODE_CLICK)
     {
       /* When display->mouse_mode is false, we want to ignore
        * EnterNotify events unless they come from mouse motion.  To do
@@ -2879,7 +2879,7 @@ window_state_on_map (MetaWindow *window,
    * approximation to enforce so we do that.
    */
   if (*takes_focus &&
-      meta_prefs_get_focus_new_windows () == C_DESKTOP_FOCUS_NEW_WINDOWS_STRICT &&
+      *window->display->prefs->focus_new_windows == C_DESKTOP_FOCUS_NEW_WINDOWS_STRICT &&
       !window->display->allow_terminal_deactivation &&
       __window_is_terminal (window->display->focus_window) &&
       !meta_window_is_ancestor_of_transient (window->display->focus_window,
@@ -3081,8 +3081,8 @@ meta_window_show (MetaWindow *window)
        * that new window below a lot of other windows.
        */
       if (overlap ||
-          (meta_prefs_get_focus_mode () == C_DESKTOP_FOCUS_MODE_CLICK &&
-           meta_prefs_get_raise_on_click ()))
+          (*window->display->prefs->focus_mode == C_DESKTOP_FOCUS_MODE_CLICK &&
+           *window->display->prefs->raise_on_click))
         meta_window_stack_just_below (window, focus_window);
 
       /* If the window will be obscured by the focus window, then the
@@ -4342,7 +4342,7 @@ meta_window_adjust_opacity (MetaWindow   *window,
   if (increase) {
     new_opacity = MIN (current_opacity + OPACITY_STEP, 255);
   } else {
-    new_opacity = MAX (current_opacity - OPACITY_STEP, MAX (0, meta_prefs_get_min_win_opacity ()));
+    new_opacity = MAX (current_opacity - OPACITY_STEP, MAX (0, *window->display->prefs->min_window_opacity));
   }
 
   if (new_opacity != current_opacity)
@@ -4426,7 +4426,7 @@ window_activate (MetaWindow     *window,
 
   unminimize_window_and_all_transient_parents (window);
 
-  if (meta_prefs_get_raise_on_click () ||
+  if (*window->display->prefs->raise_on_click ||
       source_indication == META_CLIENT_TYPE_PAGER)
     meta_window_raise (window);
 
@@ -4909,7 +4909,7 @@ meta_window_update_monitor (MetaWindow *window)
        * we want it when moving from one primary monitor to another (can happen during
        * screen reconfiguration.
        */
-      if (meta_prefs_get_workspaces_only_on_primary () &&
+      if (*window->display->prefs->workspaces_only_on_primary &&
           meta_window_is_on_primary_monitor (window)  &&
           old != NULL && !old->is_primary &&
           window->screen->active_workspace != window->workspace)
@@ -6010,7 +6010,7 @@ meta_window_get_titlebar_rect (MetaWindow *window,
     {
       /* Pick an arbitrary height for a titlebar. We might want to
        * eventually have CSD windows expose their borders to us. */
-      rect->height = CSD_TITLEBAR_HEIGHT * meta_prefs_get_ui_scale ();
+      rect->height = CSD_TITLEBAR_HEIGHT * (*window->display->prefs->ui_scale);
     }
 }
 
@@ -6583,7 +6583,7 @@ meta_window_move_resize_request (MetaWindow *window,
 
   allow_position_change = FALSE;
 
-  if (meta_prefs_get_disable_workarounds ())
+  if (*window->display->prefs->disable_workarounds)
     {
       if (window->type == META_WINDOW_DIALOG ||
           window->type == META_WINDOW_MODAL_DIALOG ||
@@ -6688,7 +6688,7 @@ meta_window_move_resize_request (MetaWindow *window,
       {
         meta_screen_get_monitor_geometry (window->screen, window->monitor->number, &monitor_rect);
 
-        if (meta_prefs_get_force_fullscreen() &&
+        if (*window->display->prefs->force_fullscreen &&
             !window->hide_titlebar_when_maximized &&
             (window->decorated && !window->has_custom_frame_extents) &&
             meta_rectangle_equal (&rect, &monitor_rect) &&
@@ -6789,7 +6789,7 @@ meta_window_configure_request (MetaWindow *window,
     {
       MetaWindow *active_window;
       active_window = window->display->expected_focus_window;
-      if (meta_prefs_get_disable_workarounds ())
+      if (*window->display->prefs->disable_workarounds)
         {
           meta_topic (META_DEBUG_STACK,
                       "%s sent an xconfigure stacking request; this is "
@@ -6930,8 +6930,6 @@ meta_window_client_message (MetaWindow *window,
 {
   MetaDisplay *display;
 
-  display = window->display;
-
   if (window->override_redirect)
     {
       /* Don't warn here: we could warn on any of the messages below,
@@ -6941,6 +6939,9 @@ meta_window_client_message (MetaWindow *window,
        */
       return FALSE;
     }
+
+  display = window->display;
+  gboolean raise_on_click = *display->prefs->raise_on_click;
 
   if (event->xclient.message_type ==
       display->atom__NET_CLOSE_WINDOW)
@@ -7067,13 +7068,13 @@ meta_window_client_message (MetaWindow *window,
                   !window->maximized_horizontally));
           if (max && window->has_maximize_func)
             {
-              if (meta_prefs_get_raise_on_click ())
+              if (raise_on_click)
                 meta_window_raise (window);
               meta_window_maximize (window, META_MAXIMIZE_HORIZONTAL);
             }
           else
             {
-              if (meta_prefs_get_raise_on_click ())
+              if (raise_on_click)
                 meta_window_raise (window);
               meta_window_unmaximize (window, META_MAXIMIZE_HORIZONTAL);
             }
@@ -7089,13 +7090,13 @@ meta_window_client_message (MetaWindow *window,
                   !window->maximized_vertically));
           if (max && window->has_maximize_func)
             {
-              if (meta_prefs_get_raise_on_click ())
+              if (raise_on_click)
                 meta_window_raise (window);
               meta_window_maximize (window, META_MAXIMIZE_VERTICAL);
             }
           else
             {
-              if (meta_prefs_get_raise_on_click ())
+              if (raise_on_click)
                 meta_window_raise (window);
               meta_window_unmaximize (window, META_MAXIMIZE_VERTICAL);
             }
@@ -7401,7 +7402,7 @@ meta_window_client_message (MetaWindow *window,
 
           meta_screen_hide_hud_and_preview (window->screen);
 
-          if (meta_prefs_get_raise_on_click ())
+          if (raise_on_click)
             meta_window_raise (window);
           meta_window_focus (window, meta_display_get_current_time_roundtrip (display));
 
@@ -7622,8 +7623,8 @@ meta_window_notify_focus (MetaWindow *window,
            *
            * There is dicussion in bugs 102209, 115072, and 461577
            */
-          if (meta_prefs_get_focus_mode () == C_DESKTOP_FOCUS_MODE_CLICK ||
-              !meta_prefs_get_raise_on_click())
+          if (*window->display->prefs->focus_mode == C_DESKTOP_FOCUS_MODE_CLICK ||
+              !(*window->display->prefs->raise_on_click))
             meta_display_ungrab_focus_window_button (window->display, window);
 
           g_signal_emit (window, window_signals[FOCUS], 0);
@@ -7675,8 +7676,8 @@ meta_window_notify_focus (MetaWindow *window,
           meta_error_trap_pop (window->display);
 
           /* Re-grab for click to focus and raise-on-click, if necessary */
-          if (meta_prefs_get_focus_mode () == C_DESKTOP_FOCUS_MODE_CLICK ||
-              !meta_prefs_get_raise_on_click ())
+          if (*window->display->prefs->focus_mode == C_DESKTOP_FOCUS_MODE_CLICK ||
+              !(*window->display->prefs->raise_on_click))
             meta_display_grab_focus_window_button (window->display, window);
        }
     }
@@ -7893,7 +7894,7 @@ update_sm_hints (MetaWindow *window)
     {
       meta_verbose ("Didn't find a client leader for %s\n", window->desc);
 
-      if (!meta_prefs_get_disable_workarounds ())
+      if (!(*window->display->prefs->disable_workarounds))
         {
           /* Some broken apps (kdelibs fault?) set SM_CLIENT_ID on the app
            * instead of the client leader
@@ -8924,7 +8925,7 @@ meta_window_show_menu (MetaWindow *window,
       window->type != META_WINDOW_DESKTOP)
     ops |= META_MENU_OP_RECOVER;
 
-  if (!meta_prefs_get_workspaces_only_on_primary () ||
+  if (!(*window->display->prefs->workspaces_only_on_primary) ||
       meta_window_is_on_primary_monitor (window))
     {
       n_workspaces = meta_screen_get_n_workspaces (window->screen);
@@ -9233,7 +9234,7 @@ meta_window_get_current_zone (MetaWindow   *window,
                 zone = ZONE_6;
             break;
         case ZONE_TOP:
-            if (meta_prefs_get_tile_maximize() || window->maybe_retile_maximize)
+            if (*window->display->prefs->tile_maximize || window->maybe_retile_maximize)
               {
                 if (meta_window_can_tile_maximized(window))
                     zone = ZONE_0;
@@ -9316,6 +9317,7 @@ update_move (MetaWindow  *window,
   MetaRectangle old;
   int breakloose_threshold;
   MetaDisplay *display = window->display;
+  MetaPrefsState *prefs = display->prefs;
 
   display->grab_latest_motion_x = x;
   display->grab_latest_motion_y = y;
@@ -9354,14 +9356,14 @@ update_move (MetaWindow  *window,
    * because it's about the right size
    */
 
-  if (legacy_snap && meta_prefs_get_legacy_snap ())
+  if (legacy_snap && *prefs->legacy_snap)
     {
       /* We don't want to tile while snapping. Also, clear any previous tile
          request. */
       window->tile_mode = META_TILE_NONE;
       window->tile_monitor_number = -1;
     }
-  else if (meta_prefs_get_edge_tiling () && !META_WINDOW_TILED_OR_SNAPPED (window))
+  else if (*prefs->edge_tiling && !META_WINDOW_TILED_OR_SNAPPED (window))
     {
       const MetaMonitorInfo *monitor;
       MetaRectangle work_area;
@@ -9393,19 +9395,19 @@ update_move (MetaWindow  *window,
                                                                      work_area,
                                                                      x,
                                                                      y,
-                                                                     meta_prefs_get_tile_hud_threshold ());
+                                                                     *prefs->tile_hud_threshold);
 
       guint edge_zone = meta_window_get_current_zone (window,
                                                       monitor->rect,
                                                       work_area,
                                                       x,
                                                       y,
-                                                      HUD_WIDTH * meta_prefs_get_ui_scale ());
+                                                      HUD_WIDTH * (*prefs->ui_scale));
 
       switch (edge_zone) {
         case ZONE_0:
             window->tile_mode = window->maybe_retile_maximize ? META_TILE_MAXIMIZE :
-                (meta_prefs_get_tile_maximize() ? META_TILE_MAXIMIZE : META_TILE_TOP);
+                (*prefs->tile_maximize ? META_TILE_MAXIMIZE : META_TILE_TOP);
             break;
         case ZONE_1:
             window->tile_mode = META_TILE_BOTTOM;
@@ -9441,7 +9443,7 @@ update_move (MetaWindow  *window,
    * the threshold in the Y direction. Tiled windows can also be pulled
    * loose via X motion.
    */
-  breakloose_threshold = meta_prefs_get_resize_threshold () * 2;
+  breakloose_threshold = *prefs->resize_threshold * 2;
 
   if (window->tile_type == META_WINDOW_TILE_TYPE_SNAPPED)
     breakloose_threshold *= 2;
@@ -9456,7 +9458,7 @@ update_move (MetaWindow  *window,
        * when dragged near the top; do not snap back if tiling
        * is enabled, as top edge tiling can be used in that case
        */
-      window->shaken_loose = !meta_prefs_get_edge_tiling ();
+      window->shaken_loose = !(*prefs->edge_tiling);
       if (window->saved_maximize)
         window->maybe_retile_maximize = TRUE;
       window->tile_mode = META_TILE_NONE;
@@ -9554,7 +9556,7 @@ update_move (MetaWindow  *window,
   if (window->tile_mode != last_tile_mode_state ||
       window->mouse_on_edge != last_mouse_on_edge_state)
     {
-      if (meta_prefs_get_edge_tiling ())
+      if (*prefs->edge_tiling)
         {
           if (window->current_proximity_zone != ZONE_NONE && !window->mouse_on_edge)
             meta_screen_tile_hud_update (window->screen, TRUE, FALSE);
@@ -9605,7 +9607,7 @@ update_move (MetaWindow  *window,
                                         &new_x,
                                         &new_y,
                                         update_move_timeout,
-                                        legacy_snap && meta_prefs_get_legacy_snap (),
+                                        legacy_snap && *prefs->legacy_snap,
                                         FALSE);
 
   meta_window_move (window, TRUE, new_x, new_y);
@@ -9626,7 +9628,7 @@ check_resize_unmaximize(MetaWindow *window,
   int threshold;
   MetaMaximizeFlags new_unmaximize;
 
-  threshold = meta_prefs_get_resize_threshold ();
+  threshold = *window->display->prefs->resize_threshold;
   new_unmaximize = 0;
 
   if (window->maximized_horizontally ||
@@ -10255,7 +10257,7 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
                                event->xbutton.state & ShiftMask,
                                event->xbutton.state & get_mask_from_snap_keysym (window),
                                event->xbutton.x_root, event->xbutton.y_root);
-              if (meta_prefs_get_edge_tiling ())
+              if (*window->display->prefs->edge_tiling)
                   meta_screen_tile_hud_update (window->screen, FALSE, TRUE);
             }
           else if (meta_grab_op_is_resizing (window->display->grab_op))
@@ -10691,13 +10693,15 @@ meta_window_unextend_by_frame (MetaWindow              *window,
 LOCAL_SYMBOL void
 meta_window_refresh_resize_popup (MetaWindow *window)
 {
-  if (window->display->grab_op == META_GRAB_OP_NONE)
+  MetaDisplay *display = window->display;
+
+  if (display->grab_op == META_GRAB_OP_NONE)
     return;
 
-  if (window->display->grab_window != window)
+  if (display->grab_window != window)
     return;
 
-  switch (window->display->grab_op)
+  switch (display->grab_op)
     {
     case META_GRAB_OP_RESIZING_SE:
     case META_GRAB_OP_RESIZING_S:
@@ -10723,11 +10727,11 @@ meta_window_refresh_resize_popup (MetaWindow *window)
       return;
     }
 
-  if (window->display->grab_resize_popup == NULL)
+  if (display->grab_resize_popup == NULL)
     {
       gint scale;
 
-      scale = meta_prefs_get_ui_scale ();
+      scale = *display->prefs->ui_scale;
 
       if (window->size_hints.width_inc > scale ||
           window->size_hints.height_inc > scale)
@@ -11193,7 +11197,7 @@ meta_window_set_user_time (MetaWindow *window,
       /* If this is a terminal, user interaction with it means the user likely
        * doesn't want to have focus transferred for now due to new windows.
        */
-      if (meta_prefs_get_focus_new_windows () ==
+      if (*window->display->prefs->focus_new_windows ==
                C_DESKTOP_FOCUS_NEW_WINDOWS_STRICT &&
           __window_is_terminal (window))
         window->display->allow_terminal_deactivation = FALSE;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3573,7 +3573,7 @@ meta_window_maximize (MetaWindow        *window,
                                    saved_rect);
 
     MetaRectangle old_rect;
-    gboolean desktop_effects = meta_prefs_get_desktop_effects ();
+    gboolean desktop_effects = window->display->desktop_effects;
 
     if (desktop_effects)
       old_rect = window->outer_rect;
@@ -3790,7 +3790,7 @@ meta_window_real_tile (MetaWindow *window, gboolean force)
     {
       MetaRectangle old_rect;
       MetaRectangle new_rect;
-      gboolean desktop_effects = meta_prefs_get_desktop_effects ();
+      gboolean desktop_effects = window->display->desktop_effects;
 
       if (desktop_effects)
         meta_window_get_input_rect (window, &old_rect);
@@ -4011,7 +4011,7 @@ meta_window_unmaximize_internal (MetaWindow        *window,
       if (window->resizing_tile_type == META_WINDOW_TILE_TYPE_NONE)
         {
           MetaRectangle old_rect;
-          gboolean desktop_effects = meta_prefs_get_desktop_effects ();
+          gboolean desktop_effects = window->display->desktop_effects;
 
           if (desktop_effects)
             old_rect = window->outer_rect;

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -385,7 +385,6 @@ typedef struct
   gboolean *edge_tiling;
   gboolean *edge_resistance_window;
   gboolean *force_fullscreen;
-  unsigned int *snap_modifier;
   MetaButtonLayout *button_layout;
   gboolean *workspaces_only_on_primary;
   gboolean *legacy_snap;

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -2,10 +2,10 @@
 
 /* Muffin preferences */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -343,6 +343,58 @@ typedef struct
   gboolean      builtin:1;
 } MetaKeyPref;
 
+typedef struct
+{
+  gboolean *use_system_font;
+  PangoFontDescription *titlebar_font;
+  MetaVirtualModifier *mouse_button_mods;
+  MetaVirtualModifier *mouse_button_zoom_mods;
+  gboolean *mouse_zoom_enabled;
+  CDesktopFocusMode *focus_mode;
+  CDesktopFocusNewWindows *focus_new_windows;
+  gboolean *raise_on_click;
+  gboolean *attach_modal_dialogs;
+  gboolean *ignore_hide_titlebar_when_maximized;
+  char *current_theme;
+  char **workspace_names;
+  int *num_workspaces;
+  gboolean *workspace_cycle;
+  CDesktopTitlebarAction *action_double_click_titlebar;
+  CDesktopTitlebarAction *action_middle_click_titlebar;
+  CDesktopTitlebarAction *action_right_click_titlebar;
+  CDesktopTitlebarScrollAction *action_scroll_titlebar;
+  gboolean *dynamic_workspaces;
+  gboolean *unredirect_fullscreen_windows;
+  gboolean *desktop_effects;
+  gboolean *sync_method;
+  gboolean *threaded_swap;
+  gboolean *send_frame_timings;
+  gboolean *application_based;
+  gboolean *disable_workarounds;
+  gboolean *auto_raise;
+  gboolean *auto_raise_delay;
+  gboolean *gnome_animations;
+  char *cursor_theme;
+  int *cursor_size;
+  int *draggable_border_width;
+  int *tile_hud_threshold;
+  int *resize_threshold;
+  int *ui_scale;
+  int *min_window_opacity;
+  gboolean *resize_with_right_button;
+  gboolean *edge_tiling;
+  gboolean *edge_resistance_window;
+  gboolean *force_fullscreen;
+  unsigned int *snap_modifier;
+  MetaButtonLayout *button_layout;
+  gboolean *workspaces_only_on_primary;
+  gboolean *legacy_snap;
+  gboolean *invert_workspace_flip;
+  gboolean *tile_maximize;
+  MetaPlacementMode *placement_mode;
+  MetaBackgroundTransition *background_transition;
+} MetaPrefsState;
+
 GType meta_key_binding_get_type    (void);
 
 GList *meta_prefs_get_keybindings (void);
@@ -360,5 +412,7 @@ CDesktopVisualBellType meta_prefs_get_visual_bell_type (void);
 MetaPlacementMode meta_prefs_get_placement_mode (void);
 
 MetaBackgroundTransition meta_prefs_get_background_transition (void);
+
+MetaPrefsState* meta_prefs_get_default_state (void);
 
 #endif

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -552,7 +552,7 @@ meta_frames_ensure_layout (MetaFrames  *frames,
       pango_layout_set_auto_dir (frame->layout, FALSE);
 
       font_desc = meta_gtk_widget_get_font_desc (widget, scale,
-                                                 meta_prefs_get_titlebar_font ());
+                                                 frame->meta_window->display->prefs->titlebar_font);
 
       size = pango_font_description_get_size (font_desc);
 
@@ -1222,7 +1222,7 @@ static gboolean
 meta_frame_double_click_event (MetaUIFrame    *frame,
                                GdkEventButton *event)
 {
-  int action = meta_prefs_get_action_double_click_titlebar ();
+  int action = *frame->meta_window->display->prefs->action_double_click_titlebar;
 
   return meta_frame_titlebar_event (frame, event, action);
 }
@@ -1231,7 +1231,7 @@ static gboolean
 meta_frame_middle_click_event (MetaUIFrame    *frame,
                                GdkEventButton *event)
 {
-  int action = meta_prefs_get_action_middle_click_titlebar();
+  int action = *frame->meta_window->display->prefs->action_middle_click_titlebar;
 
   return meta_frame_titlebar_event (frame, event, action);
 }
@@ -1240,7 +1240,7 @@ static gboolean
 meta_frame_right_click_event(MetaUIFrame     *frame,
                              GdkEventButton  *event)
 {
-  int action = meta_prefs_get_action_right_click_titlebar();
+  int action = *frame->meta_window->display->prefs->action_right_click_titlebar;
 
   return meta_frame_titlebar_event (frame, event, action);
 }
@@ -1249,7 +1249,7 @@ static gboolean
 meta_frame_scroll_wheel_event (MetaUIFrame     *frame,
                                GdkEventButton  *event)
 {
-  int action = meta_prefs_get_action_scroll_wheel_titlebar();
+  int action = *frame->meta_window->display->prefs->action_scroll_titlebar;
 
   return meta_frame_titlebar_event (frame, event, action);
 }


### PR DESCRIPTION
b77b6ff4732e8830bfb3eda5f11edef82d793f0a

This stores pointers to the static values in prefs.c in a new struct, which is stored on the MetaDisplay struct, and accessible from most muffin code. The benefit of this is it allows us to get GSettings values without calling functions.

Includes #450, #452, and one commit from #464 to avoid conflicts.