### PR TITLE
4.0-maintenance: Revert "Phase out MetaCompScreen (#424)"

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -11,10 +11,11 @@
 #include "meta-window-actor-private.h"
 #include <clutter/clutter.h>
 
+typedef struct _MetaCompScreen MetaCompScreen;
+
 struct _MetaCompositor
 {
   MetaDisplay    *display;
-  MetaScreen     *screen;
 
   Atom            atom_x_root_pixmap;
   Atom            atom_x_set_root;
@@ -22,28 +23,9 @@ struct _MetaCompositor
   guint           pre_paint_func_id;
   guint           post_paint_func_id;
 
-  ClutterActor   *stage, *shadow_src;
-  ClutterActor   *bottom_window_group, *window_group, *overlay_group, *top_window_group;
-  ClutterActor   *background_actor;
-  ClutterActor   *hidden_group;
-
-  GList          *windows;
-
-  MetaWindowActor *unredirected_window;
+  ClutterActor   *shadow_src;
 
   CoglContext    *context;
-
-  Window          output;
-
-  /* Used for unredirecting fullscreen windows */
-  guint           disable_unredirect_count;
-
-  /* Before we create the output window */
-  XserverRegion   pending_input_region;
-
-  gint            switch_workspace_in_progress;
-
-  MetaPluginManager *plugin_mgr;
 
   MetaPlugin     *modal_plugin;
 
@@ -57,6 +39,33 @@ struct _MetaCompositor
 
   gboolean frame_has_updated_xsurfaces;
   gboolean have_x11_sync_object;
+};
+
+struct _MetaCompScreen
+{
+  MetaCompositor        *compositor;
+  MetaScreen            *screen;
+
+  ClutterActor          *stage, *bottom_window_group, *window_group, *overlay_group, *top_window_group;
+  ClutterActor          *background_actor;
+  ClutterActor		*hidden_group;
+  GList                 *windows;
+  GHashTable            *windows_by_xid;
+  Window                 output;
+
+  CoglOnscreen          *onscreen;
+  CoglFrameClosure      *frame_closure;
+
+  /* Used for unredirecting fullscreen windows */
+  guint                   disable_unredirect_count;
+  MetaWindowActor             *unredirected_window;
+
+  /* Before we create the output window */
+  XserverRegion     pending_input_region;
+
+  gint                   switch_workspace_in_progress;
+
+  MetaPluginManager *plugin_mgr;
 };
 
 /* Wait 2ms after vblank before starting to draw next frame */

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1611,11 +1611,20 @@ meta_compositor_grab_op_begin (MetaCompositor *compositor)
   // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
   // but causes windows to flicker in and out of view sporadically on some configurations
   // while dragging windows. Make sure it is disabled during the grab.
-  clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
+
+  if (!info)
+    return NULL;
+  clutter_actor_unset_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 void
 meta_compositor_grab_op_end (MetaCompositor *compositor)
 {
-  clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
+  MetaCompScreen *info = meta_screen_get_compositor_data (compositor->display->active_screen);
+
+  if (!info)
+    return NULL;
+
+  clutter_actor_set_flags (info->window_group, CLUTTER_ACTOR_NO_LAYOUT);
 }

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -504,10 +504,10 @@ meta_window_actor_dispose (GObject *object)
 {
   MetaWindowActor        *self = META_WINDOW_ACTOR (object);
   MetaWindowActorPrivate *priv = self->priv;
-  MetaScreen *screen;
-  MetaDisplay *display;
-  Display *xdisplay;
-  MetaCompositor *compositor;
+  MetaScreen             *screen;
+  MetaDisplay            *display;
+  Display                *xdisplay;
+  MetaCompScreen         *info;
 
   if (priv->disposed)
     return;
@@ -520,10 +520,10 @@ meta_window_actor_dispose (GObject *object)
       priv->send_frame_messages_timer = 0;
     }
 
-  screen = priv->screen;
-  display = screen->display;
-  xdisplay = display->xdisplay;
-  compositor = display->compositor;
+  screen   = priv->screen;
+  display  = meta_screen_get_display (screen);
+  xdisplay = meta_display_get_xdisplay (display);
+  info     = meta_screen_get_compositor_data (screen);
 
   meta_window_actor_detach (self);
 
@@ -546,7 +546,7 @@ meta_window_actor_dispose (GObject *object)
       priv->damage = None;
     }
 
