### PR TITLE
Revert "x11 backend: Don't let muffin reset the keyboard layout..."

### DIFF
--- a/src/backends/x11/cm/meta-backend-x11-cm.c
+++ b/src/backends/x11/cm/meta-backend-x11-cm.c
@@ -360,10 +360,9 @@ meta_backend_x11_cm_handle_host_xevent (MetaBackendX11 *backend_x11,
             case XkbStateNotify:
               if (xkb_ev->state.changed & XkbGroupLockMask)
                 {
-                  // TODO: Restore this, ditch libgnomekbd
-                  // if (x11_cm->locked_group != xkb_ev->state.locked_group)
-                  //   XkbLockGroup (xdisplay, XkbUseCoreKbd,
-                  //                 x11_cm->locked_group);
+                  if (x11_cm->locked_group != xkb_ev->state.locked_group)
+                    XkbLockGroup (xdisplay, XkbUseCoreKbd,
+                                  x11_cm->locked_group);
                 }
               break;
             default:


### PR DESCRIPTION
This reverts commit e6bcb95cc2b005223c60e8b3157f0e9f1fb56d86.

Layouts will no longer be handled by libgnomekbd.

ref: https://github.com/linuxmint/cinnamon/pull/12758