### PR TITLE
backends: Guard against NULL monitor mode during XRandR transitions

### DIFF
--- a/src/backends/meta-logical-monitor.c
+++ b/src/backends/meta-logical-monitor.c
@@ -266,6 +266,11 @@ meta_logical_monitor_foreach_crtc (MetaLogicalMonitor        *logical_monitor,
       };
 
       mode = meta_monitor_get_current_mode (monitor);
+      if (!mode)
+        {
+          g_warning ("Monitor has NULL current_mode during foreach_crtc, skipping");
+          continue;
+        }
       meta_monitor_mode_foreach_crtc (monitor, mode, foreach_crtc, &data, NULL);
     }
 }

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -259,6 +259,11 @@ calculate_monitor_scale (MetaMonitorManager *manager,
   MetaMonitorMode *monitor_mode;
 
   monitor_mode = meta_monitor_get_current_mode (monitor);
+  if (!monitor_mode)
+    {
+      g_warning ("Monitor has NULL mode in calculate_monitor_scale, using scale 1.0");
+      return 1.0f;
+    }
   return meta_monitor_manager_calculate_monitor_mode_scale (manager,
                                                             manager->layout_mode,
                                                             monitor,
@@ -281,6 +286,8 @@ meta_monitor_manager_is_scale_supported_by_other_monitors (MetaMonitorManager *m
         continue;
 
       mode = meta_monitor_get_current_mode (monitor);
+      if (!mode)
+        continue;
       if (!meta_monitor_manager_is_scale_supported (manager, manager->layout_mode,
                                                     monitor, mode, scale))
         return FALSE;
@@ -376,6 +383,8 @@ derive_scale_from_crtc (MetaMonitorManager *manager,
   threshold = 0.001f;
 
   monitor_mode = meta_monitor_get_current_mode (monitor);
+  if (!monitor_mode)
+    return FALSE;
   if (meta_monitor_manager_is_scale_supported_with_threshold (manager,
                                                               manager->layout_mode,
                                                               monitor,

--- a/src/backends/x11/meta-gpu-xrandr.c
+++ b/src/backends/x11/meta-gpu-xrandr.c
@@ -188,6 +188,16 @@ meta_gpu_xrandr_read_current (MetaGpu  *gpu,
   monitor_manager->screen_width = WidthOfScreen (screen);
   monitor_manager->screen_height = HeightOfScreen (screen);
 
+  if (monitor_manager->screen_width < 64 || monitor_manager->screen_height < 64)
+    {
+      g_warning ("Rejecting invalid screen size %dx%d from X server",
+                 monitor_manager->screen_width, monitor_manager->screen_height);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Screen size %dx%d below minimum threshold",
+                   monitor_manager->screen_width, monitor_manager->screen_height);
+      return FALSE;
+    }
+
   resources = XRRGetScreenResourcesCurrent (xdisplay,
                                             DefaultRootWindow (xdisplay));
   if (!resources)

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -1419,7 +1419,10 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManagerXrandr *manager_xra
 
   XRRUpdateConfiguration (event);
 
+  g_debug ("Processing RRScreenChangeNotify event");
   meta_monitor_manager_read_current_state (manager);
+  g_debug ("RRScreenChangeNotify processed, screen: %dx%d",
+           manager->screen_width, manager->screen_height);
 
   gpu_xrandr = META_GPU_XRANDR (gpu);
   resources = meta_gpu_xrandr_get_resources (gpu_xrandr);

--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -2090,6 +2090,13 @@ meta_x11_display_logical_monitor_to_xinerama_index (MetaX11Display     *x11_disp
 
   logical_monitor_data = get_x11_display_logical_monitor_data (logical_monitor);
 
+  if (!logical_monitor_data)
+    {
+      g_warning ("Logical monitor has no X11 display data during xinerama "
+                 "index lookup, returning -1");
+      return -1;
+    }
+
   return logical_monitor_data->xinerama_index;
 }
 


### PR DESCRIPTION
## Problem

NVIDIA drivers can report intermediate CRTC states with no valid mode during multi-monitor reconfiguration (e.g. when monitors wake from DPMS sleep). Several code paths dereference `monitor->current_mode` without NULL checks, causing a segfault in `meta_monitor_mode_foreach_crtc` when the mode's `crtc_modes` array is accessed through a NULL pointer.

## Solution

Add NULL guards in four functions:
- `meta_logical_monitor_foreach_crtc()` — skip monitors with no mode
- `calculate_monitor_scale()` — return 1.0 as safe default
- `meta_monitor_manager_is_scale_supported_by_other_monitors()` — skip
- `derive_scale_from_crtc()` — return FALSE

Also reject screen sizes below 64px in `meta_gpu_xrandr_read_current()` as these indicate transient invalid states from the driver.

Add `g_debug()` logging around `RRScreenChangeNotify` processing to aid future diagnosis.

## Testing

Tested on a single machine:
- Ubuntu 25.10 (Cinnamon 6.4, muffin 6.4.1)
- NVIDIA driver 570.133.07, proprietary
- Dual monitor: 3440x1440 (DP) + 2560x1440 (HDMI)
- DPMS sleep/wake cycling over multiple days with no segfaults

Previously this configuration would crash muffin within hours of enabling DPMS. With these guards, the NULL dereference crash path is eliminated.

**This has only been tested on one machine and has not been widely tested.**

## Disclosure

This patch was developed with AI assistance (Claude Code). The code changes are minimal (NULL guards and a minimum size check) and have been manually reviewed.

## Related issues

- Closes #671 — muffin.so crashes in nvidia/cinnamon on monitor powerups from sleep
- May also help #581 — Segfault in libmuffin.so with NVIDIA (same crash pattern, Intel+NVIDIA hybrid)