### PR TITLE
fixup defines for HAVE_XSYNC by running fallback code only in else block

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1289,9 +1289,10 @@ meta_window_actor_queue_frame_drawn (MetaWindowActor *self,
 
   priv->needs_frame_drawn = TRUE;
 
-  frame->sync_request_serial = 0;
 #ifdef HAVE_XSYNC
   frame->sync_request_serial = priv->window->sync_request_serial;
+#else
+  frame->sync_request_serial = 0;
 #endif
 
   priv->frames = g_list_prepend (priv->frames, frame);


### PR DESCRIPTION
Followup for commit babce7fed0da86ce5c77fc04b3f794e5cfbbbb70 which added the HAVE_XSYNC checks. Since this is immediately overwritten by the xsync code, it does nothing unless xsync is disabled. Make this explicit by moving it down into an #else section, so that it doesn't generate any code.

/cc @filakhtov