### PR TITLE
Fix build failure if introspection is disabled

### DIFF
--- a/clutter/clutter/Makefile.am
+++ b/clutter/clutter/Makefile.am
@@ -649,6 +649,7 @@ install-exec-local:
 	  ) ; \
 	done
 
+if HAVE_INTROSPECTION
 # gobject-introspection rules
 -include $(INTROSPECTION_MAKEFILE)
 
@@ -720,8 +721,9 @@ gir_DATA = $(INTROSPECTION_GIRS)
 typelibdir = $(muffinlibdir)
 typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
+endif
+
 EXTRA_DIST += \
 	Makefile.am.marshal	\
 	Makefile.am.enums
-
-CLEANFILES += $(gir_DATA) $(typelib_DATA)


### PR DESCRIPTION
Currently, build is failing with:
```
make[4]: *** No rule to make target 'Clutter-0.typelib', needed by 'all-am'.  Stop.
```
due to clutter's `Makefile.am` always trying to generate GObject
Introspection GIR and typelib files, despite the
`--disable-introspection` flag and configure script reporting
introspection being disabled like so:
```
 • Extra:
        Build introspection data: no
        Build X11-specific tests: yes
        Build tests using GDK-Pixbuf: yes
        Install test suites:
        Build examples: no
```
This commit fixes the problem by introducing the check for
`HAVE_INTROSPECTION` flag and skipping GObject files generation.