### PR TITLE
[Wayland] Bump wl_compositor to version 5

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ udev_req = '>= 228'
 gudev_req = '>= 232'
 
 # wayland version requirements
-wayland_server_req = '>= 1.13.0'
+wayland_server_req = '>= 1.20'
 wayland_protocols_req = '>= 1.19'
 
 # native backend version requirements

--- a/src/wayland/meta-wayland-versions.h
+++ b/src/wayland/meta-wayland-versions.h
@@ -35,7 +35,7 @@
 /* #define META_WL_BUFFER_VERSION     1 */
 
 /* Global/master objects (version exported by wl_registry and negotiated through bind) */
-#define META_WL_COMPOSITOR_VERSION          4
+#define META_WL_COMPOSITOR_VERSION          5
 #define META_WL_DATA_DEVICE_MANAGER_VERSION 3
 #define META_XDG_WM_BASE_VERSION            3
 #define META_ZXDG_SHELL_V6_VERSION          1


### PR DESCRIPTION
This adds support for` wl_surface.offset` interface which is aims to replace the x,y arguments in wl_surface.attach(). The most common use case for the offset is setting the hotspot of DND surfaces. Backported from Mutter https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1905

See also https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/123