### PR TITLE
Bring back window placement-mode 

### DIFF
--- a/data/org.cinnamon.muffin.gschema.xml.in
+++ b/data/org.cinnamon.muffin.gschema.xml.in
@@ -5,6 +5,13 @@
     <value value="2" nick="blend"/>
   </enum>
 
+  <enum id="placement_mode">
+    <value value="0" nick="automatic"/>
+    <value value="1" nick="pointer"/>
+    <value value="2" nick="manual"/>
+    <value value="3" nick="center"/>
+  </enum>
+
   <schema id="org.cinnamon.muffin" path="/org/cinnamon/muffin/"
           gettext-domain="@GETTEXT_DOMAIN@">
 
@@ -135,6 +142,27 @@
       <description>
         When true, the new windows will always be put in the center of the
         active screen of the monitor.
+      </description>
+    </key>
+
+    <key name="placement-mode" enum="placement_mode">
+      <default>'automatic'</default>
+      <summary>Window placement mode</summary>
+      <description>
+        The window placement mode indicates how new windows are positioned.
+
+        • “automatic” — the system chooses a location automatically based on
+                        the space available on the desktop, or by a simple
+                        cascade if there is no space
+
+        • “pointer”   — new windows are placed according to the mouse pointer
+                        position
+
+        • “manual”    — the user must manually place the new window with the
+                        mouse or keyboard.
+
+        • “center”    — new windows are always put in the center of the active
+                        screen of the monitor
       </description>
     </key>
 

--- a/debian/libmuffin0.symbols
+++ b/debian/libmuffin0.symbols
@@ -2386,7 +2386,7 @@ libmuffin.so.0 libmuffin0 #MINVER#
  meta_prefs_get_auto_raise@Base 5.3.0
  meta_prefs_get_auto_raise_delay@Base 5.3.0
  meta_prefs_get_button_layout@Base 5.3.0
- meta_prefs_get_center_new_windows@Base 5.3.0
+ meta_prefs_get_new_window_placement_mode@Base 5.3.0
  meta_prefs_get_check_alive_timeout@Base 5.3.0
  meta_prefs_get_cursor_size@Base 5.3.0
  meta_prefs_get_cursor_theme@Base 5.3.0

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -93,7 +93,7 @@ static MetaKeyCombo locate_pointer_key_combo = { 0, 0, 0 };
 static CDesktopFocusMode focus_mode = C_DESKTOP_FOCUS_MODE_CLICK;
 static CDesktopFocusNewWindows focus_new_windows = C_DESKTOP_FOCUS_NEW_WINDOWS_SMART;
 static gboolean raise_on_click = TRUE;
-static gboolean center_new_windows = FALSE;
+static MetaPlacementMode new_window_placement_mode = META_PLACEMENT_MODE_AUTOMATIC;
 static gboolean attach_modal_dialogs = FALSE;
 static int num_workspaces = 4;
 static gboolean workspace_cycle = FALSE;
