### PR TITLE
Fix vertical height calculation when applying edge resistance.

### DIFF
--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -636,7 +636,7 @@ apply_edge_resistance_to_each_side (MetaDisplay         *display,
             }
 
 
-          if (ABS (vertical_point - new_left) < 16)
+          if (ABS (vertical_point - new_top) < 16)
             {
               new_top = vertical_point;
               new_bottom = workarea.y + workarea.height;


### PR DESCRIPTION
# Related Issues

*  https://github.com/linuxmint/cinnamon/issues/13342
* https://github.com/linuxmint/cinnamon/issues/11219
* https://github.com/linuxmint/cinnamon/issues/11169
* https://github.com/linuxmint/cinnamon/issues/12305

# Summary
When resizing a right-side tiled window horizontally, the left position of the window changes as you resize it. The bug in apply_edge_resistance_to_each_side  is deciding whether or not to apply an adjustment to the height of the window using the current left position of the window instead of the current top position of the window as it should. This leads to unwanted vertical height changes while resizing the window horizontally.


# Before 


https://github.com/user-attachments/assets/d9eadb82-3380-48c4-ba12-dcdd6bb4c0d1

# After





https://github.com/user-attachments/assets/523e7913-0f5c-4b38-b812-33287026a05e

