### PR TITLE
WIP/RFT Revert renaming of the X11 atoms wm_name and gnome_wm_keybindings

### DIFF
--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -82,8 +82,8 @@ typedef struct _MetaX11DisplayLogicalMonitorData
 
 static GdkDisplay *prepared_gdk_display = NULL;
 
-static const char *gnome_wm_keybindings = "Mutter";
-static const char *net_wm_name = "Mutter";
+static const char *gnome_wm_keybindings = "Mutter,Metacity";
+static const char *net_wm_name = "Mutter (Muffin)";
 
 static char *get_screen_name (Display *xdisplay,
                               int      number);


### PR DESCRIPTION
This reverts two X11 atoms back to how they were in 5.2
This needs some testing to see if there are any negative side effects.