### PR TITLE
cogl-pipeline-private.h: remove a couple of redundant declarations

### DIFF
--- a/cogl/cogl/cogl-pipeline-private.h
+++ b/cogl/cogl/cogl-pipeline-private.h
@@ -846,9 +846,6 @@ _cogl_pipeline_weak_copy (CoglPipeline *pipeline,
 void
 _cogl_pipeline_set_progend (CoglPipeline *pipeline, int progend);
 
-CoglPipeline *
-_cogl_pipeline_get_parent (CoglPipeline *pipeline);
-
 void
 _cogl_pipeline_get_colorubv (CoglPipeline *pipeline,
                              uint8_t       *color);
@@ -923,10 +920,6 @@ _cogl_pipeline_set_static_breadcrumb (CoglPipeline *pipeline,
 
 unsigned long
 _cogl_pipeline_get_age (CoglPipeline *pipeline);
-
-CoglPipeline *
-_cogl_pipeline_get_authority (CoglPipeline *pipeline,
-                              unsigned long difference);
 
 void
 _cogl_pipeline_add_layer_difference (CoglPipeline *pipeline,


### PR DESCRIPTION
and say goodbye to nearly 1100 lines of build log warnings