### PR TITLE
Revert 23aba56e6d (ignore XkbNewKeyboardNotify) - filter by req_minor code.

### DIFF
--- a/src/backends/x11/meta-backend-x11.c
+++ b/src/backends/x11/meta-backend-x11.c
@@ -395,6 +395,18 @@ handle_host_xevent (MetaBackend *backend,
         {
           switch (xkb_ev->any.xkb_type)
             {
+            case XkbNewKeyboardNotify:
+              XkbNewKeyboardNotifyEvent *xkb_nkb_ev = (XkbNewKeyboardNotifyEvent *) xkb_ev;
+              // req_minor == 23 is X_kbGetKeyboardByName, triggered by:
+              // - set_keymap() calls
+              // - true keyboard hotplug
+              // req_minor == 9 is X_kbGetDeviceInfo, triggered by device switches
+              // (e.g., alternating between keyboard and volume knob) - ignore these
+              if (xkb_nkb_ev->req_minor == 23)
+                {
+                  keymap_changed (backend);
+                }
+              break;
             case XkbMapNotify:
               keymap_changed (backend);
               break;


### PR DESCRIPTION
Originally removed because keymap_changed() was being called in ordinary use - with multiple devices involved (a volume knob on a keyboard is considered a separate device), a freeze could occur when switching between them.

Unfortunately, the updating of xkb options also triggers this event, and ignoring it was causing Muffin keybinding handling of iso-next- group (grp) xkb option changes to be ignored, including at the beginning of a session when the xkb options are first applied.

Re-add this event case, but check the event's req_minor value to determine whether or not to call keymap_changed() - hotplug and set_keymap() events have the same code, and should be handled.

ref:

https://gitlab.gnome.org/GNOME/mutter/-/issues/398 https://github.com/linuxmint/cinnamon/issues/13361
https://github.com/linuxmint/cinnamon/issues/13361