### PR TITLE
Update README.md to mention the fact that Muffin is a fork of Mutter,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Muffin is a fork of Mutter, specifically adapted to work as the window manager for the Cinnamon desktop environment.
+
 # Mutter
 
 Mutter is a Wayland display server and X11 window manager and compositor library.


### PR DESCRIPTION
… instead of the default readme from Mutter