### PR TITLE
wayland/subsurface: Move actor unparenting back to rebuild_surface_tr…

### DIFF
--- a/src/compositor/meta-window-actor-wayland.c
+++ b/src/compositor/meta-window-actor-wayland.c
@@ -44,6 +44,10 @@ get_surface_actor_list (GNode    *node,
 {
   MetaWaylandSurface *surface = node->data;
   MetaSurfaceActor *surface_actor = meta_wayland_surface_get_actor (surface);
+
+  if (!surface_actor)
+    return FALSE;
+
   GList **surface_actors = data;
 
   *surface_actors = g_list_prepend (*surface_actors, surface_actor);
@@ -58,8 +62,13 @@ set_surface_actor_index (GNode    *node,
   SurfaceTreeTraverseData *traverse_data = data;
 
   ClutterActor *window_actor = CLUTTER_ACTOR (traverse_data->window_actor);
-  ClutterActor *surface_actor =
-    CLUTTER_ACTOR (meta_wayland_surface_get_actor (surface));
+  MetaSurfaceActor *meta_surface_actor =
+  meta_wayland_surface_get_actor (surface);
+
+  if (!meta_surface_actor)
+    return FALSE;
+
+  ClutterActor *surface_actor = CLUTTER_ACTOR (meta_surface_actor);
 
   if (clutter_actor_contains (window_actor, surface_actor))
     {
@@ -77,6 +86,7 @@ set_surface_actor_index (GNode    *node,
                                            surface_actor,
                                            traverse_data->index);
     }
+
   traverse_data->index++;
 
   return FALSE;

--- a/src/wayland/meta-wayland-subsurface.c
+++ b/src/wayland/meta-wayland-subsurface.c
@@ -282,30 +282,15 @@ meta_wayland_subsurface_class_init (MetaWaylandSubsurfaceClass *klass)
 }
 
 static void
-unparent_actor (MetaWaylandSurface *surface)
-{
-  ClutterActor *actor;
-  ClutterActor *parent_actor;
-
-  actor = CLUTTER_ACTOR (meta_wayland_surface_get_actor (surface));
-  if (!actor)
-    return;
-
-  parent_actor = clutter_actor_get_parent (actor);
-  if (parent_actor)
-    clutter_actor_remove_child (parent_actor, actor);
-}
-
-static void
 wl_subsurface_destructor (struct wl_resource *resource)
 {
   MetaWaylandSurface *surface = wl_resource_get_user_data (resource);
 
   g_node_unlink (surface->subsurface_branch_node);
-  unparent_actor (surface);
 
   if (surface->sub.parent)
     {
+      meta_wayland_surface_notify_subsurface_state_changed (surface->sub.parent);
       wl_list_remove (&surface->sub.parent_destroy_listener.link);
       surface->sub.parent = NULL;
     }


### PR DESCRIPTION
…ee()

Unparenting the surface actor when the subsurface object is destroyed has several issues:

subsurface actors can be unparented while a close animation is still ongoing, breaking the animation for e.g. Firefox. adding and removing the actor to/from the parent is not handled in one place, making the code harder to follow.
if the destroyed subsurface had children of its own, they potentially stick around until a surface-tree rebuild. This makes the Firefox hamburger menu not close with the "compositor" backend.

Move the unparenting back to
`meta_window_actor_wayland_rebuild_surface_tree()` and instead just notify the parent of a state change, if it still exist. This will ensure a correct mapping between the subsurface node tree and the flat surface actor list. In case of the closing animation the parent will already be removed and the call is skipped.