### PR TITLE
Make clutter_offscreen_effect_get_target available to Cjs

### DIFF
--- a/clutter/clutter/clutter-offscreen-effect.c
+++ b/clutter/clutter/clutter-offscreen-effect.c
@@ -579,7 +579,7 @@ clutter_offscreen_effect_get_texture (ClutterOffscreenEffect *effect)
 }
 
 /**
- * clutter_offscreen_effect_get_target: (skip)
+ * clutter_offscreen_effect_get_target:
  * @effect: a #ClutterOffscreenEffect
  *
  * Retrieves the material used as a render target for the offscreen


### PR DESCRIPTION
In order to enable all effects in the "Cinnamon Burn My Windows" extension it's required that the clutter OffscreenEffect.get_target() API is available to Cjs. I believe that the "(skip)" comment text is a GObject-Introspection annotations that prevents the API from being exposed as a API call in Cjs. The current GNOME equivalent is OffscreenEffect.get_pipeline() which is available to Gjs. https://github.com/GNOME/mutter/blob/625965d956a8818b77eadbdf0ae6e5edbf60b029/clutter/clutter/clutter-offscreen-effect.c#L666