### PR TITLE
[WIP] compositor: Add meta_get_stage_xwindow().

### DIFF
--- a/debian/libmuffin0.symbols
+++ b/debian/libmuffin0.symbols
@@ -2211,6 +2211,7 @@ libmuffin.so.0 libmuffin0 #MINVER#
  meta_get_option_context@Base 5.3.0
  meta_get_replace_current_wm@Base 5.3.0
  meta_get_stage_for_display@Base 5.3.0
+ meta_get_stage_xwindow@Base 6.6.3
  meta_get_top_window_group_for_display@Base 5.3.0
  meta_get_window_actors@Base 5.3.0
  meta_get_window_group_for_display@Base 5.3.0

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -1773,6 +1773,31 @@ meta_get_desklet_container_for_display (MetaDisplay *display)
   return priv->desklet_container;
 }
 
+/**
+ * meta_get_stage_xwindow:
+ * @display: a #MetaDisplay
+ *
+ * Returns the X11 window ID of the stage window backing the compositor.
+ *
+ * Returns: The X11 Window ID, or 0 if not available
+ */
+gulong
+meta_get_stage_xwindow (MetaDisplay *display)
+{
+  ClutterStage *stage;
+
+  g_return_val_if_fail (display != NULL, 0);
+
+  if (meta_is_wayland_compositor ())
+    return 0;
+
+  stage = CLUTTER_STAGE (meta_get_stage_for_display (display));
+  if (!stage)
+    return 0;
+
+  return (gulong) meta_x11_get_stage_window (stage);
+}
+
 void
 meta_update_desklet_stacking (MetaCompositor *compositor)
 {

--- a/src/meta/compositor-muffin.h
+++ b/src/meta/compositor-muffin.h
@@ -66,4 +66,7 @@ ClutterActor *meta_get_x11_background_actor_for_display (MetaDisplay *display);
 META_EXPORT
 ClutterActor *meta_get_desklet_container_for_display (MetaDisplay *display);
 
+META_EXPORT
+gulong meta_get_stage_xwindow (MetaDisplay *display);
+
 #endif


### PR DESCRIPTION
Needed for native screensaver backup-locker window.

see https://github.com/linuxmint/cinnamon/pull/13432