### PR TITLE
[Next] [RFC/WIP]buffer and frame timing changes from upstream

### DIFF
--- a/clutter/clutter/cogl/clutter-stage-cogl.h
+++ b/clutter/clutter/cogl/clutter-stage-cogl.h
@@ -61,6 +61,8 @@ struct _ClutterStageCogl
    * junk frames to start with. */
   unsigned int frame_count;
 
+  gint last_sync_delay;
+
   cairo_rectangle_int_t bounding_redraw_clip;
 
   guint initialized_redraw_clip : 1;

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -300,7 +300,7 @@ meta_shadow_paint (MetaShadow     *shadow,
             {
               cogl_pipeline_set_color4ub (shadow->pipeline,
                                           opacity, opacity, opacity, opacity);
-//              cogl_set_source (shadow->pipeline); suspect not needed, but this line still there in mutter
+              cogl_set_source (shadow->pipeline);
               source_updated = TRUE;
             }
 

--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -300,7 +300,7 @@ meta_shadow_paint (MetaShadow     *shadow,
             {
               cogl_pipeline_set_color4ub (shadow->pipeline,
                                           opacity, opacity, opacity, opacity);
-              cogl_set_source (shadow->pipeline);
+//              cogl_set_source (shadow->pipeline); suspect not needed, but this line still there in mutter
               source_updated = TRUE;
             }
 


### PR DESCRIPTION
This has the buffer and frame timing changes from upstream, that have been fairly widely trailed [phoronix etc.].  I'm not sure I can notice the difference, but Daniel van Vugt gives reasons why the problem was not noticed here https://gitlab.gnome.org/GNOME/mutter/commit/45244852acc214a7a9d01dc96896ad0c079b437c

so perhaps those reasons apply for us. Anyway I know I am not as observant as others over frame timing issues.  Here to try out.  Not to pull.