### PR TITLE
meson: fix some implicit ordering dependencies on generated headers

### DIFF
--- a/clutter/clutter/meson.build
+++ b/clutter/clutter/meson.build
@@ -421,6 +421,7 @@ libmutter_clutter = shared_library(libmutter_clutter_name,
     cally_sources,
     cally_headers,
     cally_private_headers,
+    libmutter_cogl_path_enum_types_h
   ],
   version: '0.0.0',
   soversion: 0,

--- a/src/compositor/plugins/meson.build
+++ b/src/compositor/plugins/meson.build
@@ -5,7 +5,7 @@ default_plugin_c_args = [
 ]
 
 default_plugin = shared_module('default',
-  sources: ['default.c'],
+  sources: ['default.c', libmutter_cogl_path_enum_types_h],
   include_directories: mutter_includes,
   c_args: default_plugin_c_args,
   dependencies: [

--- a/src/meson.build
+++ b/src/meson.build
@@ -903,6 +903,7 @@ libmutter = shared_library(libmutter_name,
   sources: [
     mutter_sources,
     mutter_built_sources,
+    libmutter_cogl_path_enum_types_h,
   ],
   version: '0.0.0',
   soversion: 0,
@@ -933,6 +934,7 @@ libmutter_dep = declare_dependency(
 executable('muffin',
   sources: [
     files('core/mutter.c'),
+    libmutter_cogl_path_enum_types_h,
   ],
   include_directories: mutter_includes,
   c_args: mutter_c_args,


### PR DESCRIPTION
Given sufficiently high or simply random parallelism, it was possible to build various source files that included this generated header, without having coincidentally built the header previously. It then failed to compile, since there was no actual guarantee the header would come first. Add explicit header-only dependencies by adding the header as additional sources to targets that draw it in.

Fixes:

```
 * QA Notice: missing ninja dependencies in /var/tmp/portage/x11-wm/muffin-6.4.1/work/muffin-6.4.1-build:
[...]
 * Processed 517 nodes.
 * Error: There are 249 missing dependency paths.
 * 249 targets had depfile dependencies on 1 distinct generated inputs (from 1 rules)  without a non-depfile dep path to the generator.
 * There might be build flakiness if any of the targets listed above are built alone, or not late enough, in a clean output directory.
```