### PR TITLE
[Next] Don't set CLUTTER_ACTOR_NO_LAYOUT flag

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -79,9 +79,6 @@ void     meta_end_modal_for_plugin   (MetaScreen       *screen,
 gint64 meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
                                                       gint64       monotonic_time);
 
-void meta_compositor_grab_op_begin (MetaCompositor *compositor);
-void meta_compositor_grab_op_end (MetaCompositor *compositor);
-
 void meta_check_end_modal (MetaScreen *screen);
 
 void meta_compositor_update_sync_state (MetaCompositor *compositor,

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1604,21 +1604,6 @@ meta_compositor_monotonic_time_to_server_time (MetaDisplay *display,
     return monotonic_time + compositor->server_time_offset;
 }
 
-void
-meta_compositor_grab_op_begin (MetaCompositor *compositor)
-{
-  // CLUTTER_ACTOR_NO_LAYOUT set on the window group improves responsiveness of windows,
-  // but causes windows to flicker in and out of view sporadically on some configurations
-  // while dragging windows. Make sure it is disabled during the grab.
-  clutter_actor_unset_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-}
-
-void
-meta_compositor_grab_op_end (MetaCompositor *compositor)
-{
-  clutter_actor_set_flags (compositor->window_group, CLUTTER_ACTOR_NO_LAYOUT);
-}
-
 CoglContext *
 meta_compositor_get_cogl_context (void)
 {

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -315,9 +315,6 @@ meta_window_group_class_init (MetaWindowGroupClass *klass)
 static void
 meta_window_group_init (MetaWindowGroup *window_group)
 {
-  ClutterActor *actor = CLUTTER_ACTOR (window_group);
-
-  clutter_actor_set_flags (actor, CLUTTER_ACTOR_NO_LAYOUT);
 }
 
 LOCAL_SYMBOL ClutterActor *

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3728,8 +3728,6 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_window_refresh_resize_popup (display->grab_window);
     }
 
-  meta_compositor_grab_op_begin (display->compositor);
-
   g_signal_emit (display, display_signals[GRAB_OP_BEGIN], 0,
                  screen, display->grab_window, display->grab_op);
 
@@ -3778,8 +3776,6 @@ meta_display_end_grab_op (MetaDisplay *display,
   
   if (display->grab_op == META_GRAB_OP_NONE)
     return;
-
-  meta_compositor_grab_op_end (display->compositor);
 
   g_signal_emit (display, display_signals[GRAB_OP_END], 0,
                  display->grab_screen, display->grab_window, display->grab_op);


### PR DESCRIPTION
Fixes the flydown issue in linuxmint/alpha-testing#2.

This could also be responsible for flickering regressions.

With this PR: [no_layout_flag.zip](https://github.com/linuxmint/muffin/files/3277549/no_layout_flag.zip)
Without: [master-11.6.zip](https://github.com/linuxmint/muffin/files/3277552/master-11.6.zip)

