### PR TITLE
Add get_pipeline() API

### DIFF
--- a/clutter/clutter/clutter-offscreen-effect.c
+++ b/clutter/clutter/clutter-offscreen-effect.c
@@ -604,6 +604,30 @@ clutter_offscreen_effect_get_target (ClutterOffscreenEffect *effect)
 }
 
 /**
+ * clutter_offscreen_effect_get_pipeline:
+ * @effect: a #ClutterOffscreenEffect
+ *
+ * Retrieves the pipeline used as a render target for the offscreen
+ * buffer created by @effect
+ *
+ * You should only use the returned #CoglPipeline when painting. The
+ * returned pipeline might change between different frames.
+ *
+ * Return value: (transfer none): a #CoglPipeline or %NULL. The
+ *   returned pipeline is owned by Clutter and it should not be
+ *   modified or freed
+ *
+ */
+CoglPipeline *
+clutter_offscreen_effect_get_pipeline (ClutterOffscreenEffect *effect)
+{
+  g_return_val_if_fail (CLUTTER_IS_OFFSCREEN_EFFECT (effect),
+                        NULL);
+
+  return effect->priv->target;
+}
+
+/**
  * clutter_offscreen_effect_paint_target:
  * @effect: a #ClutterOffscreenEffect
  * @paint_context: a #ClutterPaintContext

--- a/clutter/clutter/clutter-offscreen-effect.h
+++ b/clutter/clutter/clutter-offscreen-effect.h
@@ -99,6 +99,9 @@ CLUTTER_EXPORT
 CoglMaterial *  clutter_offscreen_effect_get_target             (ClutterOffscreenEffect *effect);
 
 CLUTTER_EXPORT
+CoglPipeline *  clutter_offscreen_effect_get_pipeline           (ClutterOffscreenEffect *effect);
+
+CLUTTER_EXPORT
 CoglHandle      clutter_offscreen_effect_get_texture            (ClutterOffscreenEffect *effect);
 
 CLUTTER_EXPORT


### PR DESCRIPTION
In order to enable the full set of effect in the CinnamonBurnMyWindows extension, I need access to OffscreenEffect's CoglPipeline in Cjs. I had hopped that making get_target() available to Cjs (PR #702) would give me access to the pipeline, but it turns out that get_target() is returning the target as a CoglMaterial which I probably should have known would only give me access to the CoglMaterial APIs in Cjs. This proposed change copies the get_target() code and renames the copy to get_pipeline() and returns the target as a CoglPipeline rather than casting it to a CoglMaterial.

I am not setup to build muffin for testing these changes, but the changes are minor modifications to copies of the existing get_target() code. If these changes are accepted, I am not sure what Cinnamon version it would be included in so I didn't update the libmuffin0.symbols file to include get_pipeline with this PR.