### PR TITLE
use non-deprecated g_spawn_check_wait_status

### DIFF
--- a/src/compositor/plugins/default.c
+++ b/src/compositor/plugins/default.c
@@ -895,7 +895,7 @@ on_dialog_closed (GPid     pid,
   MetaPlugin *plugin = user_data;
   gboolean ok;
 
-  ok = g_spawn_check_exit_status (status, NULL);
+  ok = g_spawn_check_wait_status (status, NULL);
   meta_plugin_complete_display_change (plugin, ok);
 }
 


### PR DESCRIPTION
this fixes a deprecated function