### PR TITLE
keybindings/modifiers (wayland): Remove old workaround for xwayland, clients, fix event processing for wayland clients.

### DIFF
--- a/src/core/keybindings-private.h
+++ b/src/core/keybindings-private.h
@@ -139,6 +139,7 @@ void     meta_window_ungrab_all_keys        (MetaWindow  *window,
 gboolean meta_keybindings_process_event     (MetaDisplay        *display,
                                              MetaWindow         *window,
                                              const ClutterEvent *event);
+gboolean meta_keybindings_is_modifier       (xkb_keysym_t        keysym);
 int      meta_keybindings_get_mouse_zoom_modifiers (MetaDisplay *display);
 ClutterModifierType meta_display_get_window_grab_modifiers (MetaDisplay *display);
 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1953,8 +1953,8 @@ meta_display_unfreeze_keyboard (MetaDisplay *display, guint32 timestamp)
                  XIAsyncDevice, timestamp);
 }
 
-static gboolean
-is_modifier (xkb_keysym_t keysym)
+gboolean
+meta_keybindings_is_modifier (xkb_keysym_t keysym)
 {
   switch (keysym)
     {
@@ -2631,7 +2631,7 @@ process_keyboard_move_grab (MetaDisplay     *display,
     return TRUE;
 
   /* don't end grab on modifier key presses */
-  if (is_modifier (event->keyval))
+  if (meta_keybindings_is_modifier (event->keyval))
     return TRUE;
 
   meta_window_get_frame_rect (window, &frame_rect);
@@ -2885,7 +2885,7 @@ process_keyboard_resize_grab (MetaDisplay     *display,
     return TRUE;
 
   /* don't end grab on modifier key presses */
-  if (is_modifier (event->keyval))
+  if (meta_keybindings_is_modifier (event->keyval))
     return TRUE;
 
   if (event->keyval == CLUTTER_KEY_Escape)

--- a/src/wayland/meta-wayland-keyboard.h
+++ b/src/wayland/meta-wayland-keyboard.h
@@ -95,6 +95,8 @@ struct _MetaWaylandKeyboard
   uint32_t key_up_keycode;
   uint32_t key_up_serial;
 
+  struct wl_array pressed_keys;
+
   MetaWaylandXkbInfo xkb_info;
   enum xkb_state_component mods_changed;
   xkb_mod_mask_t kbd_a11y_latched_mods;


### PR DESCRIPTION

ref:
https://gitlab.gnome.org/GNOME/mutter/-/commit/cefa4044d1

Fixes https://github.com/linuxmint/wayland/issues/1.