### PR TITLE
Fix the build without XSync extension enabled

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1289,7 +1289,10 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
 
   priv->needs_frame_drawn = TRUE;
 
+  frame->sync_request_serial = 0;
+#ifdef HAVE_XSYNC
   frame->sync_request_serial = priv->window->sync_request_serial;
+#endif
 
   priv->frames = g_list_prepend (priv->frames, frame);
 

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -1141,9 +1141,8 @@ reload_update_counter (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       meta_window_destroy_sync_request_alarm (window);
-      window->sync_request_counter = None;
-
 #ifdef HAVE_XSYNC
+      window->sync_request_counter = None;
       if (value->v.xcounter_list.n_counters == 0)
         {
           meta_warning ("_NET_WM_SYNC_REQUEST_COUNTER is empty\n");

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1906,11 +1906,13 @@ meta_window_unmanage (MetaWindow  *window,
       invalidate_work_areas (window);
     }
 
+#ifdef HAVE_XSYNC
   if (window->sync_request_timeout_id)
     {
       g_source_remove (window->sync_request_timeout_id);
       window->sync_request_timeout_id = 0;
     }
+#endif
 
   if (window->display->grab_window == window)
     meta_display_end_grab_op (window->display, timestamp);

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -1262,9 +1262,11 @@ free_value (MetaPropValue *value)
       break;
     case META_PROP_VALUE_SYNC_COUNTER:
       break;
+#ifdef HAVE_XSYNC
     case META_PROP_VALUE_SYNC_COUNTER_LIST:
       meta_XFree (value->v.xcounter_list.counters);
       break;
+#endif
     }
 }
 


### PR DESCRIPTION
When trying to build muffin with `--disable-xsync` option, it fails for
a variety of reasons:

```
compositor/meta-window-actor.c:1292:44: error: 'MetaWindow' {aka 'struct _MetaWindow'} has no member named 'sync_request_serial'
 1292 |   frame->sync_request_serial = priv->window->sync_request_serial;
```

```
core/window.c: In function 'meta_window_unmanage':
core/window.c:1865:13: error: 'MetaWindow' {aka 'struct _MetaWindow'} has no member named 'sync_request_timeout_id'
 1865 |   if (window->sync_request_timeout_id)
      |             ^~
core/window.c:1867:30: error: 'MetaWindow' {aka 'struct _MetaWindow'} has no member named 'sync_request_timeout_id'
 1867 |       g_source_remove (window->sync_request_timeout_id);
      |                              ^~
core/window.c:1868:13: error: 'MetaWindow' {aka 'struct _MetaWindow'} has no member named 'sync_request_timeout_id'
 1868 |       window->sync_request_timeout_id = 0;
      |             ^~
```

```
core/window-props.c:1143:15: error: 'MetaWindow' {aka 'struct _MetaWindow'} has no member named 'sync_request_counter'; did you mean 'extended_sync_request_counter'?
 1143 |       window->sync_request_counter = None;
      |               ^~~~~~~~~~~~~~~~~~~~
```

This seems to be due to missing `HAVE_XSYNC` macro checks. Adding these
checks where appropriate to make sure that muffin can be built.