### PR TITLE
[NEXT] clutter/actor: Allow specifying the layout manager for an actor type

### DIFF
--- a/clutter/clutter/clutter-actor.h
+++ b/clutter/clutter/clutter-actor.h
@@ -303,6 +303,8 @@ struct _ClutterActorClass
 
   /*< private >*/
   /* padding for future expansion */
+  GType layout_manager_type;
+
   gpointer _padding_dummy[25];
 };
 
@@ -925,6 +927,13 @@ CLUTTER_EXPORT
 void clutter_actor_pick_box (ClutterActor          *self,
                              ClutterPickContext    *pick_context,
                              const ClutterActorBox *box);
+
+CLUTTER_EXPORT
+void clutter_actor_class_set_layout_manager_type (ClutterActorClass *actor_class,
+                                                  GType              type);
+
+CLUTTER_EXPORT
+GType clutter_actor_class_get_layout_manager_type (ClutterActorClass *actor_class);
 
 G_END_DECLS
 

--- a/debian/libmuffin0.symbols
+++ b/debian/libmuffin0.symbols
@@ -106,6 +106,8 @@ libmuffin-clutter-0.so.0 libmuffin0 #MINVER#
  clutter_actor_box_set_origin@Base 5.3.0
  clutter_actor_box_set_size@Base 5.3.0
  clutter_actor_box_union@Base 5.3.0
+ clutter_actor_class_get_layout_manager_type@Base 6.4.0
+ clutter_actor_class_set_layout_manager_type@Base 6.4.0
  clutter_actor_clear_actions@Base 5.3.0
  clutter_actor_clear_constraints@Base 5.3.0
  clutter_actor_clear_effects@Base 5.3.0


### PR DESCRIPTION
Some actors have a well-defined layout manager other than FixedLayout.

If they do, we can handle the layout manager creation at the ClutterActor instantiation, like GTK does for widget layout managers.