### PR TITLE
cogl-context-private: correct a prototype

### DIFF
--- a/cogl/cogl/cogl-context-private.h
+++ b/cogl/cogl/cogl-context-private.h
@@ -360,7 +360,7 @@ struct _CoglContext
 };
 
 CoglContext *
-_cogl_context_get_default ();
+_cogl_context_get_default (void);
 
 const CoglWinsysVtable *
 _cogl_context_get_winsys (CoglContext *context);


### PR DESCRIPTION
and remove 550 lines of warning code from the build error log