### PR TITLE
native: Add preferred-primary GPU selection via udev tag

### DIFF
--- a/src/backends/native/meta-backend-native.c
+++ b/src/backends/native/meta-backend-native.c
@@ -526,6 +526,9 @@ create_gpu_from_udev_device (MetaBackendNative  *native,
   if (meta_is_udev_device_requires_modifiers (device))
     flags |= META_KMS_DEVICE_FLAG_REQUIRES_MODIFIERS;
 
+  if (meta_is_udev_device_preferred_primary (device))
+    flags |= META_KMS_DEVICE_FLAG_PREFERRED_PRIMARY;
+
   device_path = g_udev_device_get_device_file (device);
 
   kms_device = meta_kms_create_device (native->kms, device_path, flags,

--- a/src/backends/native/meta-gpu-kms.c
+++ b/src/backends/native/meta-gpu-kms.c
@@ -283,6 +283,15 @@ meta_gpu_kms_requires_modifiers (MetaGpuKms *gpu_kms)
   return !!(flags & META_KMS_DEVICE_FLAG_REQUIRES_MODIFIERS);
 }
 
+gboolean
+meta_gpu_kms_is_preferred_primary (MetaGpuKms *gpu_kms)
+{
+  MetaKmsDeviceFlag flags;
+
+  flags = meta_kms_device_get_flags (gpu_kms->kms_device);
+  return !!(flags & META_KMS_DEVICE_FLAG_PREFERRED_PRIMARY);
+}
+
 static int
 compare_outputs (gconstpointer one,
                  gconstpointer two)

--- a/src/backends/native/meta-gpu-kms.h
+++ b/src/backends/native/meta-gpu-kms.h
@@ -48,6 +48,7 @@ gboolean meta_gpu_kms_is_crtc_active (MetaGpuKms *gpu_kms,
 gboolean meta_gpu_kms_is_boot_vga (MetaGpuKms *gpu_kms);
 gboolean meta_gpu_kms_is_platform_device (MetaGpuKms *gpu_kms);
 gboolean meta_gpu_kms_requires_modifiers (MetaGpuKms *gpu_kms);
+gboolean meta_gpu_kms_is_preferred_primary (MetaGpuKms *gpu_kms);
 
 gboolean meta_gpu_kms_wait_for_flip (MetaGpuKms *gpu_kms,
                                      GError    **error);

--- a/src/backends/native/meta-kms-types.h
+++ b/src/backends/native/meta-kms-types.h
@@ -57,6 +57,7 @@ typedef enum _MetaKmsDeviceFlag
   META_KMS_DEVICE_FLAG_BOOT_VGA = 1 << 0,
   META_KMS_DEVICE_FLAG_PLATFORM_DEVICE = 1 << 1,
   META_KMS_DEVICE_FLAG_REQUIRES_MODIFIERS = 1 << 2,
+  META_KMS_DEVICE_FLAG_PREFERRED_PRIMARY = 1 << 3,
 } MetaKmsDeviceFlag;
 
 typedef enum _MetaKmsPlaneType MetaKmsPlaneType;

--- a/src/backends/native/meta-renderer-native.c
+++ b/src/backends/native/meta-renderer-native.c
@@ -3940,6 +3940,17 @@ choose_primary_gpu_unchecked (MetaBackend        *backend,
    */
   for (allow_sw = 0; allow_sw < 2; allow_sw++)
   {
+    /* Prefer a device tagged as preferred primary via udev */
+    for (l = gpus; l; l = l->next)
+      {
+        MetaGpuKms *gpu_kms = META_GPU_KMS (l->data);
+
+        if (meta_gpu_kms_is_preferred_primary (gpu_kms) &&
+            (allow_sw == 1 ||
+             gpu_kms_is_hardware_rendering (renderer_native, gpu_kms)))
+          return gpu_kms;
+      }
+
     /* Prefer a platform device */
     for (l = gpus; l; l = l->next)
       {

--- a/src/backends/native/meta-udev.c
+++ b/src/backends/native/meta-udev.c
@@ -75,6 +75,18 @@ meta_is_udev_device_boot_vga (GUdevDevice *device)
 }
 
 gboolean
+meta_is_udev_device_preferred_primary (GUdevDevice *device)
+{
+  const char * const * tags;
+
+  tags = g_udev_device_get_tags (device);
+  if (!tags)
+    return FALSE;
+
+  return g_strv_contains (tags, "muffin-device-preferred-primary");
+}
+
+gboolean
 meta_is_udev_device_requires_modifiers (GUdevDevice *device)
 {
   g_autoptr (GUdevDevice) platform_device = NULL;

--- a/src/backends/native/meta-udev.h
+++ b/src/backends/native/meta-udev.h
@@ -32,6 +32,8 @@ gboolean meta_is_udev_device_platform_device (GUdevDevice *device);
 
 gboolean meta_is_udev_device_boot_vga (GUdevDevice *device);
 
+gboolean meta_is_udev_device_preferred_primary (GUdevDevice *device);
+
 gboolean meta_is_udev_device_requires_modifiers (GUdevDevice *device);
 
 gboolean meta_udev_is_drm_device (MetaUdev    *udev,


### PR DESCRIPTION
## Summary

On multi-GPU SoCs like **RK3588** (Rockchip), the mainline kernel exposes two DRM devices:
- `card0` → `rockchip-drm` (display controller only, no 3D rendering)
- `card1` → `panthor` (Mali-G610 GPU, full OpenGL/Vulkan)

Muffin's `choose_primary_gpu_unchecked()` selects the first platform device with render capability, which picks `card0` — a display controller with no OpenGL/Vulkan support. This causes all Wayland EGL clients to fall back to **llvmpipe (software rendering)**.

GNOME's Mutter solved this with a [udev tag mechanism](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-udev.c#L86) (`mutter-device-preferred-primary`). This PR ports that mechanism to Muffin using the tag `muffin-device-preferred-primary`.

## Changes

| File | Change |
|------|--------|
| `meta-udev.c/h` | Add `meta_is_udev_device_preferred_primary()` — checks for `muffin-device-preferred-primary` udev tag |
| `meta-kms-types.h` | Add `META_KMS_DEVICE_FLAG_PREFERRED_PRIMARY` flag |
| `meta-backend-native.c` | Propagate flag during GPU init |
| `meta-gpu-kms.c/h` | Add `meta_gpu_kms_is_preferred_primary()` accessor |
| `meta-renderer-native.c` | Check preferred_primary **before** platform_device and boot_vga |

**Total: +39 lines across 7 files.** No behavioral change on systems without the udev tag.

## Usage

System integrators add a udev rule to mark the 3D-capable GPU:

```
# /etc/udev/rules.d/61-muffin-panthor.rules
SUBSYSTEM=="drm", KERNEL=="card1", DRIVERS=="panthor", TAG+="muffin-device-preferred-primary"
```

## Testing

- **Hardware**: Rock 5B+ (RK3588), Orange Pi 5 Plus (RK3588)
- **OS**: BredOS (Arch Linux ARM), kernels 6.19.1 and 7.0-rc1
- **Session**: Cinnamon Wayland
- **Verified**:
  - `muffin-device-preferred-primary` tag correctly detected via `udevadm info /dev/dri/card1`
  - Muffin selects `renderD128` (panthor) as primary GPU (verified via `/proc/PID/fd` and `/sys/kernel/debug/dri/1/clients`)
  - GBM EGL platform reports `Mali-G610 MC4 (Panfrost)` ✅

## Scope

This is **Part A** of a two-part fix for multi-GPU Wayland on Cinnamon:
- **Part A (this PR)**: Compositor-side GPU selection — Muffin picks the correct GPU internally
- **Part B (separate, larger work)**: Client-side device discovery — requires upgrading `zwp_linux_dmabuf_v1` from v3 to v4+ with `main_device` feedback, so that Wayland EGL clients know which render node to use. See related issue for details.

## Related

- Mutter implementation: [`meta_is_udev_device_preferred_primary()`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-udev.c)
- Wayland protocol: [`zwp_linux_dmabuf_v1` v4 feedback](https://wayland.app/protocols/linux-dmabuf-v1#zwp_linux_dmabuf_feedback_v1)