### PR TITLE
window: Fix edge resistance

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9599,6 +9599,9 @@ update_move (MetaWindow  *window,
 
   meta_window_get_client_root_coords (window, &old);
 
+  if (*prefs->edge_resistance_window)
+    meta_window_update_outer_rect (window);
+
   /* Don't allow movement in the maximized directions or while tiled */
   if (window->maximized_horizontally || META_WINDOW_TILED_OR_SNAPPED (window))
     new_x = old.x;


### PR DESCRIPTION
The outer rect needs to be updated on drag for edge resistance to work. This conditionalizes it based on if the setting is used. This could probably be guarded even more, but for another merge cycle.

C/O @mtwebster 