### PR TITLE
window.c: Properly update gtk_edge_constraints

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -9486,6 +9486,8 @@ update_move (MetaWindow  *window,
         window->tile_monitor_number = monitor->number;
     }
 
+  update_edge_constraints (window);
+
   /* shake loose (unmaximize) maximized or tiled window if dragged beyond
    * the threshold in the Y direction. Tiled windows can also be pulled
    * loose via X motion.

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -12370,8 +12370,8 @@ update_edge_constraints (MetaWindow *window)
     case META_TILE_TOP:
       window->edge_constraints[0] = META_EDGE_CONSTRAINT_MONITOR;
       window->edge_constraints[1] = META_EDGE_CONSTRAINT_MONITOR;
-      window->edge_constraints[2] = META_EDGE_CONSTRAINT_MONITOR;
-      window->edge_constraints[3] = META_EDGE_CONSTRAINT_NONE;
+      window->edge_constraints[2] = META_EDGE_CONSTRAINT_NONE;
+      window->edge_constraints[3] = META_EDGE_CONSTRAINT_MONITOR;
       break;
 
     case META_TILE_BOTTOM:


### PR DESCRIPTION
We support the atom but it was never being updated. This resulted in csd
windows not having their style properly updated when tiled or maximized.