### PR TITLE
meta-window-actor.c: Detach after redirecting, not before unredirecting.

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1600,11 +1600,11 @@ meta_window_actor_set_redirected (MetaWindowActor *self, gboolean state)
   if (state)
     {
       XCompositeRedirectWindow (xdisplay, xwin, CompositeRedirectManual);
+      meta_window_actor_detach (self);
       priv->unredirected = FALSE;
     }
   else
     {
-      meta_window_actor_detach (self);
       XCompositeUnredirectWindow (xdisplay, xwin, CompositeRedirectManual);
       priv->repaint_scheduled = TRUE;
       priv->unredirected = TRUE;


### PR DESCRIPTION
It's possible this was accidentally done due to upstream reversing the
logic in this function (set_redirected -> set_unredirected), and the
if/else was also reversed.

https://github.com/GNOME/mutter/commit/56f8d32ca9f87c2be0ed93d42e799d04b17ad08

Original mutter patch that added _detach: 
https://github.com/GNOME/mutter/commit/2ecc50af535d6dbdba07b18b7834979cbb12b41a
bug report:
https://bugzilla.gnome.org/show_bug.cgi?id=693042

Note: For reference, mutter's current implementation has this reversed once more, though no explanation was given, it occurred during some refactoring.  But, our codebase is different enough I'm not going to assume it's correct.

Fixes: linuxmint/cinnamon-screensaver#314