### PR TITLE
clutter-enums.h: Fix introspection definition and prefix.

### DIFF
--- a/clutter/clutter/clutter-enums.h
+++ b/clutter/clutter/clutter-enums.h
@@ -853,17 +853,18 @@ typedef enum /*< prefix=CLUTTER_DRAG >*/
 
 /**
  * ClutterEventFlags:
- * @CLUTTER_EVENT_NONE: No flag set
+ * @CLUTTER_EVENT_FLAG_NONE: No flag set
  * @CLUTTER_EVENT_FLAG_SYNTHETIC: Synthetic event
+ * @CLUTTER_EVENT_FLAG_INPUT_METHOD: From an IM,
  * @CLUTTER_EVENT_FLAG_REPEATED: Auto-repeated event
  *
  * Flags for the #ClutterEvent
  *
  * Since: 0.6
  */
-typedef enum /*< flags prefix=CLUTTER_EVENT >*/
+typedef enum /*< flags prefix=CLUTTER_EVENT_FLAG >*/
 {
-  CLUTTER_EVENT_NONE              = 0,
+  CLUTTER_EVENT_FLAG_NONE              = 0,
   CLUTTER_EVENT_FLAG_SYNTHETIC    = 1 << 0,
   CLUTTER_EVENT_FLAG_INPUT_METHOD = 1 << 1,
   CLUTTER_EVENT_FLAG_REPEATED     = 1 << 2

--- a/clutter/clutter/clutter-event.c
+++ b/clutter/clutter/clutter-event.c
@@ -645,7 +645,7 @@ clutter_event_set_stage (ClutterEvent *event,
 ClutterEventFlags
 clutter_event_get_flags (const ClutterEvent *event)
 {
-  g_return_val_if_fail (event != NULL, CLUTTER_EVENT_NONE);
+  g_return_val_if_fail (event != NULL, CLUTTER_EVENT_FLAG_NONE);
 
   return event->any.flags;
 }


### PR DESCRIPTION
This does not affect muffin code, except one place, but makes accessing them from Cinnamon more consistent, and lets you use .SYNTHETIC, instead of the redundant Clutter.EventFlags.FLAG_SYNTHETIC.