-  compositor->windows = g_list_remove (compositor->windows, (gconstpointer) self);
+  info->windows = g_list_remove (info->windows, (gconstpointer) self);
 
   g_clear_object (&priv->window);
 
@@ -759,7 +759,7 @@ static void
 assign_frame_counter_to_frames (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  ClutterStage *stage = priv->window->display->compositor->stage;
+  ClutterStage *stage = clutter_actor_get_stage (CLUTTER_ACTOR (self));
   GList *l;
 
   /* If the window is obscured, then we're expecting to deal with sending
@@ -1227,7 +1227,7 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
 
   if (no_delay_frame)
     {
-      ClutterActor *stage = priv->window->display->compositor->stage;
+      ClutterActor *stage = clutter_actor_get_stage (CLUTTER_ACTOR (self));
       clutter_stage_skip_sync_delay (CLUTTER_STAGE (stage));
     }
 
@@ -1302,11 +1302,11 @@ start_simple_effect (MetaWindowActor *self,
                      gulong        event)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  MetaCompositor *compositor = priv->screen->display->compositor;
+  MetaCompScreen *info = meta_screen_get_compositor_data (priv->screen);
   gint *counter = NULL;
   gboolean use_freeze_thaw = FALSE;
 
-  if (!compositor->plugin_mgr)
+  if (!info->plugin_mgr)
     return FALSE;
 
   switch (event)
@@ -1337,7 +1337,7 @@ start_simple_effect (MetaWindowActor *self,
 
   (*counter)++;
 
-  if (!meta_plugin_manager_event_simple (compositor->plugin_mgr,
+  if (!meta_plugin_manager_event_simple (info->plugin_mgr,
                                          self,
                                          event))
     {
@@ -1543,9 +1543,11 @@ meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
 LOCAL_SYMBOL void
 meta_window_actor_destroy (MetaWindowActor *self)
 {
-  MetaWindow *window;
-  MetaWindowActorPrivate *priv = self->priv;
+  MetaWindow	      *window;
+  MetaWindowActorPrivate *priv;
   MetaWindowType window_type;
+
+  priv = self->priv;
 
   window = priv->window;
   window_type = meta_window_get_window_type (window);
@@ -1626,6 +1628,7 @@ meta_window_actor_sync_actor_geometry (MetaWindowActor *self,
 
   if (priv->position_changed)
     {
+      MetaCompScreen *info;
       clutter_actor_set_position (CLUTTER_ACTOR (self),
                                   window_rect.x, window_rect.y);
     }
@@ -1635,12 +1638,16 @@ void
 meta_window_actor_show (MetaWindowActor   *self,
                         MetaCompEffect     effect)
 {
-  MetaWindowActorPrivate *priv = self->priv;
-  gulong event;
+  MetaWindowActorPrivate *priv;
+  MetaCompScreen         *info;
+  gulong                  event;
+
+  priv = self->priv;
+  info = meta_screen_get_compositor_data (priv->screen);
 
   g_return_if_fail (!priv->visible);
 
-  priv->visible = TRUE;
+  self->priv->visible = TRUE;
 
   event = 0;
   switch (effect)
@@ -1660,7 +1667,7 @@ meta_window_actor_show (MetaWindowActor   *self,
     }
 
   if (priv->redecorating ||
-      priv->screen->display->compositor->switch_workspace_in_progress ||
+      info->switch_workspace_in_progress ||
       event == 0 ||
       !start_simple_effect (self, event))
     {
@@ -1673,9 +1680,12 @@ LOCAL_SYMBOL void
 meta_window_actor_hide (MetaWindowActor *self,
                         MetaCompEffect   effect)
 {
-  MetaWindowActorPrivate *priv = self->priv;
-  MetaCompositor *compositor = priv->screen->display->compositor;
-  gulong event;
+  MetaWindowActorPrivate *priv;
+  MetaCompScreen         *info;
+  gulong                  event;
+
+  priv = self->priv;
+  info = meta_screen_get_compositor_data (priv->screen);
 
   g_return_if_fail (priv->visible || (!priv->visible && meta_window_is_attached_dialog (priv->window)));
 
@@ -1685,7 +1695,7 @@ meta_window_actor_hide (MetaWindowActor *self,
    * hold off on hiding the window, and do it after the workspace
    * switch completes
    */
-  if (compositor->switch_workspace_in_progress)
+  if (info->switch_workspace_in_progress)
     return;
 
   event = 0;
@@ -1714,7 +1724,8 @@ meta_window_actor_maximize (MetaWindowActor    *self,
                             MetaRectangle      *old_rect,
                             MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaCompScreen *info = meta_screen_get_compositor_data (self->priv->screen);
+
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
    * old size and position */
@@ -1724,8 +1735,8 @@ meta_window_actor_maximize (MetaWindowActor    *self,
   self->priv->maximize_in_progress++;
   meta_window_actor_freeze (self);
 
-  if (!compositor->plugin_mgr ||
-      !meta_plugin_manager_event_maximize (compositor->plugin_mgr,
+  if (!info->plugin_mgr ||
+      !meta_plugin_manager_event_maximize (info->plugin_mgr,
                                            self,
                                            META_PLUGIN_MAXIMIZE,
                                            new_rect->x, new_rect->y,
@@ -1742,7 +1753,7 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
                               MetaRectangle     *old_rect,
                               MetaRectangle     *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaCompScreen *info = meta_screen_get_compositor_data (self->priv->screen);
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -1753,8 +1764,8 @@ meta_window_actor_unmaximize (MetaWindowActor   *self,
   self->priv->unmaximize_in_progress++;
   meta_window_actor_freeze (self);
 
-  if (!compositor->plugin_mgr ||
-      !meta_plugin_manager_event_maximize (compositor->plugin_mgr,
+  if (!info->plugin_mgr ||
+      !meta_plugin_manager_event_maximize (info->plugin_mgr,
                                            self,
                                            META_PLUGIN_UNMAXIMIZE,
                                            new_rect->x, new_rect->y,
@@ -1770,7 +1781,7 @@ meta_window_actor_tile (MetaWindowActor    *self,
                         MetaRectangle      *old_rect,
                         MetaRectangle      *new_rect)
 {
-  MetaCompositor *compositor = self->priv->screen->display->compositor;
+  MetaCompScreen *info = meta_screen_get_compositor_data (self->priv->screen);
 
   /* The window has already been resized (in order to compute new_rect),
    * which by side effect caused the actor to be resized. Restore it to the
@@ -1781,8 +1792,8 @@ meta_window_actor_tile (MetaWindowActor    *self,
   self->priv->tile_in_progress++;
   meta_window_actor_freeze (self);
 
-  if (!compositor->plugin_mgr ||
-      !meta_plugin_manager_event_maximize (compositor->plugin_mgr,
+  if (!info->plugin_mgr ||
+      !meta_plugin_manager_event_maximize (info->plugin_mgr,
                                            self,
                                            META_PLUGIN_TILE,
                                            new_rect->x, new_rect->y,
@@ -1797,9 +1808,9 @@ meta_window_actor_tile (MetaWindowActor    *self,
 LOCAL_SYMBOL MetaWindowActor *
 meta_window_actor_new (MetaWindow *window)
 {
-  MetaScreen *screen = window->screen;
-  MetaCompositor *compositor = screen->display->compositor;
-  MetaWindowActor *self;
+  MetaScreen	 	 *screen = meta_window_get_screen (window);
+  MetaCompScreen         *info = meta_screen_get_compositor_data (screen);
+  MetaWindowActor        *self;
   MetaWindowActorPrivate *priv;
   MetaFrame		 *frame;
   Window		  top_window;
@@ -1843,13 +1854,13 @@ meta_window_actor_new (MetaWindow *window)
   meta_window_set_compositor_private (window, G_OBJECT (self));
 
   if (window->type == META_WINDOW_DND)
-    window_group = compositor->window_group;
+    window_group = info->window_group;
   else if (window->layer == META_LAYER_OVERRIDE_REDIRECT)
-    window_group = compositor->top_window_group;
+    window_group = info->top_window_group;
   else if (window->type == META_WINDOW_DESKTOP)
-    window_group = compositor->bottom_window_group;
+    window_group = info->bottom_window_group;
   else
-    window_group = compositor->window_group;
+    window_group = info->window_group;
 
   clutter_actor_add_child (window_group, CLUTTER_ACTOR (self));
 
@@ -1858,7 +1869,7 @@ meta_window_actor_new (MetaWindow *window)
   /* Initial position in the stack is arbitrary; stacking will be synced
    * before we first paint.
    */
-  compositor->windows = g_list_append (compositor->windows, self);
+  info->windows = g_list_append (info->windows, self);
 
   return self;
 }
@@ -2014,19 +2025,22 @@ meta_window_actor_reset_visible_regions (MetaWindowActor *self)
 static void
 check_needs_pixmap (MetaWindowActor *self)
 {
-  MetaWindowActorPrivate *priv = self->priv;
-  MetaScreen *screen = priv->screen;
-  MetaDisplay *display = screen->display;
-  Display *xdisplay = display->xdisplay;
-  MetaCompositor *compositor = display->compositor;
-  Window xwindow = priv->xwindow;
+  MetaWindowActorPrivate *priv     = self->priv;
+  MetaScreen          *screen   = priv->screen;
+  MetaDisplay         *display  = meta_screen_get_display (screen);
+  Display             *xdisplay = meta_display_get_xdisplay (display);
+  MetaCompScreen      *info     = meta_screen_get_compositor_data (screen);
+  MetaCompositor      *compositor;
+  Window               xwindow  = priv->xwindow;
 
   if ((!priv->window->mapped && !priv->window->shaded) || !priv->needs_pixmap)
     return;
 
-  if (xwindow == screen->xroot ||
-      xwindow == clutter_x11_get_stage_window (compositor->stage))
+  if (xwindow == meta_screen_get_xroot (screen) ||
+      xwindow == clutter_x11_get_stage_window (CLUTTER_STAGE (info->stage)))
     return;
+
+  compositor = meta_display_get_compositor (display);
 
   if (priv->size_changed)
     {
@@ -2169,11 +2183,11 @@ meta_window_actor_process_damage (MetaWindowActor    *self,
                                   XDamageNotifyEvent *event)
 {
   MetaWindowActorPrivate *priv = self->priv;
-  MetaCompositor *compositor = priv->window->display->compositor;
+  MetaCompScreen *info = meta_screen_get_compositor_data (priv->screen);
 
   priv->received_damage = TRUE;
 
-  if (meta_window_is_fullscreen (priv->window) && g_list_last (compositor->windows)->data == self && !priv->unredirected)
+  if (meta_window_is_fullscreen (priv->window) && g_list_last (info->windows)->data == self && !priv->unredirected)
     {
       MetaRectangle window_rect;
       meta_window_get_outer_rect (priv->window, &window_rect);

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -316,8 +316,6 @@ static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
   ClutterActor *actor = CLUTTER_ACTOR (window_group);
-
-  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -7,8 +7,6 @@
 
 #include <gdk/gdk.h> /* for gdk_rectangle_intersect() */
 
-#include <core/screen-private.h>
-
 #include "clutter-utils.h"
 #include "compositor-private.h"
 #include "meta-window-actor-private.h"
@@ -89,8 +87,6 @@ painting_untransformed (MetaWindowGroup *window_group,
 
 static void
 meta_window_group_cull_out (MetaWindowGroup *group,
-                            ClutterActor    *unredirected_window,
-                            gboolean         has_unredirected_window,
                             cairo_region_t  *unobscured_region,
                             cairo_region_t  *clip_region)
 {
@@ -105,10 +101,13 @@ meta_window_group_cull_out (MetaWindowGroup *group,
   clutter_actor_iter_init (&iter, actor);
   while (clutter_actor_iter_prev (&iter, &child))
     {
+      MetaCompScreen *info = meta_screen_get_compositor_data (group->screen);
+
       if (!CLUTTER_ACTOR_IS_VISIBLE (child))
         continue;
 
-      if (has_unredirected_window && child == unredirected_window)
+      if (info->unredirected_window != NULL &&
+          child == CLUTTER_ACTOR (info->unredirected_window))
         continue;
 
       /* If an actor has effects applied, then that can change the area
@@ -215,8 +214,8 @@ meta_window_group_paint (ClutterActor *actor)
   int actor_x_origin, actor_y_origin;
 
   MetaWindowGroup *window_group = META_WINDOW_GROUP (actor);
-  MetaCompositor *compositor = window_group->screen->display->compositor;
-  ClutterActor *stage = CLUTTER_STAGE (compositor->stage);
+  ClutterActor *stage = clutter_actor_get_stage (actor);
+  MetaCompScreen *info = meta_screen_get_compositor_data (window_group->screen);
 
   /* Start off by treating all windows as completely unobscured, so damage anywhere
    * in a window queues redraws, but confine it more below. */
@@ -254,8 +253,8 @@ meta_window_group_paint (ClutterActor *actor)
   paint_y_offset = paint_y_origin - actor_y_origin;
 
   visible_rect.x = visible_rect.y = 0;
-  visible_rect.width = clutter_actor_get_width (stage);
-  visible_rect.height = clutter_actor_get_height (stage);
+  visible_rect.width = clutter_actor_get_width (CLUTTER_ACTOR (stage));
+  visible_rect.height = clutter_actor_get_height (CLUTTER_ACTOR (stage));
 
   unobscured_region = cairo_region_create_rectangle (&visible_rect);
 
@@ -265,28 +264,24 @@ meta_window_group_paint (ClutterActor *actor)
    * sizes, we could intersect this with an accurate union of the
    * monitors to avoid painting shadows that are visible only in the
    * holes. */
-  clutter_stage_get_redraw_clip_bounds (stage, &clip_rect);
+  clutter_stage_get_redraw_clip_bounds (CLUTTER_STAGE (stage),
+                                        &clip_rect);
 
   clip_region = cairo_region_create_rectangle (&clip_rect);
 
   cairo_region_translate (clip_region, -paint_x_offset, -paint_y_offset);
 
-  gboolean has_unredirected_window = compositor->unredirected_window != NULL;
-  if (has_unredirected_window)
+  if (info->unredirected_window != NULL)
     {
       cairo_rectangle_int_t unredirected_rect;
-      MetaWindow *window = meta_window_actor_get_meta_window (compositor->unredirected_window);
+      MetaWindow *window = meta_window_actor_get_meta_window (info->unredirected_window);
 
       meta_window_get_outer_rect (window, (MetaRectangle *)&unredirected_rect);
       cairo_region_subtract_rectangle (unobscured_region, &unredirected_rect);
       cairo_region_subtract_rectangle (clip_region, &unredirected_rect);
     }
 
-  meta_window_group_cull_out (window_group,
-                              CLUTTER_ACTOR (compositor->unredirected_window),
-                              has_unredirected_window,
-                              unobscured_region,
-                              clip_region);
+  meta_window_group_cull_out (window_group, unobscured_region, clip_region);
 
   cairo_region_destroy (unobscured_region);
   cairo_region_destroy (clip_region);

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -316,6 +316,8 @@ static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
   ClutterActor *actor = CLUTTER_ACTOR (window_group);
+
+  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -134,6 +134,9 @@ struct _MetaScreen
   
   int closing;
 
+  /* Managed by compositor.c */
+  gpointer compositor_data;
+  
   /* Instead of unmapping withdrawn windows we can leave them mapped
    * and restack them below a guard window. When using a compositor
    * this allows us to provide live previews of unmapped windows */

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -987,6 +987,7 @@ meta_screen_new (MetaDisplay *display,
   screen->columns_of_workspaces = -1;
   screen->vertical_workspaces = FALSE;
   screen->starting_corner = META_SCREEN_TOPLEFT;
+  screen->compositor_data = NULL;
   screen->guard_window = None;
 
   screen->composite_overlay_window = XCompositeGetOverlayWindow (xdisplay, xroot);
@@ -3664,6 +3665,23 @@ meta_screen_get_size (MetaScreen *screen,
 {
   *width = screen->rect.width;
   *height = screen->rect.height;
+}
+
+/**
+ * meta_screen_get_compositor_data: (skip)
+ *
+ */
+gpointer
+meta_screen_get_compositor_data (MetaScreen *screen)
+{
+  return screen->compositor_data;
+}
+
+void
+meta_screen_set_compositor_data (MetaScreen *screen,
+                                 gpointer    compositor)
+{
+  screen->compositor_data = compositor;
 }
 
 void

--- a/src/meta/screen.h
+++ b/src/meta/screen.h
@@ -45,6 +45,11 @@ Window meta_screen_get_xroot (MetaScreen *screen);
 void meta_screen_get_size (MetaScreen *screen,
                            int        *width,
                            int        *height);
+
+gpointer meta_screen_get_compositor_data (MetaScreen *screen);
+void meta_screen_set_compositor_data (MetaScreen *screen,
+                                      gpointer    info);
+
 MetaScreen *meta_screen_for_x_screen (Screen *xscreen);
 
 void meta_screen_set_cm_selection (MetaScreen *screen);


### PR DESCRIPTION
This commit slipped by my radar because #405 was open for a while, but this commit is not stable yet and is causing Cinnamon to segfault during restarts.