### PR TITLE
wayland: optimize frame scheduling for 120Hz+ displays

### DIFF
--- a/src/backends/native/meta-kms-impl-simple.c
+++ b/src/backends/native/meta-kms-impl-simple.c
@@ -400,10 +400,13 @@ retry_page_flips (gpointer user_data)
       if (ret == -EBUSY)
         {
           float refresh_rate;
+          gint64 retry_interval;
 
           refresh_rate = get_cached_crtc_refresh_rate (impl_simple, crtc);
-          retry_page_flip_data->retry_time_us +=
-            (uint64_t) (G_USEC_PER_SEC / refresh_rate);
+          /* On high-refresh displays, retry sooner than a full cycle
+           * to recover faster from transient EBUSY. */
+          retry_interval = (gint64) (G_USEC_PER_SEC / refresh_rate) / 2;
+          retry_page_flip_data->retry_time_us += MAX (retry_interval, 500);
           l = l_next;
           continue;
         }

--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -14,6 +14,10 @@
 /* Wait 2ms after vblank before starting to draw next frame */
 #define META_SYNC_DELAY 2
 
+/* On Wayland the KMS page-flip event already synchronizes rendering;
+ * a fixed delay consumes too much budget on 120 Hz+. */
+#define META_SYNC_DELAY_WAYLAND 0
+
 typedef struct _MetaLaters MetaLaters;
 
 struct _MetaCompositorClass

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -726,7 +726,10 @@ meta_compositor_do_manage (MetaCompositor  *compositor,
     g_signal_connect_after (priv->stage, "after-paint",
                             G_CALLBACK (after_stage_paint), compositor);
 
-  clutter_stage_set_sync_delay (CLUTTER_STAGE (priv->stage), META_SYNC_DELAY);
+  if (meta_is_wayland_compositor ())
+    clutter_stage_set_sync_delay (CLUTTER_STAGE (priv->stage), META_SYNC_DELAY_WAYLAND);
+  else
+    clutter_stage_set_sync_delay (CLUTTER_STAGE (priv->stage), META_SYNC_DELAY);
 
   priv->window_group = meta_window_group_new (display);
   priv->top_window_group = meta_window_group_new (display);


### PR DESCRIPTION
## Problem

On Cinnamon Wayland with high refresh rate displays (120Hz+), window flickering occurs due to tight frame scheduling:

- \+EBUSY+` waits a **full refresh cycle** before retrying, adding exactly one frame of latency on any scheduling hiccup.

## Environment

- GPU: AMD Radeon 880M (RDNA 3.5, amdgpu driver)
- Display: 2560×1600 @ 120Hz (BOE eDP-1)
- Session: Cinnamon 6.6.7 Wayland
- Kernel: Linux with DRM atomic

## Changes

### 1. Wayland: remove fixed 2ms sync delay
File: \+src/compositor/compositor.c+`

On Wayland the KMS page-flip event already provides synchronization. The 2ms delay is a legacy X11 artifact (for \+GL_EXT_x11_sync_object+`) that hurts high-refresh-rate performance. X11 path is kept unchanged for compatibility.

### 2. Faster page-flip retry on EBUSY
File: \+EBUSY+` without stalling a full frame.

## Testing

1. Disable experimental feature to eliminate offscreen overhead:
   \++`

2. Apply patch and rebuild muffin.

3. Observe flickering significantly reduced or eliminated on 120Hz panel.

## Related gaps (not addressed in this PR)

- \+wp_tearing_control_manager_v1+` Wayland protocols are not yet implemented in Muffin. Adding these would allow clients to better synchronize with the compositor and optionally allow tearing for latency-critical content.