### PR TITLE
Don't allow fullscreen windows to also become decorated.

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -527,11 +527,10 @@ place_window_if_needed(MetaWindow     *window,
   if (window->placed || did_placement)
     {
       if (window->maximize_horizontally_after_placement ||
-          window->maximize_vertically_after_placement   ||
-          window->fullscreen_after_placement)
+          window->maximize_vertically_after_placement)
         {
-          /* define a sane saved_rect so that the user can unmaximize or
-           * make unfullscreen to something reasonable.
+          /* define a sane saved_rect so that the user can unmaximize to
+           * something reasonable.
            */
           if (info->current.width >= info->work_area_monitor.width)
             {
@@ -562,15 +561,6 @@ place_window_if_needed(MetaWindow     *window,
           /* maximization may have changed frame geometry */
           if (!window->fullscreen)
             meta_frame_calc_borders (window->frame, info->borders);
-
-          if (window->fullscreen_after_placement)
-            {
-              window->saved_rect = info->current;
-              window->fullscreen = TRUE;
-              window->fullscreen_after_placement = FALSE;
-
-              g_object_notify (G_OBJECT (window), "fullscreen");
-            }
 
           window->maximize_horizontally_after_placement = FALSE;
           window->maximize_vertically_after_placement = FALSE;

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -226,9 +226,6 @@ struct _MetaWindow
   /* Whether the urgent flag of WM_HINTS is set */
   guint wm_hints_urgent : 1;
 
-  /* Whether we have to fullscreen after placement */
-  guint fullscreen_after_placement : 1;
-
   /* Area to cover when in fullscreen mode.  If _NET_WM_FULLSCREEN_MONITORS has
    * been overridden (via a client message), the window will cover the union of
    * these monitors.  If not, this is the single monitor which the window's

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -902,7 +902,10 @@ reload_net_wm_state (MetaWindow    *window,
       else if (value->v.atom_list.atoms[i] == window->display->atom__NET_WM_STATE_SKIP_PAGER)
         window->wm_state_skip_pager = TRUE;
       else if (value->v.atom_list.atoms[i] == window->display->atom__NET_WM_STATE_FULLSCREEN)
-        window->fullscreen_after_placement = TRUE;
+        {
+          window->fullscreen = TRUE;
+          g_object_notify (G_OBJECT (window), "fullscreen");
+        }
       else if (value->v.atom_list.atoms[i] == window->display->atom__NET_WM_STATE_ABOVE)
         window->wm_state_above = TRUE;
       else if (value->v.atom_list.atoms[i] == window->display->atom__NET_WM_STATE_BELOW)
@@ -927,7 +930,6 @@ reload_mwm_hints (MetaWindow    *window,
                   gboolean       initial)
 {
   MotifWmHints *hints;
-  gboolean old_decorated = window->decorated;
 
   window->mwm_decorated = TRUE;
   window->mwm_border_only = FALSE;
@@ -1031,23 +1033,6 @@ reload_mwm_hints (MetaWindow    *window,
     meta_verbose ("Functions flag unset\n");
 
   meta_window_recalc_features (window);
-
-  /* We do all this anyhow at the end of meta_window_new() */
-  if (!window->constructing)
-    {
-      if (window->decorated)
-        meta_window_ensure_frame (window);
-      else
-        meta_window_destroy_frame (window);
-
-      meta_window_queue (window,
-                         META_QUEUE_MOVE_RESIZE |
-                         /* because ensure/destroy frame may unmap: */
-                         META_QUEUE_CALC_SHOWING);
-
-      if (old_decorated != window->decorated)
-        g_object_notify (G_OBJECT (window), "decorated");
-    }
 }
 
 static void


### PR DESCRIPTION
Windows that were starting out as fullscreen (_NET_WM_FULLSCREEN)
were being initially decorated, as the fullscreen property wasn't
being applied until after window construction and placement. The
decorations also were not being removed at that point, leaving
space around the window which was visible in adjacent monitors.

This patch is a combination of:
https://github.com/GNOME/metacity/commit/829ce2e3ca794d6c17a1ea9f0748ac75be5007fa
https://github.com/GNOME/metacity/commit/7a7aaa338b89c0c66122958e7c6cb56322e73371
and
https://github.com/GNOME/mutter/commit/07f533f617e3771861a92f25d3cc288d3c9d465a

Test cases in the bug report for the original commit that 07f533 reverts
are still behaving properly. See:

https://bugzilla.gnome.org/show_bug.cgi?id=461927

Fixes linuxmint/mint20.2-beta#49
Fixes linuxmint/cinnamon#8926