### PR TITLE
compositor: Fix crash when restarting Cinnamon

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1380,10 +1380,10 @@ meta_compositor_dispose (GObject *object)
                           priv->top_window_actor);
 
   g_clear_pointer (&priv->background_actor, clutter_actor_destroy);
+  g_clear_pointer (&priv->bottom_window_group, clutter_actor_destroy);
   g_clear_pointer (&priv->desklet_container, clutter_actor_destroy);
   g_clear_pointer (&priv->window_group, clutter_actor_destroy);
   g_clear_pointer (&priv->top_window_group, clutter_actor_destroy);
-  g_clear_pointer (&priv->bottom_window_group, clutter_actor_destroy);
   g_clear_pointer (&priv->feedback_group, clutter_actor_destroy);
   g_clear_pointer (&priv->windows, g_list_free);
 


### PR DESCRIPTION
I ran into a crash when restarting cinnamon on NixOS:

- (Optionally, to start a NixOS Cinnamon VM on any Linux distribution) [Install Nix](https://nixos.org/manual/nix/stable/installation/installing-binary.html), run `nix --experimental-features "nix-command flakes" run github:bobby285271/test-cinnamon` and login with username and password `test`
- Right click the bottom panel
- Select "Troubleshoot"
- Select "Restart Cinnamon"
- Do some random clicks and see no respond


![](https://user-images.githubusercontent.com/20080233/209893768-0476222d-4068-466b-82b5-a7501920a055.png)

This PR resolves the problem for me, will appreciate some review with it :bow:

---

Here are the first few lines of backtrace (though probably not useful, you can get the full output in https://github.com/NixOS/nixpkgs/issues/208122):

```gdb
#0  0x00007f57010062ea in clutter_actor_destroy (self=0xb76b40) at ../clutter/clutter/clutter-actor.c:8927
        __inst = 0xb76b40
        __t = 10529936
        __r = <optimized out>
        _g_boolean_var_ = <optimized out>
        __func__ = "clutter_actor_destroy"
#1  0x00007f5700d66c29 in meta_compositor_dispose (object=0x7124f0) at ../src/compositor/compositor.c:1386
        _pp = 0x7124a8
        _ptr = <optimized out>
        compositor = <optimized out>
        priv = 0x712450
#2  0x00007f57012560c9 in g_object_run_dispose (object=0x7124f0) at ../gobject/gobject.c:1448
        __func__ = "g_object_run_dispose"
#3  0x00007f5700d66f06 in meta_compositor_destroy (compositor=0x7124f0) at ../src/compositor/compositor.c:194
No locals.
#4  0x00007f5700d85a66 in meta_display_close (display=0xb32030, timestamp=0) at ../src/core/display.c:1139
        _pp = 0xb32230
        _ptr = <optimized out>
        __func__ = "meta_display_close"
#5  0x00007f57014e2b33 in cinnamon_global_real_restart (global=0xa6c0c0) at ../src/cinnamon-global.c:1213
        arr = 0x33ad5a0
        len = 46
        buf = 0x22cd200 "/run/current-system/sw/bin/cinnamon"
        buf_p = <optimized out>
        buf_end = <optimized out>
        error = 0x0
```

The crash probably happens at https://github.com/linuxmint/muffin/blame/5.6.2/src/compositor/compositor.c#L1386

Probably the order matters based on the following lines and https://github.com/linuxmint/muffin/commit/db3dcdbb784ecd94ce5bbbea008712a8f201993e, I don't know:

https://github.com/linuxmint/muffin/blob/8c1cb88373e1af1023c8a642da05040e7d83829d/src/compositor/compositor.c#L610-L615