### PR TITLE
Fix screensaver rendering issues introduced by unredirection bug fixes

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -55,6 +55,8 @@ struct _MetaCompositor
   guint           show_redraw : 1;
   guint           debug       : 1;
   guint           no_mipmaps  : 1;
+  // Screensaver case
+  guint           override_window_on_top;
 
   gboolean frame_has_updated_xsurfaces;
   gboolean have_x11_sync_object;

--- a/src/compositor/meta-window-actor-private.h
+++ b/src/compositor/meta-window-actor-private.h
@@ -8,6 +8,116 @@
 #include <X11/extensions/Xdamage.h>
 #include <meta/compositor-muffin.h>
 #include <clutter/clutter-muffin.h>
+#include "meta-shadow-factory-private.h"
+
+struct _MetaWindowActorPrivate
+{
+  MetaWindow       *window;
+  Window            xwindow;
+  MetaScreen       *screen;
+
+  ClutterActor     *actor;
+
+  /* MetaShadowFactory only caches shadows that are actually in use;
+   * to avoid unnecessary recomputation we do two things: 1) we store
+   * both a focused and unfocused shadow for the window. If the window
+   * doesn't have different focused and unfocused shadow parameters,
+   * these will be the same. 2) when the shadow potentially changes we
+   * don't immediately unreference the old shadow, we just flag it as
+   * dirty and recompute it when we next need it (recompute_focused_shadow,
+   * recompute_unfocused_shadow.) Because of our extraction of
+   * size-invariant window shape, we'll often find that the new shadow
+   * is the same as the old shadow.
+   */
+  MetaShadow       *focused_shadow;
+  MetaShadow       *unfocused_shadow;
+
+  Pixmap            back_pixmap;
+
+  Damage            damage;
+
+  guint8            opacity;
+
+  /* If the window is shaped, a region that matches the shape */
+  cairo_region_t   *shape_region;
+  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
+   * the shape region. */
+  cairo_region_t   *opaque_region;
+  /* The region we should clip to when painting the shadow */
+  cairo_region_t   *shadow_clip;
+
+   /* The region that is visible, used to optimize out redraws */
+  cairo_region_t   *unobscured_region;
+
+  /* Extracted size-invariant shape used for shadows */
+  MetaWindowShape  *shadow_shape;
+
+  gint              last_width;
+  gint              last_height;
+  gint              last_x;
+  gint              last_y;
+
+  gint              freeze_count;
+
+  char *            shadow_class;
+
+  /*
+   * These need to be counters rather than flags, since more plugins
+   * can implement same effect; the practicality of stacking effects
+   * might be dubious, but we have to at least handle it correctly.
+   */
+  gint              minimize_in_progress;
+  gint              maximize_in_progress;
+  gint              unmaximize_in_progress;
+  gint              tile_in_progress;
+  gint              map_in_progress;
+  gint              destroy_in_progress;
+
+  /* List of FrameData for recent frames */
+  GList            *frames;
+
+  guint		    visible                : 1;
+  guint		    argb32                 : 1;
+  guint		    disposed               : 1;
+  guint             redecorating           : 1;
+
+  guint		    needs_damage_all       : 1;
+  guint		    received_damage        : 1;
+  guint             repaint_scheduled      : 1;
+
+  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
+   * client message using the most recent frame in ->frames */
+  guint             send_frame_messages_timer;
+  gint64            frame_drawn_time;
+  guint             needs_frame_drawn      : 1;
+
+  guint             size_changed_id;
+  guint             opacity_changed_id;
+
+  guint		    needs_pixmap           : 1;
+  guint             needs_reshape          : 1;
+  guint             recompute_focused_shadow   : 1;
+  guint             recompute_unfocused_shadow : 1;
+  guint             size_changed               : 1;
+  guint             position_changed           : 1;
+  guint             updates_frozen         : 1;
+
+  guint		    needs_destroy	   : 1;
+
+  guint             no_shadow              : 1;
+
+  guint             unredirected           : 1;
+  guint unredirection_blocked;
+
+  /* This is used to detect fullscreen windows that need to be unredirected */
+  guint             full_damage_frames_count;
+  guint             does_full_damage  : 1;
+
+  guint             has_desat_effect : 1;
+
+  guint             reshapes;
+  guint             should_have_shadow : 1;
+};
 
 MetaWindowActor *meta_window_actor_new (MetaWindow *window);
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -28,7 +28,6 @@
 
 #include "compositor-private.h"
 #include "meta-shaped-texture-private.h"
