### PR TITLE
[Wayland] Bump wl_output interface to v4

### DIFF
--- a/src/wayland/meta-wayland-versions.h
+++ b/src/wayland/meta-wayland-versions.h
@@ -41,7 +41,7 @@
 #define META_ZXDG_SHELL_V6_VERSION          1
 #define META_WL_SHELL_VERSION               1
 #define META_WL_SEAT_VERSION                5
-#define META_WL_OUTPUT_VERSION              2
+#define META_WL_OUTPUT_VERSION              4
 #define META_XSERVER_VERSION                1
 #define META_GTK_SHELL1_VERSION             3
 #define META_WL_SUBCOMPOSITOR_VERSION       1


### PR DESCRIPTION
wl_output v3 allows clients to tell the
server that it can clean up the related wl_resource.

wl_output v4 adds the name and description events already present in xdg_output. Some clients may rely on that information instead of xdg-output-v1