### PR TITLE
wayland/dma-buf: Add support for BGR_8888 formats

### DIFF
--- a/src/wayland/meta-wayland-dma-buf.c
+++ b/src/wayland/meta-wayland-dma-buf.c
@@ -107,8 +107,14 @@ meta_wayland_dma_buf_realize_texture (MetaWaylandBuffer  *buffer,
     case DRM_FORMAT_XRGB8888:
       cogl_format = COGL_PIXEL_FORMAT_RGB_888;
       break;
+    case DRM_FORMAT_XBGR8888:
+      cogl_format = COGL_PIXEL_FORMAT_BGR_888;
+      break;
     case DRM_FORMAT_ARGB8888:
       cogl_format = COGL_PIXEL_FORMAT_ARGB_8888_PRE;
+      break;
+    case DRM_FORMAT_ABGR8888:
+      cogl_format = COGL_PIXEL_FORMAT_ABGR_8888_PRE;
       break;
     case DRM_FORMAT_ARGB2101010:
       cogl_format = COGL_PIXEL_FORMAT_ARGB_2101010_PRE;
@@ -527,7 +533,9 @@ dma_buf_bind (struct wl_client *client,
   wl_resource_set_implementation (resource, &dma_buf_implementation,
                                   compositor, NULL);
   send_modifiers (resource, DRM_FORMAT_ARGB8888);
+  send_modifiers (resource, DRM_FORMAT_ABGR8888);
   send_modifiers (resource, DRM_FORMAT_XRGB8888);
+  send_modifiers (resource, DRM_FORMAT_XBGR8888);
   send_modifiers (resource, DRM_FORMAT_ARGB2101010);
   send_modifiers (resource, DRM_FORMAT_RGB565);
 }


### PR DESCRIPTION
This is from https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1999 and landed as https://gitlab.gnome.org/GNOME/mutter/-/commit/922878ac upstream, but muffin isn't even up-to-date with [41.1](https://gitlab.gnome.org/GNOME/mutter/-/commits/41.1) (or [40.9](https://gitlab.gnome.org/GNOME/mutter/-/commit/18754031)) and thus missed it still nearly 4 years later.

This is now required to run the latest https://waydro.id Android 13 images, and I've confirmed locally this is simply all that was missing:
<img width="1280" height="800" alt="Android 13 Waydroid on Cinnamon Wayland" src="https://github.com/user-attachments/assets/42f0578f-720e-4b2e-849d-4d2b2c387cb3" />

@mtwebster if you'd consider this along with a bugfix release that'd be great, Cinnamon Wayland users are currently unable to use Waydroid with the latest images without additional workarounds (such as `gralloc.gbm.legacy=true`) :)

This also closes https://github.com/linuxmint/wayland/issues/38, surprised no one else backported this when the same fix was already well known for that issue as well.