### PR TITLE
x11: Do not unminimize windows with initial IconicState

### DIFF
--- a/src/x11/events.c
+++ b/src/x11/events.c
@@ -1406,33 +1406,22 @@ handle_other_xevent (MetaX11Display *x11_display,
         {
           window = meta_window_x11_new (display, event->xmaprequest.window,
                                         FALSE, META_COMP_EFFECT_CREATE);
-          /* The window might have initial iconic state, but this is a
-           * MapRequest, fall through to ensure it is unminimized in
-           * that case.
-           */
         }
-      else if (frame_was_receiver)
+      else
         {
-          meta_warning ("Map requests on the frame window are unexpected\n");
-          break;
-        }
+          meta_verbose ("MapRequest on %s mapped = %d minimized = %d",
+                        window->desc, window->mapped, window->minimized);
 
-      /* Double check that creating the MetaWindow succeeded */
-      if (window == NULL)
-        break;
-
-      meta_verbose ("MapRequest on %s mapped = %d minimized = %d\n",
-                    window->desc, window->mapped, window->minimized);
-
-      if (window->minimized)
-        {
-          meta_window_unminimize (window);
-          if (window->workspace != workspace_manager->active_workspace)
+          if (window->minimized && !frame_was_receiver)
             {
-              meta_verbose ("Changing workspace due to MapRequest mapped = %d minimized = %d\n",
-                            window->mapped, window->minimized);
-              meta_window_change_workspace (window,
-                                            workspace_manager->active_workspace);
+              meta_window_unminimize (window);
+              if (window->workspace != workspace_manager->active_workspace)
+                {
+                  meta_verbose ("Changing workspace due to MapRequest mapped = %d minimized = %d",
+                                window->mapped, window->minimized);
+                  meta_window_change_workspace (window,
+                                                workspace_manager->active_workspace);
+                }
             }
         }
       break;


### PR DESCRIPTION
This fixes XCOM® 2 (SteamID: 268500) keyboard controls not working on Proton experimental_11.0. Wine expects the WM_STATE property to be changed to Iconic after mapping a window with XWMHints.initial_state set to IconicState.

This is picked from Mutter commit 3218626d. Below is the original commit message.

```
This is a revert of commit be5c2ebc, adapted to this day and age.
While this worked around issues in wine/proton, it did contravene
icccm in the interpretation of initially iconic windows.

Closes: https://gitlab.gnome.org/GNOME/mutter/-/issues/2043
Part-of: <https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3001>
```

Signed-off-by: Zhiyi Zhang <zzhang@codeweavers.com>