### PR TITLE
wayland/xdg-shell: Implement support for xdg_toplevel.wm_capabilities

### DIFF
--- a/src/wayland/meta-wayland-versions.h
+++ b/src/wayland/meta-wayland-versions.h
@@ -37,7 +37,7 @@
 /* Global/master objects (version exported by wl_registry and negotiated through bind) */
 #define META_WL_COMPOSITOR_VERSION          5
 #define META_WL_DATA_DEVICE_MANAGER_VERSION 3
-#define META_XDG_WM_BASE_VERSION            4
+#define META_XDG_WM_BASE_VERSION            5
 #define META_WL_SEAT_VERSION                5
 #define META_WL_OUTPUT_VERSION              4
 #define META_XSERVER_VERSION                1


### PR DESCRIPTION
GTK4 since version 4.20 checks if minimize or maximize is supported by the compositor, and disables the window buttons if not:
https://gitlab.gnome.org/GNOME/gtk/-/commit/d73871c670c6aafd24f923cd98ccd559d7e9e14e

Mutter since version 45 reports these capabilities as supported:
https://gitlab.gnome.org/GNOME/mutter/-/commit/3af02e1b57f90145e0a843195d8a96dc2a36e16b

Applying the same commit for Muffin fixes the problem that the minimize and maximize buttons are disabled on Wayland:
https://github.com/linuxmint/wayland/issues/153