### PR TITLE
window: Call update_outer_rect in update_resize

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9975,6 +9975,8 @@ update_resize (MetaWindow *window,
 
   g_assert (gravity >= 0);
 
+  meta_window_update_outer_rect (window);
+
   /* Do any edge resistance/snapping */
   meta_window_edge_resistance_for_resize (window,
                                           old.width,


### PR DESCRIPTION
This fixes resizing indication in the workspace switcher applet.