### PR TITLE
some fixes to debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -145,11 +145,12 @@ Package: libmuffin-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Breaks: libmuffin0 (<< 5.1)
-Replaces: libmuffin0 (<< 5.1)
+Breaks: libmuffin0 (<< 5.3)
+Replaces: libmuffin0 (<< 5.3)
 Depends: gir1.2-meta-muffin-0.0 (= ${binary:Version}),
          libatk1.0-dev,
          libcairo2-dev,
+         libcinnamon-desktop-dev (>= 5.4),
          libdrm-dev,
          libegl1-mesa-dev,
          libgdk-pixbuf2.0-dev,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Source: https://download.gnome.org/sources/mutter/
+Upstream-Name: muffin
+Upstream-Contact: Linux Mint Project <root@linuxmint.com>
+Source: https://github.com/linuxmint/muffin
 
 Files:
  *

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,8 @@ CONFFLAGS = \
 ifneq ($(DEB_HOST_ARCH_OS),linux)
 CONFFLAGS += \
 	-Dudev=false \
-	-Dcore_tests=false
+	-Dcore_tests=false \
+	-Dlibwacom=false
 endif
 
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH),armel armhf))

--- a/debian/tests/libmuffin-dev
+++ b/debian/tests/libmuffin-dev
@@ -34,7 +34,7 @@ EOF
 
 # Deliberately word-splitting pkg-config's output:
 # shellcheck disable=SC2046
-"${CROSS_COMPILE}gcc" -o trivial trivial.c $("${CROSS_COMPILE}pkg-config" --cflags --libs libmuffin)
+"${CROSS_COMPILE}gcc" -o trivial trivial.c $("${CROSS_COMPILE}pkg-config" --cflags --libs libmuffin-0)
 echo "build: OK"
 [ -x trivial ]
 xvfb-run -a dbus-run-session -- ./trivial


### PR DESCRIPTION
- Fix library name for pkgconfig in autopkgtest
- d/control:
  add missed libcinnamon-desktop-dev to libmuffin-dev deps
missed increment of breaks/replaces (as rebase was postponed from 5.2
to 5.4
- d/rules: disable wacom in configure for not linux archs
- fix some fields in d/copyright