### PR TITLE
Change all g_memdup() to g_memdup2()

### DIFF
--- a/clutter/clutter/clutter-event.c
+++ b/clutter/clutter/clutter-event.c
@@ -1412,20 +1412,29 @@ clutter_event_copy (const ClutterEvent *event)
     case CLUTTER_BUTTON_PRESS:
     case CLUTTER_BUTTON_RELEASE:
       if (event->button.axes != NULL)
-        new_event->button.axes = g_memdup (event->button.axes,
-                                           sizeof (gdouble) * n_axes);
+        {
+          new_event->button.axes =
+            g_memdup2 (event->button.axes,
+                       sizeof (double) * n_axes);
+        }
       break;
 
     case CLUTTER_SCROLL:
       if (event->scroll.axes != NULL)
-        new_event->scroll.axes = g_memdup (event->scroll.axes,
-                                           sizeof (gdouble) * n_axes);
+        {
+          new_event->scroll.axes =
+            g_memdup2 (event->scroll.axes,
+                       sizeof (double) * n_axes);
+        }
       break;
 
     case CLUTTER_MOTION:
       if (event->motion.axes != NULL)
-        new_event->motion.axes = g_memdup (event->motion.axes,
-                                           sizeof (gdouble) * n_axes);
+        {
+          new_event->motion.axes =
+            g_memdup2 (event->motion.axes,
+                       sizeof (double) * n_axes);
+        }
       break;
 
     case CLUTTER_TOUCH_BEGIN:
@@ -1433,8 +1442,11 @@ clutter_event_copy (const ClutterEvent *event)
     case CLUTTER_TOUCH_END:
     case CLUTTER_TOUCH_CANCEL:
       if (event->touch.axes != NULL)
-        new_event->touch.axes = g_memdup (event->touch.axes,
-                                          sizeof (gdouble) * n_axes);
+        {
+          new_event->touch.axes =
+            g_memdup2 (event->touch.axes,
+                      sizeof (double) * n_axes);
+        }
       break;
 
     case CLUTTER_IM_COMMIT:

--- a/clutter/clutter/clutter-shader-types.c
+++ b/clutter/clutter/clutter-shader-types.c
@@ -157,7 +157,8 @@ clutter_value_lcopy_shader_float (const GValue *value,
                             G_VALUE_TYPE_NAME (value));
 
   *float_count = shader_float->size;
-  *floats = g_memdup (shader_float->value, shader_float->size * sizeof (float));
+  *floats = g_memdup2 (shader_float->value,
+                       shader_float->size * sizeof (float));
 
   return NULL;
 }
@@ -248,7 +249,7 @@ clutter_value_lcopy_shader_int (const GValue *value,
                             G_VALUE_TYPE_NAME (value));
 
   *int_count = shader_int->size;
-  *ints = g_memdup (shader_int->value, shader_int->size * sizeof (int));
+  *ints = g_memdup2 (shader_int->value, shader_int->size * sizeof (int));
 
   return NULL;
 }
@@ -339,8 +340,10 @@ clutter_value_lcopy_shader_matrix (const GValue *value,
                             G_VALUE_TYPE_NAME (value));
 
   *float_count = shader_float->size;
-  *floats = g_memdup (shader_float->value,
-                      shader_float->size * shader_float->size * sizeof (float));
+  *floats = g_memdup2 (shader_float->value,
+                       shader_float->size *
+                       shader_float->size *
+                       sizeof (float));
 
   return NULL;
 }

