### PR TITLE
Fix the build with slibtool.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 
-SUBDIRS=cogl clutter src po doc data
+SUBDIRS=cogl clutter src src/compositor/plugins po doc data
 
 EXTRA_DIST = HACKING MAINTAINERS rationales.txt
 

--- a/clutter/clutter/Makefile.am
+++ b/clutter/clutter/Makefile.am
@@ -666,7 +666,11 @@ Clutter-@MUFFIN_PLUGIN_API_VERSION@.gir: libmuffin-clutter-@MUFFIN_PLUGIN_API_VE
 
 Clutter_@MUFFIN_PLUGIN_API_VERSION@_gir_NAMESPACE = Clutter
 Clutter_@MUFFIN_PLUGIN_API_VERSION@_gir_VERSION = @MUFFIN_PLUGIN_API_VERSION@
-Clutter_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la
+Clutter_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = \
+	libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl/libmuffin-cogl-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-pango/libmuffin-cogl-pango-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-path/libmuffin-cogl-path-@MUFFIN_PLUGIN_API_VERSION@.la
 Clutter_@MUFFIN_PLUGIN_API_VERSION@_gir_FILES = \
 	$(clutter_include_HEADERS) \
 	$(clutter_deprecated_HEADERS) \
@@ -687,7 +691,11 @@ Cally-@MUFFIN_PLUGIN_API_VERSION@.gir: Makefile Clutter-@MUFFIN_PLUGIN_API_VERSI
 
 Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_NAMESPACE = Cally
 Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_VERSION = @MUFFIN_PLUGIN_API_VERSION@
-Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la
+Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = \
+	libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl/libmuffin-cogl-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-pango/libmuffin-cogl-pango-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-path/libmuffin-cogl-path-@MUFFIN_PLUGIN_API_VERSION@.la
 Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_FILES = $(cally_sources_h) $(cally_sources_c)
 Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_CFLAGS = $(AM_CPPFLAGS) $(CLUTTER_CFLAGS)
 Cally_@MUFFIN_PLUGIN_API_VERSION@_gir_SCANNERFLAGS = \
@@ -702,7 +710,11 @@ ClutterX11-@MUFFIN_PLUGIN_API_VERSION@.gir: Makefile Clutter-@MUFFIN_PLUGIN_API_
 
 ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_NAMESPACE = ClutterX11
 ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_INCLUDES = xlib-2.0
-ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la
+ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_LIBS = \
+	libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl/libmuffin-cogl-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-pango/libmuffin-cogl-pango-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/../cogl/cogl-path/libmuffin-cogl-path-@MUFFIN_PLUGIN_API_VERSION@.la
 ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_FILES = $(x11_introspection)
 ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_CFLAGS = $(AM_CPPFLAGS) $(CLUTTER_CFLAGS)
 ClutterX11_@MUFFIN_PLUGIN_API_VERSION@_gir_SCANNERFLAGS = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,7 +277,12 @@ Meta-$(api_version).gir: libmuffin.la
 @META_GIR@_INCLUDES = GObject-2.0 CDesktopEnums-3.0 Gdk-3.0 Gtk-3.0 Cogl-$(MUFFIN_PLUGIN_API_VERSION) Clutter-$(MUFFIN_PLUGIN_API_VERSION) xlib-2.0 xfixes-4.0
 @META_GIR@_PACKAGES = gtk+-3.0
 @META_GIR@_CFLAGS = $(AM_CPPFLAGS)
-@META_GIR@_LIBS = libmuffin.la
+@META_GIR@_LIBS = \
+	libmuffin.la \
+	$(top_builddir)/clutter/clutter/libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/cogl/cogl/libmuffin-cogl-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/cogl/cogl-pango/libmuffin-cogl-pango-@MUFFIN_PLUGIN_API_VERSION@.la \
+	$(top_builddir)/cogl/cogl-path/libmuffin-cogl-path-@MUFFIN_PLUGIN_API_VERSION@.la
 @META_GIR@_FILES =				\
 	muffin-enum-types.h			\
 	$(libmuffininclude_base_headers)	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@
 
 lib_LTLIBRARIES = libmuffin.la
 
-SUBDIRS=wm-tester tools compositor/plugins
+SUBDIRS=wm-tester tools
 
 NULL =
 

--- a/src/compositor/plugins/Makefile.am
+++ b/src/compositor/plugins/Makefile.am
@@ -2,9 +2,9 @@
 pkglibdir=@MUFFIN_PLUGIN_DIR@
 
 AM_CPPFLAGS= \
-  $(WARN_CFLAGS) \
+	$(WARN_CFLAGS) \
 	$(MUFFIN_CFLAGS) \
-  -I$(top_builddir)/src						\
+	-I$(top_builddir)/src						\
 	-I$(top_srcdir)/src						\
 	-I$(top_srcdir)/cogl						\
 	-I$(top_builddir)/cogl						\
@@ -27,7 +27,10 @@ AM_CPPFLAGS= \
 default_la_CFLAGS   = $(WARN_CFLAGS) -fPIC
 default_la_SOURCES  = default.c
 default_la_LDFLAGS  = $(WARN_LDFLAGS) -module -avoid-version -no-undefined
-default_la_LIBADD   = $(CLUTTER_LIBS)
+default_la_LIBADD   = \
+	$(CLUTTER_LIBS) \
+	$(top_builddir)/src/libmuffin.la \
+	$(top_builddir)/clutter/clutter/libmuffin-clutter-@MUFFIN_PLUGIN_API_VERSION@.la
 
 pkglib_LTLIBRARIES = default.la
 


### PR DESCRIPTION
When building muffin with slibtool (https://dev.midipix.org/cross/slibtool) it fails, this PR has two commits to fix the build.

1. Several libtool `.la` files are missing as dependencies in some of the `Makefile.am` files.
2. The build fails with `-no-undefined`, this works with GNU libtool because it silently ignores `-no-undefined` while slibtool does not. This requires building `src/compositor/plugins` separately from the rest of `src/` to ensure `libmuffin.la` exists when it is needed.

Full logs:

[muffin-slibtool.1.log](https://github.com/linuxmint/muffin/files/5871673/muffin-slibtool.1.log)
[muffin-slibtool.2.log](https://github.com/linuxmint/muffin/files/5871687/muffin-slibtool.2.log)