### PR TITLE
Fix the current workspace not being selected during startup

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -553,6 +553,7 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
 {
   MetaDisplay    *display       = meta_screen_get_display (screen);
   Display        *xdisplay      = meta_display_get_xdisplay (display);
+  MetaWorkspace *startup_workspace = NULL;
   Window          xwin;
   gint            width, height;
   XWindowAttributes attr;
@@ -665,6 +666,11 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
   XMapWindow (xdisplay, compositor->output);
 
   compositor->have_x11_sync_object = meta_sync_ring_init (xdisplay);
+
+  startup_workspace = meta_screen_get_workspace_by_index (screen, screen->startup_workspace_index);
+
+  if (startup_workspace != NULL)
+    meta_workspace_activate (startup_workspace, display->current_time);
 }
 
 void

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -85,6 +85,7 @@ struct _MetaScreen
   gboolean tile_hud_visible;
 
   MetaWorkspace *active_workspace;
+  gulong startup_workspace_index;
 
   /* This window holds the focus when we don't want to focus
    * any actual clients

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -996,10 +996,12 @@ meta_screen_new (MetaDisplay *display,
 
   /* Get current workspace */
   current_workspace = 0;
-  if (meta_prop_get_cardinal (screen->display,
-                              screen->xroot,
-                              screen->display->atom__NET_CURRENT_DESKTOP,
-                              &current_workspace))
+
+  if (meta_prop_get_cardinal_with_atom_type (screen->display,
+                                             screen->xroot,
+                                             screen->display->atom__NET_CURRENT_DESKTOP,
+                                             XA_CARDINAL,
+                                             &current_workspace))
     meta_verbose ("Read existing _NET_CURRENT_DESKTOP = %d\n",
                   (int) current_workspace);
   else
@@ -1013,6 +1015,7 @@ meta_screen_new (MetaDisplay *display,
 
   set_workspace_names (screen);
 
+  screen->startup_workspace_index = current_workspace;
   screen->all_keys_grabbed = FALSE;
   screen->keys_grabbed = FALSE;
   meta_screen_grab_keys (screen);
@@ -1043,17 +1046,6 @@ meta_screen_new (MetaDisplay *display,
   screen->startup_sequences = NULL;
   screen->startup_sequence_timeout = 0;
 #endif
-
-  /* Switch to the _NET_CURRENT_DESKTOP workspace */
-  {
-    MetaWorkspace *space;
-    
-    space = meta_screen_get_workspace_by_index (screen,
-                                                current_workspace);
-    
-    if (space != NULL)
-      meta_workspace_activate (space, timestamp);
-  }
 
   meta_verbose ("Added screen %d ('%s') root 0x%lx\n",
                 screen->number, screen->screen_name, screen->xroot);

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -805,7 +805,8 @@ meta_screen_new (MetaDisplay *display,
   Atom wm_sn_atom;
   char buf[128];
   guint32 manager_timestamp;
-
+  gulong current_workspace;
+  
   replace_current_wm = meta_get_replace_current_wm ();
 
   /* Only display->name, display->xdisplay, and display->error_traps
@@ -993,6 +994,17 @@ meta_screen_new (MetaDisplay *display,
 
   meta_screen_update_workspace_layout (screen);
 
+  /* Get current workspace */
+  current_workspace = 0;
+  if (meta_prop_get_cardinal (screen->display,
+                              screen->xroot,
+                              screen->display->atom__NET_CURRENT_DESKTOP,
+                              &current_workspace))
+    meta_verbose ("Read existing _NET_CURRENT_DESKTOP = %d\n",
+                  (int) current_workspace);
+  else
+    meta_verbose ("No _NET_CURRENT_DESKTOP present\n");
+  
   /* Screens must have at least one workspace at all times,
    * so create that required workspace.
    */
@@ -1031,6 +1043,17 @@ meta_screen_new (MetaDisplay *display,
   screen->startup_sequences = NULL;
   screen->startup_sequence_timeout = 0;
 #endif
+
+  /* Switch to the _NET_CURRENT_DESKTOP workspace */
+  {
+    MetaWorkspace *space;
+    
+    space = meta_screen_get_workspace_by_index (screen,
+                                                current_workspace);
+    
+    if (space != NULL)
+      meta_workspace_activate (space, timestamp);
+  }
 
   meta_verbose ("Added screen %d ('%s') root 0x%lx\n",
                 screen->number, screen->screen_name, screen->xroot);


### PR DESCRIPTION
This reverts 12a1246d876660a61d95340100df7c82f6b19bba. At the time the code looked like it never would have worked and was removed, but after testing 4.0.6 that appears to only be the case after #424. This restores the original behavior without crashing by deferring the workspace switching until after MetaCompositor is initialized with a managed screen.

Ref https://github.com/linuxmint/cinnamon/issues/8602