### PR TITLE
Fix X11 screen size when using fractional "scale-up" mode

### DIFF
--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -669,7 +669,7 @@ apply_crtc_assignments (MetaMonitorManager *manager,
   if (!n_crtcs)
     goto out;
 
-  if (width > manager->screen_width || height > manager->screen_height)
+  if (width > 0 && height > 0)
     {
       meta_monitor_manager_xrandr_update_screen_size (manager_xrandr,
                                                       width, height,
@@ -789,13 +789,6 @@ apply_crtc_assignments (MetaMonitorManager *manager,
 
       meta_output_unassign_crtc (output);
       output->is_primary = FALSE;
-    }
-
-  if (width > 0 && height > 0)
-    {
-      meta_monitor_manager_xrandr_update_screen_size (manager_xrandr,
-                                                      width, height,
-                                                      avg_screen_scale);
     }
 
 out:

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -847,7 +847,7 @@ meta_monitor_manager_xrandr_update_screen_size_derived (MetaMonitorManager *mana
       if (!crtc || !crtc->config)
         continue;
 
-      if (!have_scaling || scale_mode != META_X11_SCALE_MODE_UI_DOWN)
+      if (!have_scaling)
         {
           /* When scaling up we should not reduce the screen size, or X will
            * fail miserably, while we must do it when scaling down, in order to


### PR DESCRIPTION
These commits aim to fix the X11 screen size getting improperly set if fractional scaling is used in "scale-up" mode.  An investigation into why we were improperly setting the screen size in the first place led to the discovery that this was to work around an issue where the X server would throw an error if the requested screen size is, in any dimension, smaller than what the screen size would be without any xrandr scaling applied.  See, e.g., [1, 2].  The first two commits aim to fix the way that we set the screen size so that the worked around issue no longer applies.

Finally, with the worked around issue no longer applying, the third commit removes the workaround, setting the correct screen size when using fractional scaling in "scale-up" mode.

[1] https://lists.x.org/archives/xorg-devel/2018-March/056203.html
[2] https://github.com/linuxmint/muffin/blob/b15de53d7bc43dbcd0136cd7f845eb7ec9d89e6a/src/backends/x11/meta-monitor-manager-xrandr.c#L851