### PR TITLE
Make sure windows paint before un-fullscreening

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2142,9 +2142,6 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
       priv->needs_pixmap = TRUE;
       meta_window_actor_update_shape (self);
 
-      if (priv->unredirected)
-        meta_display_set_all_obscured ();
-
       clutter_actor_set_size (CLUTTER_ACTOR (self),
                               window_rect->width, window_rect->height);
     }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4214,6 +4214,8 @@ meta_window_unmake_fullscreen (MetaWindow  *window)
     {
       MetaRectangle target_rect;
 
+      meta_display_set_all_obscured ();
+
       meta_topic (META_DEBUG_WINDOW_OPS,
                   "Unfullscreening %s\n", window->desc);
 


### PR DESCRIPTION
When un-fullscreening xed, the windows underneath are still treated as obscured.

C/O @JosephMcc 