-#include "meta-shadow-factory-private.h"
 #include "meta-window-actor-private.h"
 
 enum {
@@ -38,116 +37,6 @@ enum {
 };
 
 static guint signals[LAST_SIGNAL] = {0};
-
-
-struct _MetaWindowActorPrivate
-{
-  MetaWindow       *window;
-  Window            xwindow;
-  MetaScreen       *screen;
-
-  ClutterActor     *actor;
-
-  /* MetaShadowFactory only caches shadows that are actually in use;
-   * to avoid unnecessary recomputation we do two things: 1) we store
-   * both a focused and unfocused shadow for the window. If the window
-   * doesn't have different focused and unfocused shadow parameters,
-   * these will be the same. 2) when the shadow potentially changes we
-   * don't immediately unreference the old shadow, we just flag it as
-   * dirty and recompute it when we next need it (recompute_focused_shadow,
-   * recompute_unfocused_shadow.) Because of our extraction of
-   * size-invariant window shape, we'll often find that the new shadow
-   * is the same as the old shadow.
-   */
-  MetaShadow       *focused_shadow;
-  MetaShadow       *unfocused_shadow;
-
-  Pixmap            back_pixmap;
-
-  Damage            damage;
-
-  guint8            opacity;
-
-  /* If the window is shaped, a region that matches the shape */
-  cairo_region_t   *shape_region;
-  /* The opaque region, from _NET_WM_OPAQUE_REGION, intersected with
-   * the shape region. */
-  cairo_region_t   *opaque_region;
-  /* The region we should clip to when painting the shadow */
-  cairo_region_t   *shadow_clip;
-
-   /* The region that is visible, used to optimize out redraws */
-  cairo_region_t   *unobscured_region;
-
-  /* Extracted size-invariant shape used for shadows */
-  MetaWindowShape  *shadow_shape;
-
-  gint              last_width;
-  gint              last_height;
-  gint              last_x;
-  gint              last_y;
-
-  gint              freeze_count;
-
-  char *            shadow_class;
-
-  /*
-   * These need to be counters rather than flags, since more plugins
-   * can implement same effect; the practicality of stacking effects
-   * might be dubious, but we have to at least handle it correctly.
-   */
-  gint              minimize_in_progress;
-  gint              maximize_in_progress;
-  gint              unmaximize_in_progress;
-  gint              tile_in_progress;
-  gint              map_in_progress;
-  gint              destroy_in_progress;
-
-  /* List of FrameData for recent frames */
-  GList            *frames;
-
-  guint		    visible                : 1;
-  guint		    argb32                 : 1;
-  guint		    disposed               : 1;
-  guint             redecorating           : 1;
-
-  guint		    needs_damage_all       : 1;
-  guint		    received_damage        : 1;
-  guint             repaint_scheduled      : 1;
-
-  /* If set, the client needs to be sent a _NET_WM_FRAME_DRAWN
-   * client message using the most recent frame in ->frames */
-  guint             send_frame_messages_timer;
-  gint64            frame_drawn_time;
-  guint             needs_frame_drawn      : 1;
-
-  guint             size_changed_id;
-  guint             opacity_changed_id;
-
-  guint		    needs_pixmap           : 1;
-  guint             needs_reshape          : 1;
-  guint             recompute_focused_shadow   : 1;
-  guint             recompute_unfocused_shadow : 1;
-  guint             size_changed               : 1;
-  guint             position_changed           : 1;
-  guint             updates_frozen         : 1;
-
-  guint		    needs_destroy	   : 1;
-
-  guint             no_shadow              : 1;
-
-  guint             unredirected           : 1;
-  guint unredirection_blocked;
-
-  /* This is used to detect fullscreen windows that need to be unredirected */
-  guint             full_damage_frames_count;
-  guint             does_full_damage  : 1;
-
-  guint             has_desat_effect : 1;
-
-  guint             reshapes;
-  guint             should_have_shadow : 1;
-};
 
 typedef struct _FrameData FrameData;
 

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -137,6 +137,7 @@ struct _MetaWindowActorPrivate
   guint             no_shadow              : 1;
 
   guint             unredirected           : 1;
+  guint unredirection_blocked;
 
   /* This is used to detect fullscreen windows that need to be unredirected */
   guint             full_damage_frames_count;


### PR DESCRIPTION
This forces compositing on the screensaver. I suspect this might be related to upstream refactoring that fixed issues with OR windows not being fully unredirected when they should be. The screensaver sets the `META_WINDOW_OVERRIDE_OTHER` window type so it is added to the `top_window_group` and always above all windows. This seems to have an issue with the actual underlying unredirection with Xorg though, and suggests the screensaver may not have been unredirecting before until 63ddb021f2393610e16f44949e9890fc86e3ad51 - where we see the render updates freezing. Not exactly sure why this occurs, but after testing both native and wine games, so far the screensaver is the only app I've noticed having rendering issues when unredirected.

Closes https://github.com/linuxmint/alpha-testing/issues/10