### PR TITLE
[Next] 4.0: Don't set CLUTTER_ACTOR_NO_LAYOUT flag

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -77,9 +77,6 @@ void     meta_end_modal_for_plugin   (MetaScreen       *screen,
 gint64 meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
                                                       gint64       monotonic_time);
 
-void meta_compositor_grab_op_begin (MetaCompositor *compositor);
-void meta_compositor_grab_op_end (MetaCompositor *compositor);
-
 void meta_check_end_modal (MetaScreen *screen);
 
 #endif /* META_COMPOSITOR_PRIVATE_H */

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1604,18 +1604,3 @@ meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
   else
     return monotonic_time + compositor->server_time_offset;
 }
-
-void
-meta_compositor_grab_op_begin (MetaCompositor *compositor)
-{
-  // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
-  // but causes windows to flicker in and out of view sporadically on some configurations
-  // while dragging windows. Make sure it is disabled during the grab.
-  clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-}
-
-void
-meta_compositor_grab_op_end (MetaCompositor *compositor)
-{
-  clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-}

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -315,9 +315,6 @@ meta_window_group_class_init (MetaWindowGroupClass *klass)
 static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
-  ClutterActor *actor = CLUTTER_ACTOR (window_group);
-
-  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3721,8 +3721,6 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_window_refresh_resize_popup (display->grab_window);
     }
 
-  meta_compositor_grab_op_begin (display->compositor);
-
   g_signal_emit (display, display_signals[GRAB_OP_BEGIN], 0,
                  screen, display->grab_window, display->grab_op);
   
@@ -3771,8 +3769,6 @@ meta_display_end_grab_op (MetaDisplay *display,
   
   if (display->grab_op == META_GRAB_OP_NONE)
     return;
-
-  meta_compositor_grab_op_end (display->compositor);
 
   g_signal_emit (display, display_signals[GRAB_OP_END], 0,
                  display->grab_screen, display->grab_window, display->grab_op);


### PR DESCRIPTION
Fixes the flydown issue in https://github.com/linuxmint/alpha-testing/issues/2.

This could also be responsible for flickering regressions in upgrades from 3.8 to 4.0 (where this flag is set in init())
and from 4.0.6 to 4.0.7 (where it's set in init and removed during window grabbing).

Build for 4.0-maintenance:
https://github.com/linuxmint/cinnamon/files/3273029/4.0-maintenance-no-norelayout-flag.zip