### PR TITLE
Unconditionalize meta_window_update_outer_rect

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9599,8 +9599,7 @@ update_move (MetaWindow  *window,
 
   meta_window_get_client_root_coords (window, &old);
 
-  if (*prefs->edge_resistance_window)
-    meta_window_update_outer_rect (window);
+  meta_window_update_outer_rect (window);
 
   /* Don't allow movement in the maximized directions or while tiled */
   if (window->maximized_horizontally || META_WINDOW_TILED_OR_SNAPPED (window))


### PR DESCRIPTION
This is apparently needed so the workspace switcher applet animates window movements in real-time. I don't think this warrants the performance hit for what amounts to eye candy, but I am weary of the debate and would rather more small changes like this be in place than fully reverting hundreds of hours of my work like has been discussed yesterday on Slack.