### PR TITLE
meta-shadow-factory: Tweak window shadows

### DIFF
--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -118,17 +118,17 @@ struct _MetaShadowFactoryClass
 /* The first element in this array also defines the default parameters
  * for newly created classes */
 static MetaShadowClassInfo default_shadow_classes[] = {
-  { "normal",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "dialog",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "modal_dialog", { 6, -1, 0, 1, 255 }, { 3, -1, 0, 3, 128 } },
-  { "utility",      { 3, -1, 0, 1, 255 }, { 3, -1, 0, 1, 128 } },
-  { "border",       { 6, -1, 0, 3, 255 }, { 3, -1, 0, 3, 128 } },
-  { "menu",         { 6, -1, 0, 3, 255 }, { 3, -1, 0, 0, 128 } },
+  { "normal",       { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
+  { "dialog",       { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
+  { "modal_dialog", { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
+  { "utility",      { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
+  { "border",       { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
+  { "menu",         { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } },
 
-  { "popup-menu",    { 1, -1, 0, 1, 128 }, { 1, -1, 0, 1, 128 } },
+  { "popup-menu",    { 1, -1, 0, 0, 128 }, { 1, -1, 0, 0, 128 } },
 
-  { "dropdown-menu", { 1, 10, 0, 1, 128 }, { 1, 10, 0, 1, 128 } },
-  { "attached",      { 6, -1, 0, 1, 255 }, { 3, -1, 0, 3, 128 } }
+  { "dropdown-menu", { 1, -1, 0, 0, 128 }, { 1, -1, 0, 0, 128 } },
+  { "attached",      { 10, -1, 0, 3, 128 }, { 8, -1, 0, 2, 64 } }
 };
 
 G_DEFINE_TYPE (MetaShadowFactory, meta_shadow_factory, G_TYPE_OBJECT);


### PR DESCRIPTION
With csd windows becoming more prevalent, and most themes being rooted in
Adwaita, tweak our window shadows to match. This also brings us inline
with Mutter. Should make window shadows more consistent overall. Also helps
the focused window stand out as on top a bit more.