--- a/cogl/cogl/cogl-boxed-value.c
+++ b/cogl/cogl/cogl-boxed-value.c
@@ -254,21 +254,21 @@ _cogl_boxed_value_copy (CoglBoxedValue *dst,
           break;
 
         case COGL_BOXED_INT:
-          dst->v.int_array = g_memdup (src->v.int_array,
-                                       src->size * src->count * sizeof (int));
+          dst->v.int_array = g_memdup2 (src->v.int_array,
+                                        src->size * src->count * sizeof (int));
           break;
 
         case COGL_BOXED_FLOAT:
-          dst->v.float_array = g_memdup (src->v.float_array,
-                                         src->size *
-                                         src->count *
-                                         sizeof (float));
+          dst->v.float_array = g_memdup2 (src->v.float_array,
+                                          src->size *
+                                          src->count *
+                                          sizeof (float));
           break;
 
         case COGL_BOXED_MATRIX:
-          dst->v.float_array = g_memdup (src->v.float_array,
-                                         src->size * src->size *
-                                         src->count * sizeof (float));
+          dst->v.float_array = g_memdup2 (src->v.float_array,
+                                          src->size * src->size *
+                                          src->count * sizeof (float));
           break;
         }
     }

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ libmutter_api_version = '@0@'.format(api_version)
 
 # generic version requirements
 fribidi_req = '>= 1.0.0'
-glib_req = '>= 2.61.1'
+glib_req = '>= 2.67.3'
 gi_req = '>= 0.9.5'
 graphene_req = '>= 1.9.3'
 gtk3_req = '>= 3.19.8'

