### PR TITLE
backgrounds: relayout the transition actors on size change

### DIFF
--- a/src/compositor/meta-background-actor.c
+++ b/src/compositor/meta-background-actor.c
@@ -150,6 +150,10 @@ update_wrap_mode_of_actor (MetaBackgroundActor *self)
 
   meta_background_set_layer_wrap_mode (META_BACKGROUND (priv->top_actor), priv->background->wrap_mode);
   meta_background_set_layer_wrap_mode (META_BACKGROUND (priv->bottom_actor), priv->background->wrap_mode);
+
+  /* this ensures the actors also get resized if the stage size changed */
+  clutter_actor_queue_relayout (CLUTTER_ACTOR (priv->top_actor));
+  clutter_actor_queue_relayout (CLUTTER_ACTOR (priv->bottom_actor));
 }
 
 static void
@@ -628,10 +632,6 @@ LOCAL_SYMBOL void
 meta_background_actor_screen_size_changed (MetaScreen *screen)
 {
   MetaScreenBackground *background = meta_screen_background_get (screen);
-  GSList *l;
 
   update_wrap_mode (background);
-
-  for (l = background->actors; l; l = l->next)
-    clutter_actor_queue_relayout (l->data);
 }


### PR DESCRIPTION
I don't know if this is exactly the correct way to do it, but this
ensures that the transition actors have the correct size after the
stage changes size.

Previously, we queued a relayout on the parent of the transition
actors. I don't know if this just never properly re-layouted the
children, or if another change (possibly the clutter/cogl merge)
changed the layout behavior since then.

Fixes: https://github.com/linuxmint/muffin/issues/542