### PR TITLE
compositor: Check if priv is NULL before calling meta_window_actor_should_unredirect

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1165,6 +1165,7 @@ meta_pre_paint_func (gpointer data)
   top_window_actor = compositor->top_window_actor;
 
   if (top_window_actor &&
+      top_window_actor->priv &&
       meta_window_actor_should_unredirect (top_window_actor) &&
       compositor->disable_unredirect_count == 0)
     expected_unredirected_window = top_window_actor;


### PR DESCRIPTION
Fixes a segfault.