### PR TITLE
window.c: Fix regression on window move

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9301,6 +9301,9 @@ update_move (MetaWindow  *window,
   dx = x - display->grab_anchor_root_x;
   dy = y - display->grab_anchor_root_y;
 
+  new_x = display->grab_anchor_window_pos.x + dx;
+  new_y = display->grab_anchor_window_pos.y + dy;
+
   meta_verbose ("x,y = %d,%d anchor ptr %d,%d anchor pos %d,%d dx,dy %d,%d\n",
                 x, y,
                 display->grab_anchor_root_x,


### PR DESCRIPTION
In https://github.com/linuxmint/muffin/commit/89805c059609f2cd48f60148896c057428362cb6
it looks like two lines were removed by mistake, making it impossible to
move windows.