### PR TITLE
Ignore XRRSetMonitor() errors and delete existing monitors with same name

### DIFF
--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -1082,6 +1082,8 @@ meta_monitor_manager_xrandr_tiled_monitor_added (MetaMonitorManager *manager,
   GList *outputs;
   GList *l;
   int i;
+  xcb_connection_t *xcb_conn;
+  xcb_void_cookie_t cookie;
 
   if (!(meta_monitor_manager_get_capabilities (manager) &
         META_MONITOR_MANAGER_CAPABILITY_TILING))
@@ -1117,6 +1119,11 @@ meta_monitor_manager_xrandr_tiled_monitor_added (MetaMonitorManager *manager,
       xrandr_monitor_info->outputs[i] = output->winsys_id;
     }
 
+  xcb_conn = XGetXCBConnection (manager_xrandr->xdisplay);
+  cookie = xcb_randr_delete_monitor_checked (xcb_conn,
+                                             DefaultRootWindow (manager_xrandr->xdisplay),
+                                             name_atom);
+  free (xcb_request_check (xcb_conn, cookie)); /* ignore DeleteMonitor errors */
   XRRSetMonitor (manager_xrandr->xdisplay,
                  DefaultRootWindow (manager_xrandr->xdisplay),
                  xrandr_monitor_info);


### PR DESCRIPTION
Ignore server errors on XRRSetMonitor().  A similar fix appears in mutter [1].

The RandR protocol [2] states concerning RRSetMonitor that:

> If 'name' matches an existing Monitor on the screen, the
> existing one will be deleted as if RRDeleteMonitor were called.

Unfortunately, this behavior is not the case in practice, and if an existing monitor with the same name exists the server generates a BadValue error [3].  While this was fixed very recently in the Xorg xserver [3], it is unclear when these changes will make it to most distributions due to how long it has been since a formal Xorg xserver major release.  Therefore, we must ignore this error to prevent muffin from aborting if a monitor with the same name already exists, a common condition upon restarting cinnamon or calling `cinnamon --replace`.

I used the low-level XSync() and XSetErrorHandler() calls because to my knowledge no MetaDisplay handles are available here and therefore APIs like meta_x11_error_trap_push() appear unavailable.  However, if they were available these APIs would be a cleaner approach.  The original mutter fix uses an API (mtk_x11_error_trap_push) that does not yet appear in muffin [1].

A word of warning to those that think that xcb may be the perfect tool for this job:  a crashing bug was only recently fixed in libxcb [4] which caused all calls to xcb_randr_set_monitor() to crash or otherwise cause the calling program to behave in an undefined manner.  While the fix is released in libxcb 1.17, this version is not even available in Ubuntu 24.04, for instance.  Therefore, it may be some time before we can reliably call xcb_randr_set_monitor().

Unfortunately, the above is not sufficient for correct behavior.   The aim of ignoring XRRSetMonitor() errors was merely to prevent muffin from aborting if a monitor with the same name as one we are setting already exists.  Merely ignoring the problem is fine if the monitor outputs that we tried to set happen to be the ones already set on that monitor.  However, if XRRSetMonitor() fails, then the existing monitor may have *different* outputs than the ones which we tried to set.

To work around this, we first try to delete any monitor with the new monitor's name using XRRDeleteMonitor().  This might fail if no such monitor exists, so ignore server errors from this call as well.  Then call XRRSetMonitor() as before.

[1] https://gitlab.gnome.org/GNOME/mutter/-/commit/8d3696f39a0b3af725b7615f7e2ac74ce5e0bcbf
[2] https://cgit.freedesktop.org/xorg/proto/randrproto/tree/randrproto.txt
[3] https://gitlab.freedesktop.org/xorg/xserver/-/commit/146bb9b2c19fb75b7629b65d5871969b7fcef97a
[4] https://gitlab.freedesktop.org/xorg/lib/libxcb/-/commit/038636786ad1914f3daf3503ae9611f40dffbb8f