### PR TITLE
Fix windows that cannot be moved in some Windows applications with Wine >=5.16

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3988,13 +3988,13 @@ meta_window_unmaximize_internal (MetaWindow        *window,
   if (unmaximize_horizontally && unmaximize_vertically)
     window->saved_maximize = FALSE;
 
-  /* Only do something if the window isn't already maximized in the
+  /* Only do something if the window is tiled, or maximized in the
    * given direction(s).
    */
   if ((unmaximize_horizontally && window->maximized_horizontally) ||
       (unmaximize_vertically   && window->maximized_vertically) ||
-      window->tile_type == META_WINDOW_TILE_TYPE_NONE ||
-      window->tile_mode == META_TILE_NONE)
+      window->tile_type != META_WINDOW_TILE_TYPE_NONE ||
+      window->tile_mode != META_TILE_NONE)
     {
       MetaRectangle target_rect;
       MetaRectangle work_area;


### PR DESCRIPTION
Fixes #585.

This commit makes sure we are actually unmaximising a maximised window, or untiling a tiled one, when the unmaximize function is called. This function gets called more often in Wine to prevent issues in KWin (https://source.winehq.org/git/wine.git/commit/c5ec1585f6e5211a2b63e3435748210552250534).

Mate had a similar issue with a different cause, which was also fixed in the window manager (https://github.com/mate-desktop/marco/commit/60f49ae5a272b737a944065e4199c8b2c8eec8b1).