### PR TITLE
window.c: Remove a condition for updating the outer rect

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9599,8 +9599,7 @@ update_move (MetaWindow  *window,
 
   meta_window_get_client_root_coords (window, &old);
 
-  if (*prefs->edge_resistance_window)
-    meta_window_update_outer_rect (window);
+  meta_window_update_outer_rect (window);
 
   /* Don't allow movement in the maximized directions or while tiled */
   if (window->maximized_horizontally || META_WINDOW_TILED_OR_SNAPPED (window))


### PR DESCRIPTION
We only update the outer rect if the edge resistance setting is enabled. Since
this setting is on by default it's being called on my most users installs
anyway. This also has the side effect of fixing other things that depend on
the rect being updated. An example of this is the workspace switcher Cinnamon
applet.