### PR TITLE
compositor-private: remove a couple of duplicated lines

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -91,9 +91,6 @@ void meta_check_end_modal (MetaScreen *screen);
 void meta_compositor_update_sync_state (MetaCompositor *compositor,
                                         gboolean state);
 
-void meta_compositor_grab_op_begin (MetaCompositor *compositor);
-void meta_compositor_grab_op_end (MetaCompositor *compositor);
-
 void meta_compositor_set_all_obscured (MetaCompositor *compositor,
                                        gboolean        obscured);
 


### PR DESCRIPTION
stops 450 lines of build error warnings