### PR TITLE
[WIP] [X11] Workaround 1x1 Wine window to allow unredirect.

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1100,25 +1100,30 @@ _meta_window_shared_new (MetaDisplay         *display,
   /* avoid tons of stack updates */
   meta_stack_freeze (window->display->stack);
 
-  window->rect.x = attrs->x;
-  window->rect.y = attrs->y;
-  window->rect.width = attrs->width;
-  window->rect.height = attrs->height;
+  if (attrs->width != 1 &&
+      attrs->height != 1)
+    {
+      window->rect.x = attrs->x;
+      window->rect.y = attrs->y;
+      window->rect.width = attrs->width;
+      window->rect.height = attrs->height;
 
-  /* size_hints are the "request" */
-  window->size_hints.x = attrs->x;
-  window->size_hints.y = attrs->y;
-  window->size_hints.width = attrs->width;
-  window->size_hints.height = attrs->height;
-  /* initialize the remaining size_hints as if size_hints.flags were zero */
-  meta_set_normal_hints (window, NULL);
+      /* size_hints are the "request" */
+      window->size_hints.x = attrs->x;
+      window->size_hints.y = attrs->y;
+      window->size_hints.width = attrs->width;
+      window->size_hints.height = attrs->height;
 
-  /* And this is our unmaximized size */
-  window->saved_rect = window->rect;
-  window->unconstrained_rect = window->rect;
+      /* initialize the remaining size_hints as if size_hints.flags were zero */
+      meta_set_normal_hints (window, NULL);
 
-  window->depth = attrs->depth;
-  window->xvisual = attrs->visual;
+      /* And this is our unmaximized size */
+      window->saved_rect = window->rect;
+      window->unconstrained_rect = window->rect;
+
+      window->depth = attrs->depth;
+      window->xvisual = attrs->visual;
+    }
 
   window->title = NULL;
   window->icon = NULL;

--- a/src/x11/window-x11.c
+++ b/src/x11/window-x11.c
@@ -3817,10 +3817,14 @@ meta_window_x11_configure_notify (MetaWindow      *window,
   g_assert (window->override_redirect);
   g_assert (window->frame == NULL);
 
-  window->rect.x = event->x;
-  window->rect.y = event->y;
-  window->rect.width = event->width;
-  window->rect.height = event->height;
+  if (event->width != 1 &&
+      event->height != 1)
+    {
+      window->rect.x = event->x;
+      window->rect.y = event->y;
+      window->rect.width = event->width;
+      window->rect.height = event->height;
+    }
 
   priv->client_rect = window->rect;
   window->buffer_rect = window->rect;


### PR DESCRIPTION
#### Description
Finally, after previous two PRs I have created (and closed) with chunky workarounds and wild activity in #701, I have found solution and figured out that root of issue is bugged rectangles of child windows (`1x1+0+0`), which are created by OpenGL games running through Wine/Proton (e.g. Geometry Dash) and even native ones running through Steam (e.g. native Terraria). That does not happen with OpenGL games running completely natively (i.e. w/o Steam container) and does not happen with Vulkan games at all as those are have proper rectangles on child windows as `xwininfo -tree -root` shows, so solution oriented only at that specific case.

#### Solution
So, the best way I found to solve this, is just not override currently handled window rectangles with new (child) ones if those are bugged (i.e. resolution of child reported as `1x1`), that makes muffin use parent window rectangles which are correct.

That "filter" should be used two times:
1. in `window.c`: to allow FLIP unredirection for such windows by handling those with proper rectangles. 
2. in `window-x11.c`: to avoid unredirection breakage if window mode appears changed e.g. from fullscreen to windowed and back, or when OSD stuff draws over unredirected window.

Also I fixed issue in `meta-surface-actor-x11.c` related to handling internal unredirect requests if "Disable compositing for full-screen windows" disabled in settings (or through dconf), as those requests always have been handled and fullscreen windows were unredirected.

Closes #701.