### PR TITLE
meta-shadow-factory: Fix terminal shadows

### DIFF
--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -353,16 +353,15 @@ meta_shadow_paint (MetaShadow      *shadow,
                   src_y2 = (src_y[j] * (dest_rect.y + dest_rect.height - (rect.y + rect.height)) +
                             src_y[j + 1] * (rect.y + rect.height - dest_rect.y)) / dest_rect.height;
 
-                  pos = k*4;
-                  rects[pos++] = rect.x;
-                  rects[pos++] = rect.y;
-                  rects[pos++] = rect.x + rect.width;
-                  rects[pos++] = rect.y + rect.height;
-
-                  rects[pos++] = src_x1;
-                  rects[pos++] = src_y1;
-                  rects[pos++] = src_x2;
-                  rects[pos] = src_y2;
+                  pos = k*8;
+                  rects[pos] = rect.x;
+                  rects[pos+1] = rect.y;
+                  rects[pos+2] = rect.x + rect.width;
+                  rects[pos+3] = rect.y + rect.height;
+                  rects[pos+4] = src_x1;
+                  rects[pos+5] = src_y1;
+                  rects[pos+6] = src_x2;
+                  rects[pos+7] = src_y2;
                 }
 
               cogl_framebuffer_draw_textured_rectangles (framebuffer,


### PR DESCRIPTION
The regression was introduced in https://github.com/linuxmint/muffin/commit/66efde884efce35afd433efbda966774a65c9d85

The rectangle array wasn't being filled up properly.

Screenshot of the issue:

![image](https://user-images.githubusercontent.com/1138515/69361922-5daca280-0c85-11ea-8de9-96ace388daf1.png)
