### PR TITLE
window-private: Include compositor-private.h

### DIFF
--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -35,7 +35,7 @@
 #define META_WINDOW_PRIVATE_H
 
 #include <config.h>
-#include <meta/compositor.h>
+#include <compositor/compositor-private.h>
 #include <meta/window.h>
 #include "screen-private.h"
 #include <meta/util.h>


### PR DESCRIPTION
This fixes a build error in display.c, but adding it in window-private.h because it will be compatible with the re-introduction of the compositor patches for 4.4.