### PR TITLE
meta-window-actor.c: Make sure to remove any existing desaturate effect when a window no longer has a shadow.

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -328,7 +328,7 @@ maybe_desaturate_window (ClutterActor *actor)
   MetaWindowActor *window = META_WINDOW_ACTOR (actor);
   MetaWindowActorPrivate *priv = window->priv;
 
-  if (!priv->should_have_shadow)
+  if (!priv->should_have_shadow && !priv->has_desat_effect)
     return;
 
   guint8 opacity = clutter_actor_get_opacity (actor);


### PR DESCRIPTION
If the shadow has been removed but the effect is not, the effect is still
wanting to paint the area of the client window and the offset shadow region.

With certain window effects that involve opacity changes, you can end up with
an empty region around the edges of the window that will impact visible window
size.

Fixes #530