### PR TITLE
4.0-maintenance: screen: Fix segfault when restarting Cinnamon on a workspace other than the first

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -828,8 +828,7 @@ meta_screen_new (MetaDisplay *display,
   Atom wm_sn_atom;
   char buf[128];
   guint32 manager_timestamp;
-  gulong current_workspace;
-  
+
   replace_current_wm = meta_get_replace_current_wm ();
   
   /* Only display->name, display->xdisplay, and display->error_traps
@@ -1019,17 +1018,6 @@ meta_screen_new (MetaDisplay *display,
 
   meta_screen_update_workspace_layout (screen);
 
-  /* Get current workspace */
-  current_workspace = 0;
-  if (meta_prop_get_cardinal (screen->display,
-                              screen->xroot,
-                              screen->display->atom__NET_CURRENT_DESKTOP,
-                              &current_workspace))
-    meta_verbose ("Read existing _NET_CURRENT_DESKTOP = %d\n",
-                  (int) current_workspace);
-  else
-    meta_verbose ("No _NET_CURRENT_DESKTOP present\n");
-  
   /* Screens must have at least one workspace at all times,
    * so create that required workspace.
    */
@@ -1068,17 +1056,6 @@ meta_screen_new (MetaDisplay *display,
   screen->startup_sequences = NULL;
   screen->startup_sequence_timeout = 0;
 #endif
-
-  /* Switch to the _NET_CURRENT_DESKTOP workspace */
-  {
-    MetaWorkspace *space;
-    
-    space = meta_screen_get_workspace_by_index (screen,
-                                                current_workspace);
-    
-    if (space != NULL)
-      meta_workspace_activate (space, timestamp);
-  }
 
   meta_verbose ("Added screen %d ('%s') root 0x%lx\n",
                 screen->number, screen->screen_name, screen->xroot);


### PR DESCRIPTION
Backports a necessary patch that was supposed to go along with https://github.com/linuxmint/muffin/commit/afda0261377cbf64720d02a974e03a0ed41b56dc.