### PR TITLE
[muffin-5.2-test] Small debian improvements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Build-Depends:
         libjson-glib-dev (>= 0.13.2-1~),
         libpam0g-dev,
         libpango1.0-dev (>= 1.2.0),
-        libpipewire-0.2-dev | libpipewire-0.3-dev,
+        libpipewire-0.3-dev [linux-any] | libpipewire-0.2-dev [linux-any],
         libsm-dev,
         libstartup-notification0-dev (>= 0.7),
         libsystemd-dev (>= 212) [linux-any],

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,12 @@ CONFFLAGS = \
 	-Ddefault_driver=gl \
 	-Dremote_desktop=false
 
+ifneq ($(DEB_HOST_ARCH_OS),linux)
+CONFFLAGS += \
+	-Dudev=false \
+	-Dcore_tests=false
+endif
+
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		$(CONFFLAGS)

--- a/debian/rules
+++ b/debian/rules
@@ -11,13 +11,20 @@ override_dh_autoreconf:
 
 CONFFLAGS = \
 	-Dprofiler=false \
-	-Ddefault_driver=gl \
 	-Dremote_desktop=false
 
 ifneq ($(DEB_HOST_ARCH_OS),linux)
 CONFFLAGS += \
 	-Dudev=false \
 	-Dcore_tests=false
+endif
+
+ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH),armel armhf))
+CONFFLAGS += \
+	-Ddefault_driver=gles2
+else
+CONFFLAGS += \
+	-Ddefault_driver=gl
 endif
 
 override_dh_auto_configure:


### PR DESCRIPTION
Restore kfreebsd and arm archs support to decrease differences with the official debian packages.
About arm archs can be useful also if there are users that want build new version from upstream.