### PR TITLE
window-actor: Add reference to MetaDisplay

### DIFF
--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -64,6 +64,7 @@ struct _MetaWindowActorPrivate
   char *shadow_class;
 
   gint effect_in_progress;
+  gint64 last_effect_time;
 
   /* List of FrameData for recent frames */
   GList *frames;

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -17,6 +17,7 @@ struct _MetaWindowActorPrivate
   MetaWindow *window;
   Window xwindow;
   MetaScreen *screen;
+  MetaDisplay *display;
 
   /* MetaShadowFactory only caches shadows that are actually in use;
    * to avoid unnecessary recomputation we do two things: 1) we store

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -64,7 +64,6 @@ struct _MetaWindowActorPrivate
   char *shadow_class;
 
   gint effect_in_progress;
-  gint64 last_effect_time;
 
   /* List of FrameData for recent frames */
   GList *frames;

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2148,31 +2148,21 @@ meta_window_actor_show (MetaWindowActor   *self,
       priv->screen->display->desktop_effects &&
       !priv->redecorating)
     {
-      gint64 now = g_get_monotonic_time ();
-
-      /* In most cases effects will not animate correctly for windows that map quickly,
-         such as an app restoring its windows. We could track this in Cinnamon, but in
-         this case we can save some CPU time and not activate the effect. */
-      if (now - priv->last_effect_time > MINIMUM_SAFE_EFFECT_INTERVAL)
+      switch (effect)
         {
-          switch (effect)
-            {
-              case META_COMP_EFFECT_CREATE:
-                event = META_PLUGIN_MAP;
-                break;
-              case META_COMP_EFFECT_UNMINIMIZE:
-                /* FIXME: should have META_PLUGIN_UNMINIMIZE */
-                event = META_PLUGIN_MAP;
-                break;
-              case META_COMP_EFFECT_NONE:
-                break;
-              case META_COMP_EFFECT_DESTROY:
-              case META_COMP_EFFECT_MINIMIZE:
-                g_assert_not_reached();
-            }
+          case META_COMP_EFFECT_CREATE:
+            event = META_PLUGIN_MAP;
+            break;
+          case META_COMP_EFFECT_UNMINIMIZE:
+            /* FIXME: should have META_PLUGIN_UNMINIMIZE */
+            event = META_PLUGIN_MAP;
+            break;
+          case META_COMP_EFFECT_NONE:
+            break;
+          case META_COMP_EFFECT_DESTROY:
+          case META_COMP_EFFECT_MINIMIZE:
+            g_assert_not_reached();
         }
-
-      priv->last_effect_time = now;
     }
 
   if (priv->obscured)

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -636,6 +636,9 @@ prefs_changed_callback (MetaPreference pref,
     case META_PREF_DESKTOP_EFFECTS:
       meta_get_display ()->desktop_effects = meta_prefs_get_desktop_effects ();
       break;
+    case META_PREF_DESKTOP_EFFECTS:
+      meta_get_display ()->desktop_effects = meta_prefs_get_desktop_effects ();
+      break;
     default:
       /* handled elsewhere or otherwise */
       break;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -636,9 +636,6 @@ prefs_changed_callback (MetaPreference pref,
     case META_PREF_DESKTOP_EFFECTS:
       meta_get_display ()->desktop_effects = meta_prefs_get_desktop_effects ();
       break;
-    case META_PREF_DESKTOP_EFFECTS:
-      meta_get_display ()->desktop_effects = meta_prefs_get_desktop_effects ();
-      break;
     default:
       /* handled elsewhere or otherwise */
       break;


### PR DESCRIPTION
7cfa12d258a03a8b0705a795042d52e3bfb5afc8

Currently MetaWindowActor only has a screen reference, which is mostly used to fetch MetaDisplay.

Based on #466 and #475