--- a/src/backends/meta-monitor-config-manager.c
+++ b/src/backends/meta-monitor-config-manager.c
@@ -646,7 +646,7 @@ create_monitor_config (MetaMonitor     *monitor,
   monitor_config = g_new0 (MetaMonitorConfig, 1);
   *monitor_config = (MetaMonitorConfig) {
     .monitor_spec = meta_monitor_spec_clone (monitor_spec),
-    .mode_spec = g_memdup (mode_spec, sizeof (MetaMonitorModeSpec)),
+    .mode_spec = g_memdup2 (mode_spec, sizeof (MetaMonitorModeSpec)),
     .enable_underscanning = meta_monitor_is_underscanning (monitor)
   };
 
@@ -1030,8 +1030,8 @@ clone_monitor_config_list (GList *monitor_configs_in)
       monitor_config_out = g_new0 (MetaMonitorConfig, 1);
       *monitor_config_out = (MetaMonitorConfig) {
         .monitor_spec = meta_monitor_spec_clone (monitor_config_in->monitor_spec),
-        .mode_spec = g_memdup (monitor_config_in->mode_spec,
-                               sizeof (MetaMonitorModeSpec)),
+        .mode_spec = g_memdup2 (monitor_config_in->mode_spec,
+                                sizeof (MetaMonitorModeSpec)),
         .enable_underscanning = monitor_config_in->enable_underscanning
       };
       monitor_configs_out =
@@ -1054,7 +1054,8 @@ clone_logical_monitor_config_list (GList *logical_monitor_configs_in)
       logical_monitor_config_in = l->data;
 
       logical_monitor_config_out =
-        g_memdup (logical_monitor_config_in, sizeof (MetaLogicalMonitorConfig));
+        g_memdup2 (logical_monitor_config_in,
+                   sizeof (MetaLogicalMonitorConfig));
       logical_monitor_config_out->monitor_configs =
         clone_monitor_config_list (logical_monitor_config_in->monitor_configs);
 

--- a/src/backends/meta-monitor-manager-dummy.c
+++ b/src/backends/meta-monitor-manager-dummy.c
@@ -179,7 +179,7 @@ append_monitor (MetaMonitorManager *manager,
         {
           CrtcModeSpec *spec;
 
-          spec = g_memdup (&default_specs[i], sizeof (CrtcModeSpec));
+          spec = g_memdup2 (&default_specs[i], sizeof (CrtcModeSpec));
           mode_specs = g_list_prepend (mode_specs, spec);
         }
     }

--- a/src/backends/native/meta-kms-connector.c
+++ b/src/backends/native/meta-kms-connector.c
@@ -354,7 +354,7 @@ state_set_modes (MetaKmsConnectorState *state,
                  drmModeConnector      *drm_connector)
 {
   state->modes =
-    g_memdup (drm_connector->modes,
+    g_memdup2 (drm_connector->modes,
               drm_connector->count_modes * sizeof (drmModeModeInfo));
   state->n_modes = drm_connector->count_modes;
 }

--- a/src/backends/native/meta-kms-crtc.c
+++ b/src/backends/native/meta-kms-crtc.c
@@ -201,11 +201,11 @@ meta_kms_crtc_predict_state (MetaKmsCrtc   *crtc,
       clear_gamma_state (crtc);
       crtc->current_state.gamma.size = gamma->size;
       crtc->current_state.gamma.red =
-        g_memdup (gamma->red, gamma->size * sizeof (uint16_t));
+        g_memdup2 (gamma->red, gamma->size * sizeof (uint16_t));
       crtc->current_state.gamma.green =
-        g_memdup (gamma->green, gamma->size * sizeof (uint16_t));
+        g_memdup2 (gamma->green, gamma->size * sizeof (uint16_t));
       crtc->current_state.gamma.blue =
-        g_memdup (gamma->blue, gamma->size * sizeof (uint16_t));
+        g_memdup2 (gamma->blue, gamma->size * sizeof (uint16_t));
 
       break;
     }

--- a/src/backends/native/meta-kms-impl-simple.c
+++ b/src/backends/native/meta-kms-impl-simple.c
@@ -145,7 +145,7 @@ cached_mode_set_new (GList                 *connectors,
   cached_mode_set = g_new0 (CachedModeSet, 1);
   *cached_mode_set = (CachedModeSet) {
     .connectors = g_list_copy (connectors),
-    .drm_mode = g_memdup (drm_mode, sizeof *drm_mode),
+    .drm_mode = g_memdup2 (drm_mode, sizeof *drm_mode),
   };
 
   return cached_mode_set;

--- a/src/backends/native/meta-kms-update.c
+++ b/src/backends/native/meta-kms-update.c
@@ -221,7 +221,7 @@ meta_kms_update_mode_set (MetaKmsUpdate   *update,
   *mode_set = (MetaKmsModeSet) {
     .crtc = crtc,
     .connectors = connectors,
-    .drm_mode = drm_mode ? g_memdup (drm_mode, sizeof *drm_mode) : NULL,
+    .drm_mode = drm_mode ? g_memdup2 (drm_mode, sizeof *drm_mode) : NULL,
   };
 
   update->mode_sets = g_list_prepend (update->mode_sets, mode_set);
@@ -273,9 +273,9 @@ meta_kms_update_set_crtc_gamma (MetaKmsUpdate  *update,
   *gamma = (MetaKmsCrtcGamma) {
     .crtc = crtc,
     .size = size,
-    .red = g_memdup (red, size * sizeof *red),
-    .green = g_memdup (green, size * sizeof *green),
-    .blue = g_memdup (blue, size * sizeof *blue),
+    .red = g_memdup2 (red, size * sizeof *red),
+    .green = g_memdup2 (green, size * sizeof *green),
+    .blue = g_memdup2 (blue, size * sizeof *blue),
   };
 
   update->crtc_gammas = g_list_prepend (update->crtc_gammas, gamma);

--- a/src/backends/native/meta-monitor-manager-kms.c
+++ b/src/backends/native/meta-monitor-manager-kms.c
@@ -359,9 +359,9 @@ meta_monitor_manager_kms_get_crtc_gamma (MetaMonitorManager  *manager,
   crtc_state = meta_kms_crtc_get_current_state (kms_crtc);
 
   *size = crtc_state->gamma.size;
-  *red = g_memdup (crtc_state->gamma.red, *size * sizeof **red);
-  *green = g_memdup (crtc_state->gamma.green, *size * sizeof **green);
-  *blue = g_memdup (crtc_state->gamma.blue, *size * sizeof **blue);
+  *red = g_memdup2 (crtc_state->gamma.red, *size * sizeof **red);
+  *green = g_memdup2 (crtc_state->gamma.green, *size * sizeof **green);
+  *blue = g_memdup2 (crtc_state->gamma.blue, *size * sizeof **blue);
 }
 
 static char *

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -986,9 +986,9 @@ meta_monitor_manager_xrandr_get_crtc_gamma (MetaMonitorManager  *manager,
   gamma = XRRGetCrtcGamma (manager_xrandr->xdisplay, (XID)crtc->crtc_id);
 
   *size = gamma->size;
-  *red = g_memdup (gamma->red, sizeof (unsigned short) * gamma->size);
-  *green = g_memdup (gamma->green, sizeof (unsigned short) * gamma->size);
-  *blue = g_memdup (gamma->blue, sizeof (unsigned short) * gamma->size);
+  *red = g_memdup2 (gamma->red, sizeof (unsigned short) * gamma->size);
+  *green = g_memdup2 (gamma->green, sizeof (unsigned short) * gamma->size);
+  *blue = g_memdup2 (gamma->blue, sizeof (unsigned short) * gamma->size);
 
   XRRFreeGamma (gamma);
 }

--- a/src/backends/x11/meta-output-xrandr.c
+++ b/src/backends/x11/meta-output-xrandr.c
@@ -411,7 +411,7 @@ get_edid_property (Display  *xdisplay,
 
   if (actual_type == XA_INTEGER && actual_format == 8)
     {
-      result = g_memdup (prop, nitems);
+      result = g_memdup2 (prop, nitems);
       if (len)
         *len = nitems;
     }

--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -46,7 +46,7 @@
 MetaRectangle *
 meta_rectangle_copy (const MetaRectangle *rect)
 {
-  return g_memdup (rect, sizeof (MetaRectangle));
+  return g_memdup2 (rect, sizeof (MetaRectangle));
 }
 
 void

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2653,7 +2653,7 @@ meta_display_manage_all_xwindows (MetaDisplay *display)
   meta_stack_tracker_get_stack (display->stack_tracker, &_children, &n_children);
 
   /* Copy the stack as it will be modified as part of the loop */
-  children = g_memdup (_children, sizeof (guint64) * n_children);
+  children = g_memdup2 (_children, sizeof (uint64_t) * n_children);
 
   for (i = 0; i < n_children; ++i)
     {

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -95,8 +95,8 @@ resolved_key_combo_copy (MetaResolvedKeyCombo *from,
                          MetaResolvedKeyCombo *to)
 {
   to->len = from->len;
-  to->keycodes = g_memdup (from->keycodes,
-                           from->len * sizeof (xkb_keycode_t));
+  to->keycodes = g_memdup2 (from->keycodes,
+                            from->len * sizeof (xkb_keycode_t));
 }
 
 static gboolean

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -788,7 +788,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
 static MetaStrut *
 copy_strut(MetaStrut *original)
 {
-  return g_memdup(original, sizeof(MetaStrut));
+  return g_memdup2 (original, sizeof (MetaStrut));
 }
 
 static GSList *

--- a/src/x11/window-props.c
+++ b/src/x11/window-props.c
@@ -2060,9 +2060,11 @@ meta_x11_display_init_window_prop_hooks (MetaX11Display *x11_display)
     { x11_display->atom__NET_WM_XAPP_PROGRESS_PULSE, META_PROP_VALUE_CARDINAL, reload_progress_pulse, LOAD_INIT | INCLUDE_OR },
     { 0 },
   };
+  MetaWindowPropHooks *table;
+  MetaWindowPropHooks *cursor;
 
-  MetaWindowPropHooks *table = g_memdup (hooks, sizeof (hooks)),
-    *cursor = table;
+  table = g_memdup2 (hooks, sizeof (hooks)),
+  cursor = table;
 
   g_assert (x11_display->prop_hooks == NULL);
 


### PR DESCRIPTION
Using g_memdup() is dangerous due to the type of the size argument.