### PR TITLE
configure.in: Remove gnome-doc-utils unneded dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,9 +462,6 @@ if test "x$enable_debug" = "xyes"; then
 	CFLAGS="$CFLAGS -g -O"
 fi
 
-# Use gnome-doc-utils:
-GNOME_DOC_INIT([0.8.0])
-
 GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
 
 AC_CHECK_DECL([GL_EXT_x11_sync_object],


### PR DESCRIPTION
It's not used at all. Taken from [mutter](https://gitlab.gnome.org/GNOME/mutter/-/commit/07dd4d3f93907755992eea718572c8de7a06b3dc).