### PR TITLE
src/ui/theme.c: Use a simpler method for getting an image file's dimensions for hidpi scaling

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -5376,28 +5376,28 @@ meta_theme_load_image (MetaTheme  *theme,
       else
         {
           char *full_path;
+          gint width, height;
+
           full_path = g_build_filename (theme->dirname, filename, NULL);
 
-          GdkPixbuf *test_pixbuf = NULL;
-          gint test_height, test_width;
-
-          test_pixbuf = gdk_pixbuf_new_from_file (full_path, error);
-          test_height = gdk_pixbuf_get_height (test_pixbuf);
-          test_width = gdk_pixbuf_get_width (test_pixbuf);
-
-          g_object_unref (test_pixbuf);
-
-          test_height *= scale;
-          test_width *= scale;
-
-          pixbuf = gdk_pixbuf_new_from_file_at_size (full_path, test_width, test_height, error);
-          if (pixbuf == NULL)
+          if (gdk_pixbuf_get_file_info (full_path, &width, &height) == NULL)
             {
-              free (full_path);
+              g_free (full_path);
               return NULL;
             }
 
-          free (full_path);
+          width *= scale;
+          height *= scale;
+
+          pixbuf = gdk_pixbuf_new_from_file_at_size (full_path, width, height, error);
+
+          if (pixbuf == NULL)
+            {
+              g_free (full_path);
+              return NULL;
+            }
+
+          g_free (full_path);
         }
       g_hash_table_replace (theme->images_by_filename,
                             g_strdup (filename),


### PR DESCRIPTION
This alters no behavior, but stops creating a pixbuf twice for the sole purpose of getting its size.

Adapted from the marco fix of the same original hidpi issue:
https://github.com/mate-desktop/marco/commit/af17e33e008e948e25e3df5dbe0931d0c1cf8908