### PR TITLE
window-actor: Check disposed actor in meta_window_actor_check_obscured

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1599,6 +1599,9 @@ meta_window_actor_check_obscured (MetaWindowActor *self)
 {
   MetaWindowActorPrivate *priv = self->priv;
 
+  if (!priv || !priv->window)
+    return;
+
   if (!priv->first_frame_drawn ||
       priv->window->type == META_WINDOW_OVERRIDE_OTHER)
     {


### PR DESCRIPTION
Didn't see this until using #508. but since this line conflicts with #489, keeping it separate.

```
Thread 1 (Thread 0x7ffff7fa5140 (LWP 17931)):
#0  0x00007ffff78c63b5 in meta_window_actor_check_obscured (self=0x555556bc0c60) at compositor/meta-window-actor.c:1602
#1  0x00007fffef7e9dae in ffi_call_unix64 () at /usr/lib/x86_64-linux-gnu/libffi.so.6
#2  0x00007fffef7e971f in ffi_call () at /usr/lib/x86_64-linux-gnu/libffi.so.6
#3  0x00007ffff5be8128 in gjs_invoke_c_function(JSContext*, Function*, JS::HandleObject, JS::HandleValueArray const&, mozilla::Maybe<JS::MutableHandle<JS::Value> >, GIArgument*) (context=context@entry=0x555555f20000, function=function@entry=0x555556ff12a0, obj=..., obj@entry=..., args=..., js_rval=..., r_value=r_value@entry=0x0) at gi/function.cpp:1096
#4  0x00007ffff5be9a74 in function_call(JSContext*, unsigned int, JS::Value*) (context=0x555555f20000, js_argc=1, vp=0x555556114e10) at gi/function.cpp:1414
#5  0x00007fffed051f6c in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#6  0x00007fffed044ed7 in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#7  0x00007fffed0517d6 in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#8  0x00007fffed051daf in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#9  0x00007fffed270d86 in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#10 0x000019a316686a96 in  ()
#11 0x00007fff3c44fa60 in  ()
#12 0x00007ffffffface0 in  ()
#13 0xfff9000000000000 in  ()
#14 0x00007fffee3ec620 in  () at /usr/lib/x86_64-linux-gnu/libmozjs-52.so.0
#15 0x00007fffc0571520 in  ()
#16 0x000019a3166903f3 in  ()
#17 0x0000000000005022 in  ()
#18 0x00007fffffffada8 in  ()
#19 0x0000555555a3d528 in  ()
#20 0x0000000000000002 in  ()
#21 0x00007fffffffad28 in  ()
#22 0xfffe7fff3c200b50 in  ()
#23 0xfff9000000000000 in  ()
#24 0xfffe7fff3c2716a0 in  ()
#25 0xfff8800000000001 in  ()
#26 0x00007fffffffadd8 in  ()
#27 0x0000555555a3d528 in  ()
#28 0x000019a3167a17eb in  ()
#29 0x0000000000007821 in  ()
#30 0xfff8800000000001 in  ()
#31 0xfffe7fff3c2716a0 in  ()
#32 0xfff9000000000000 in  ()
#33 0xfffe7fff3c200b50 in  ()
#34 0xfff9000000000000 in  ()
#35 0xfff9000000000000 in  ()
#36 0xfff8800000000002 in  ()
#37 0xfff8800000000001 in  ()
#38 0x161510bc95872300 in  ()
#39 0x0000555556017780 in  ()
#40 0x0000555500000078 in  ()
#41 0x00007fffc05e17c0 in  ()
#42 0x0000000000000003 in  ()
#43 0x0000000000000000 in  ()
```