### PR TITLE
fix: cogl-texture-2d.c:432:43: error: 'EGL_WAYLAND_BUFFER_WL' undeclared (first use in this function); did you mean 'EGL_TRIPLE_BUFFER_NV'?

### DIFF
--- a/cogl/configure.ac
+++ b/cogl/configure.ac
@@ -487,7 +487,8 @@ AS_IF([test "x$enable_gles1" = "xyes"],
 
             AC_CHECK_HEADERS([EGL/eglext.h],
                              [COGL_EGL_INCLUDES="$COGL_EGL_INCLUDE
-#include <EGL/eglext.h>"],
+#include <EGL/eglext.h>
+#include <EGL/eglmesaext.h>"],
                              [],
                              [$COGL_EGL_INCLUDES])
 
@@ -759,7 +760,8 @@ AS_IF([test "x$NEED_EGL" = "xyes" && test "x$EGL_CHECKED" != "xyes"],
           )
 
         COGL_EGL_INCLUDES="#include <EGL/egl.h>
-#include <EGL/eglext.h>"
+#include <EGL/eglext.h>
+#include <EGL/eglmesaext.h>"
         AC_SUBST([COGL_EGL_INCLUDES])
       ])
 


### PR DESCRIPTION
```
cogl-texture-2d.c:432:43: error: 'EGL_WAYLAND_BUFFER_WL' undeclared (first use in this function); did you mean 'EGL_TRIPLE_BUFFER_NV'?
                                             EGL_WAYLAND_BUFFER_WL,
                                             ^~~~~~~~~~~~~~~~~~~~~
                                             EGL_TRIPLE_BUFFER_NV
```

  https://bugs.gentoo.org/698736 - Muffin is a mutter fork, so patch _should_ apply