### PR TITLE
[Question] using GTimeVal/g_get_current_time

### DIFF
--- a/clutter/tests/conform/timeline-interpolate.c
+++ b/clutter/tests/conform/timeline-interpolate.c
@@ -18,7 +18,7 @@
 typedef struct _TestState
 {
   ClutterTimeline *timeline;
-  GTimeVal start_time;
+  int64_t start_time;
   guint new_frame_counter;
   gint expected_frame;
   gint completion_count;
@@ -31,18 +31,17 @@ new_frame_cb (ClutterTimeline *timeline,
 	      gint frame_num,
 	      TestState *state)
 {
-  GTimeVal current_time;
+  int64_t current_time;
   gint current_frame;
   glong msec_diff;
   gint loop_overflow = 0;
   static gint step = 1;
 
-  g_get_current_time (&current_time);
+  current_time = g_get_real_time ();
 
   current_frame = clutter_timeline_get_elapsed_time (state->timeline);
 
-  msec_diff = (current_time.tv_sec - state->start_time.tv_sec) * 1000;
-  msec_diff += (current_time.tv_usec - state->start_time.tv_usec)/1000;
+  msec_diff = (current_time - state->start_time) / G_TIME_SPAN_MILLISECOND;
 
   /* If we expect to have interpolated past the end of the timeline
    * we keep track of the overflow so we can determine when
@@ -136,7 +135,7 @@ timeline_interpolation (void)
 {
   TestState state;
 
-  state.timeline = 
+  state.timeline =
     clutter_timeline_new (TEST_TIMELINE_DURATION);
   clutter_timeline_set_loop (state.timeline, TRUE);
   g_signal_connect (G_OBJECT(state.timeline),
@@ -153,9 +152,9 @@ timeline_interpolation (void)
   state.passed = TRUE;
   state.expected_frame = 0;
 
-  g_get_current_time (&state.start_time);
+  state.start_time = g_get_real_time ();
   clutter_timeline_start (state.timeline);
-  
+
   clutter_main();
 
   g_object_unref (state.timeline);

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -2,12 +2,12 @@
 
 /* Muffin X display handler */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -17,7 +17,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street - Suite 500, Boston, MA
@@ -78,7 +78,7 @@ typedef void (* MetaWindowPingFunc) (MetaDisplay *display,
 struct _MetaDisplay
 {
   GObject parent_instance;
-  
+
   char *name;
   Display *xdisplay;
   GdkDisplay *gdk_display;
@@ -132,7 +132,7 @@ struct _MetaDisplay
   guint allow_terminal_deactivation : 1;
 
   guint static_gravity_works : 1;
-  
+
   /*< private-ish >*/
   guint error_trap_synced_at_last_pop : 1;
   MetaEventQueue *events;
@@ -141,7 +141,7 @@ struct _MetaDisplay
   GHashTable *window_ids;
   int error_traps;
   int (* error_trap_handler) (Display     *display,
-                              XErrorEvent *error);  
+                              XErrorEvent *error);
   int server_grab_count;
 
   /* serials of leave/unmap events that may
@@ -150,7 +150,7 @@ struct _MetaDisplay
    */
   unsigned long ignored_crossing_serials[N_IGNORED_CROSSING_SERIALS];
   Window ungrab_should_not_cause_focus_window;
-  
+
   guint32 current_time;
 
   /* We maintain a sequence counter, incremented for each #MetaWindow
@@ -172,7 +172,7 @@ struct _MetaDisplay
   /* Alt+click button grabs */
   unsigned int window_grab_modifiers;
   unsigned int mouse_zoom_modifiers;
-  
+
   /* current window operation */
   MetaGrabOp  grab_op;
   MetaScreen *grab_screen;
@@ -197,7 +197,7 @@ struct _MetaDisplay
   int         grab_initial_x, grab_initial_y;  /* These are only relevant for */
   gboolean    grab_threshold_movement_reached; /* raise_on_click == FALSE.    */
   MetaResizePopup *grab_resize_popup;
-  GTimeVal    grab_last_moveresize_time;
+  int64_t    grab_last_moveresize_time;
   guint32     grab_motion_notify_time;
   GList*      grab_old_window_stacking;
   MetaEdgeResistanceData *grab_edge_resistance_data;
@@ -231,7 +231,7 @@ struct _MetaDisplay
   unsigned int meta_mask;
 
   guint        rebuild_keybinding_idle_id;
-  
+
   /* Monitor cache */
   unsigned int monitor_cache_invalidated : 1;
 
@@ -272,7 +272,7 @@ struct _MetaDisplay
   int damage_error_base;
   int xfixes_event_base;
   int xfixes_error_base;
-  
+
 #ifdef HAVE_STARTUP_NOTIFICATION
   SnDisplay *sn_display;
 #endif
@@ -413,7 +413,7 @@ const char* meta_event_detail_to_string (int d);
 void meta_display_queue_retheme_all_windows (MetaDisplay *display);
 void meta_display_retheme_all (void);
 
-void meta_display_set_cursor_theme (const char *theme, 
+void meta_display_set_cursor_theme (const char *theme,
 				    int         size);
 
 void meta_display_ping_window      (MetaDisplay        *display,

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3685,8 +3685,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
   display->grab_anchor_root_y = root_y;
   display->grab_latest_motion_x = root_x;
   display->grab_latest_motion_y = root_y;
-  display->grab_last_moveresize_time.tv_sec = 0;
-  display->grab_last_moveresize_time.tv_usec = 0;
+  display->grab_last_moveresize_time = 0;
   display->grab_motion_notify_time = 0;
   display->grab_old_window_stacking = NULL;
 #ifdef HAVE_XSYNC
@@ -3785,7 +3784,7 @@ meta_display_end_grab_op (MetaDisplay *display,
 {
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Ending grab op %u at time %u\n", display->grab_op, timestamp);
-  
+
   if (display->grab_op == META_GRAB_OP_NONE)
     return;
 

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3324,7 +3324,7 @@ remove_sequence (MetaScreen        *screen,
 typedef struct
 {
   GSList *list;
-  gint64 now;
+  GDateTime *now;
 } CollectTimedOutData;
 
 /* This should be fairly long, as it should never be required unless
@@ -3340,12 +3340,14 @@ collect_timed_out_foreach (void *element,
 {
   CollectTimedOutData *ctod = data;
   SnStartupSequence *sequence = element;
-  long tv_sec, tv_usec;
+  long sec, usec;
   double elapsed;
 
+  sn_startup_sequence_get_last_active_time (sequence, &sec, &usec);
+
   elapsed =
-    ((((double)ctod->now - tv_sec) * G_USEC_PER_SEC +
-      (ctod->now - tv_usec))) / G_TIME_SPAN_MILLISECOND;
+    ((((double)g_date_time_get_second (ctod->now) - sec) * G_USEC_PER_SEC +
+      (g_date_time_get_microsecond(ctod->now) - usec))) / G_TIME_SPAN_MILLISECOND;
 
   meta_topic (META_DEBUG_STARTUP,
               "Sequence used %g seconds vs. %g max: %s\n",

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -3324,7 +3324,7 @@ remove_sequence (MetaScreen        *screen,
 typedef struct
 {
   GSList *list;
-  GTimeVal now;
+  gint64 now;
 } CollectTimedOutData;
 
 /* This should be fairly long, as it should never be required unless
@@ -3343,11 +3343,9 @@ collect_timed_out_foreach (void *element,
   long tv_sec, tv_usec;
   double elapsed;
 
-  sn_startup_sequence_get_last_active_time (sequence, &tv_sec, &tv_usec);
-
   elapsed =
-    ((((double)ctod->now.tv_sec - tv_sec) * G_USEC_PER_SEC +
-      (ctod->now.tv_usec - tv_usec))) / 1000.0;
+    ((((double)ctod->now - tv_sec) * G_USEC_PER_SEC +
+      (ctod->now - tv_usec))) / G_TIME_SPAN_MILLISECOND;
 
   meta_topic (META_DEBUG_STARTUP,
               "Sequence used %g seconds vs. %g max: %s\n",

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -810,7 +810,7 @@ meta_screen_new (MetaDisplay *display,
   char buf[128];
   guint32 manager_timestamp;
   gulong current_workspace;
-  
+
   replace_current_wm = meta_get_replace_current_wm ();
 
   /* Only display->name, display->xdisplay, and display->error_traps
@@ -1008,7 +1008,7 @@ meta_screen_new (MetaDisplay *display,
                   (int) current_workspace);
   else
     meta_verbose ("No _NET_CURRENT_DESKTOP present\n");
-  
+
   /* Screens must have at least one workspace at all times,
    * so create that required workspace.
    */
@@ -1051,10 +1051,10 @@ meta_screen_new (MetaDisplay *display,
   /* Switch to the _NET_CURRENT_DESKTOP workspace */
   {
     MetaWorkspace *space;
-    
+
     space = meta_screen_get_workspace_by_index (screen,
                                                 current_workspace);
-    
+
     if (space != NULL)
       meta_workspace_activate (space, timestamp);
   }
@@ -2217,7 +2217,7 @@ meta_screen_get_monitor_for_window (MetaScreen *screen,
                                     MetaWindow *window)
 {
   MetaRectangle window_rect;
-  
+
   meta_window_get_outer_rect (window, &window_rect);
 
   return meta_screen_get_monitor_for_rect (screen, &window_rect);
@@ -3366,7 +3366,7 @@ startup_sequence_timeout (void *data)
   GSList *tmp;
 
   ctod.list = NULL;
-  g_get_current_time (&ctod.now);
+  ctod.now = g_get_real_time ();
   g_slist_foreach (screen->startup_sequences,
                    collect_timed_out_foreach,
                    &ctod);


### PR DESCRIPTION
(Y-2038 unsafe)

References
https://github.com/GNOME/mutter/commit/56a5c5e4d189ad519bfa45c2ec08f58a2304c7fa

yes i'll later manually do this in nano so there isn't whitespace/crust