### PR TITLE
[Wayland] Fix crash when empty window geometry set

### DIFF
--- a/src/wayland/meta-wayland-legacy-xdg-shell.c
+++ b/src/wayland/meta-wayland-legacy-xdg-shell.c
@@ -1316,6 +1316,15 @@ zxdg_surface_v6_set_window_geometry (struct wl_client   *client,
   MetaWaylandSurface *surface = surface_from_xdg_surface_resource (resource);
   MetaWaylandSurfaceState *pending;
 
+  if (width == 0 || height == 0)
+    {
+      g_warning ("Invalid geometry %dx%d+%d+%d set on xdg_surface@%d. Ignoring for "
+      "now, but this will result in client termination in the future.",
+      width, height, x, y,
+      wl_resource_get_id (resource));
+      return;
+    }
+
   pending = meta_wayland_surface_get_pending_state (surface);
   pending->has_new_geometry = TRUE;
   pending->new_geometry.x = x;

--- a/src/wayland/meta-wayland-subsurface.c
+++ b/src/wayland/meta-wayland-subsurface.c
@@ -147,7 +147,8 @@ meta_wayland_subsurface_union_geometry (MetaWaylandSubsurface *subsurface,
     .height = meta_wayland_surface_get_height (surface),
   };
 
-  meta_rectangle_union (out_geometry, &geometry, out_geometry);
+  if (surface->buffer_ref.buffer)
+    meta_rectangle_union (out_geometry, &geometry, out_geometry);
 
   META_WAYLAND_SURFACE_FOREACH_SUBSURFACE (surface, subsurface_surface)
     {

--- a/src/wayland/meta-wayland-xdg-shell.c
+++ b/src/wayland/meta-wayland-xdg-shell.c
@@ -1483,6 +1483,15 @@ xdg_surface_set_window_geometry (struct wl_client   *client,
   MetaWaylandSurface *surface = surface_from_xdg_surface_resource (resource);
   MetaWaylandSurfaceState *pending;
 
+  if (width == 0 || height == 0)
+    {
+      g_warning ("Invalid geometry %dx%d+%d+%d set on xdg_surface@%d. Ignoring for "
+      "now, but this will result in client termination in the future.",
+      width, height, x, y,
+      wl_resource_get_id (resource));
+      return;
+    }
+
   pending = meta_wayland_surface_get_pending_state (surface);
   pending->has_new_geometry = TRUE;
   pending->new_geometry.x = x;
@@ -1578,6 +1587,15 @@ meta_wayland_xdg_surface_post_apply_state (MetaWaylandSurfaceRole  *surface_role
       meta_wayland_shell_surface_determine_geometry (shell_surface,
                                                      &pending->new_geometry,
                                                      &priv->geometry);
+      if (priv->geometry.width == 0 || priv->geometry.height == 0)
+        {
+          g_warning ("Invalid window geometry for xdg_surface@%d. Ignoring "
+          "for now, but this will result in client termination "
+          "in the future.",
+          wl_resource_get_id (priv->resource));
+          return;
+        }
+
       priv->has_set_geometry = TRUE;
     }
   else if (!priv->has_set_geometry)

--- a/src/wayland/meta-window-wayland.c
+++ b/src/wayland/meta-window-wayland.c
@@ -53,6 +53,7 @@ struct _MetaWindowWayland
   GList *pending_configurations;
   gboolean has_pending_state_change;
 
+  gboolean has_last_sent_configuration;
   int last_sent_x;
   int last_sent_y;
   int last_sent_width;
@@ -187,6 +188,8 @@ surface_state_changed (MetaWindow *window)
   /* don't send notify when the window is being unmanaged */
   if (window->unmanaging)
     return;
+
+  g_return_if_fail (wl_window->has_last_sent_configuration);
 
   configuration =
     meta_wayland_window_configuration_new (wl_window->last_sent_x,
@@ -401,6 +404,7 @@ meta_window_wayland_move_resize_internal (MetaWindow                *window,
         }
     }
 
+  wl_window->has_last_sent_configuration = TRUE;
   wl_window->last_sent_x = configured_x;
   wl_window->last_sent_y = configured_y;
   wl_window->last_sent_width = configured_width;


### PR DESCRIPTION
Backported from https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1557

Fixes https://github.com/linuxmint/wayland/issues/71