### PR TITLE
improve check ACLOCAL_AMFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,13 @@ MUFFIN_PLUGIN_DIR="$libdir/$PACKAGE/plugins"
 AC_SUBST(MUFFIN_PLUGIN_DIR)
 
 # Honor aclocal flags
-AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
+  dnl ensure that when the Automake generated makefile calls aclocal,
+  dnl it honours the $ACLOCAL_FLAGS environment variable
+  ACLOCAL_AMFLAGS="\${ACLOCAL_FLAGS}"
+  if test -n "$ac_macro_dir"; then
+    ACLOCAL_AMFLAGS="-I $ac_macro_dir $ACLOCAL_AMFLAGS"
+  fi
+  AC_SUBST([ACLOCAL_AMFLAGS])
 
 GETTEXT_PACKAGE=muffin
 AC_SUBST(GETTEXT_PACKAGE)


### PR DESCRIPTION
This code from https://github.com/mate-desktop/mate-common/blob/aa57109bc472ea9340020d819b26d511fb3e002c/macros/mate-common.m4#L25

on my build farm ACLOCAL_AMFLAGS not recognized, and on make stage i see aclocal-1.16 -I  is missing argument