@@ -271,6 +271,13 @@ static MetaEnumPreference preferences_enum[] =
       &focus_mode,
     },
     {
+      { "placement-mode",
+        SCHEMA_MUFFIN,
+        META_PREF_NEW_WINDOW_PLACEMENT_MODE,
+      },
+      &new_window_placement_mode,
+    },
+    {
       { "visual-bell-type",
         SCHEMA_GENERAL,
         META_PREF_VISUAL_BELL_TYPE,
@@ -323,13 +330,6 @@ static MetaBoolPreference preferences_bool[] =
         META_PREF_ATTACH_MODAL_DIALOGS,
       },
       &attach_modal_dialogs,
-    },
-    {
-      { "center-new-windows",
-        SCHEMA_MUFFIN,
-        META_PREF_CENTER_NEW_WINDOWS,
-      },
-      &center_new_windows,
     },
     {
       { "raise-on-click",
@@ -1311,10 +1311,10 @@ meta_prefs_get_focus_new_windows (void)
   return focus_new_windows;
 }
 
-gboolean
-meta_prefs_get_center_new_windows (void)
+MetaPlacementMode
+meta_prefs_get_new_window_placement_mode (void)
 {
-  return center_new_windows;
+  return new_window_placement_mode;
 }
 
 gboolean
@@ -1850,8 +1850,8 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_FOCUS_NEW_WINDOWS:
       return "FOCUS_NEW_WINDOWS";
 
-    case META_PREF_CENTER_NEW_WINDOWS:
-      return "CENTER_NEW_WINDOWS";
+    case META_PREF_NEW_WINDOW_PLACEMENT_MODE:
+      return "NEW_WINDOW_PLACEMENT_MODE";
 
     case META_PREF_ATTACH_MODAL_DIALOGS:
       return "ATTACH_MODAL_DIALOGS";

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -238,6 +238,7 @@ struct _MetaWindow
   guint maximize_horizontally_after_placement : 1;
   guint maximize_vertically_after_placement : 1;
   guint minimize_after_placement : 1;
+  guint move_after_placement : 1;
 
   /* The current tile mode */
   MetaTileMode tile_mode;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1127,6 +1127,7 @@ _meta_window_shared_new (MetaDisplay         *display,
   window->maximize_horizontally_after_placement = FALSE;
   window->maximize_vertically_after_placement = FALSE;
   window->minimize_after_placement = FALSE;
+  window->move_after_placement = FALSE;
   window->fullscreen = FALSE;
   window->require_fully_onscreen = TRUE;
   window->require_on_single_monitor = TRUE;
@@ -2631,6 +2632,14 @@ meta_window_show (MetaWindow *window)
           timestamp = meta_display_get_current_time_roundtrip (window->display);
 
           meta_window_focus (window, timestamp);
+
+          if (window->move_after_placement)
+            {
+              timestamp = meta_display_get_current_time_roundtrip (window->display);
+              meta_window_begin_grab_op(window, META_GRAB_OP_KEYBOARD_MOVING,
+                                        FALSE, timestamp);
+              window->move_after_placement = FALSE;
+            }
         }
       else if (display->x11_display)
         {

--- a/src/meta/common.h
+++ b/src/meta/common.h
@@ -548,6 +548,25 @@ typedef enum
   META_LAYER_LAST	       = 8
 } MetaStackLayer;
 
+
+/**
+ * MetaPlacementMode:
+ * @META_PLACEMENT_MODE_AUTOMATIC: Automatic
+ * @META_PLACEMENT_MODE_POINTER: Pointer
+ * @META_PLACEMENT_MODE_MANUAL: Manual
+ * @META_PLACEMENT_MODE_CENTER: Center
+ *
+ * How new windows should be placed.
+ */
+typedef enum
+{
+  META_PLACEMENT_MODE_AUTOMATIC,
+  META_PLACEMENT_MODE_POINTER,
+  META_PLACEMENT_MODE_MANUAL,
+  META_PLACEMENT_MODE_CENTER
+} MetaPlacementMode;
+
+
 /* MetaGravity: (skip)
  *
  * Identical to the corresponding gravity value macros from libX11.

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -65,7 +65,7 @@
  * @META_PREF_WORKSPACES_ONLY_ON_PRIMARY: workspaces only on primary
  * @META_PREF_DRAGGABLE_BORDER_WIDTH: draggable border width
  * @META_PREF_AUTO_MAXIMIZE: auto-maximize
- * @META_PREF_CENTER_NEW_WINDOWS: center new windows
+ * @META_PREF_NEW_WINDOW_PLACEMENT_MODE: new window placement mode
  * @META_PREF_DRAG_THRESHOLD: drag threshold
  * @META_PREF_LOCATE_POINTER: show pointer location
  * @META_PREF_GTK_THEME: gtk theme name
@@ -110,7 +110,7 @@ typedef enum
   META_PREF_WORKSPACES_ONLY_ON_PRIMARY,
   META_PREF_DRAGGABLE_BORDER_WIDTH,
   META_PREF_AUTO_MAXIMIZE,
-  META_PREF_CENTER_NEW_WINDOWS,
+  META_PREF_NEW_WINDOW_PLACEMENT_MODE,
   META_PREF_DRAG_THRESHOLD,
   META_PREF_LOCATE_POINTER,
   META_PREF_CHECK_ALIVE_TIMEOUT,
@@ -211,7 +211,7 @@ META_EXPORT
 gboolean                    meta_prefs_get_auto_maximize      (void);
 
 META_EXPORT
-gboolean                    meta_prefs_get_center_new_windows (void);
+MetaPlacementMode           meta_prefs_get_new_window_placement_mode (void);
 
 META_EXPORT
 gboolean                    meta_prefs_get_show_fallback_app_menu (void);


### PR DESCRIPTION
This resolves https://github.com/linuxmint/muffin/issues/648 by bringing back the placement-mode setting that was previously present.

As I say in the issue discussion, with this change, cinnamon-settings should be updated to match. I have not done that, but I can do so if you wish.