### PR TITLE
Restore edge-resistance-window setting

### DIFF
--- a/data/org.cinnamon.muffin.gschema.xml.in
+++ b/data/org.cinnamon.muffin.gschema.xml.in
@@ -43,6 +43,17 @@
       </description>
     </key>
 
+    <key name="edge-resistance-window" type="b">
+      <default>true</default>
+      <summary>Enable edge resistance between windows</summary>
+      <description>
+        If enabled, windows resist movement when their edges approach the
+        edges of other windows. Disabling this allows windows to be dragged
+        freely past one another without any sticky edge effect. Resistance
+        against monitor and screen boundaries is not affected by this setting.
+      </description>
+    </key>
+
     <key name="tile-maximize" type="b">
       <default>false</default>
       <summary>Sets maximize as the tile action for the top edge of the screen</summary>

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -27,6 +27,7 @@
 #include "core/display-private.h"
 #include "core/meta-workspace-manager-private.h"
 #include "core/workspace-private.h"
+#include "meta/prefs.h"
 
 /* A simple macro for whether a given window's edges are potentially
  * relevant for resistance/snapping during a move/resize operation
@@ -341,7 +342,8 @@ apply_edge_resistance (MetaWindow                *window,
   gboolean increasing = new_pos > old_pos;
   int      increment = increasing ? 1 : -1;
 
-  const int PIXEL_DISTANCE_THRESHOLD_TOWARDS_WINDOW    = 16;
+  const gboolean resist = meta_prefs_get_edge_resistance_window ();
+  const int PIXEL_DISTANCE_THRESHOLD_TOWARDS_WINDOW    = resist ? 16 :  0;
   const int PIXEL_DISTANCE_THRESHOLD_AWAYFROM_WINDOW   =  0;
   const int PIXEL_DISTANCE_THRESHOLD_TOWARDS_MONITOR   = 32;
   const int PIXEL_DISTANCE_THRESHOLD_AWAYFROM_MONITOR  =  0;

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -123,6 +123,7 @@ static int   draggable_border_width = 10;
 static int   drag_threshold;
 static gboolean resize_with_right_button = FALSE;
 static gboolean edge_tiling = FALSE;
+static gboolean edge_resistance_window = TRUE;
 static gboolean force_fullscreen = TRUE;
 static gboolean auto_maximize = TRUE;
 static gboolean show_fallback_app_menu = TRUE;
@@ -414,6 +415,13 @@ static MetaBoolPreference preferences_bool[] =
         META_PREF_EDGE_TILING,
       },
       &edge_tiling,
+    },
+    {
+      { "edge-resistance-window",
+        SCHEMA_MUFFIN,
+        META_PREF_EDGE_RESISTANCE_WINDOW,
+      },
+      &edge_resistance_window,
     },
     {
       { "workspaces-only-on-primary",
@@ -1925,6 +1933,9 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_EDGE_TILING:
       return "EDGE_TILING";
 
+    case META_PREF_EDGE_RESISTANCE_WINDOW:
+      return "EDGE_RESISTANCE_WINDOW";
+
     case META_PREF_FORCE_FULLSCREEN:
       return "FORCE_FULLSCREEN";
 
@@ -2398,6 +2409,12 @@ gboolean
 meta_prefs_get_edge_tiling (void)
 {
   return edge_tiling;
+}
+
+gboolean
+meta_prefs_get_edge_resistance_window (void)
+{
+  return edge_resistance_window;
 }
 
 gboolean

--- a/src/meta/prefs.h
+++ b/src/meta/prefs.h
@@ -106,6 +106,7 @@ typedef enum
   META_PREF_CURSOR_SIZE,
   META_PREF_RESIZE_WITH_RIGHT_BUTTON,
   META_PREF_EDGE_TILING,
+  META_PREF_EDGE_RESISTANCE_WINDOW,
   META_PREF_FORCE_FULLSCREEN,
   META_PREF_WORKSPACES_ONLY_ON_PRIMARY,
   META_PREF_DRAGGABLE_BORDER_WIDTH,
@@ -203,6 +204,9 @@ gboolean                    meta_prefs_get_gnome_animations   (void);
 
 META_EXPORT
 gboolean                    meta_prefs_get_edge_tiling        (void);
+
+META_EXPORT
+gboolean                    meta_prefs_get_edge_resistance_window (void);
 
 META_EXPORT
 gboolean                    meta_prefs_get_tile_maximize      (void);


### PR DESCRIPTION
## What this does

Reintroduces the `edge-resistance-window` gsettings/dconf key, which was
removed in an earlier refactor. When set to `false`, the
window-to-window edge resistance threshold is set to `0`, allowing
windows to be dragged freely without the sticky-edge effect.

Defaults to `true`, so existing behavior is unchanged for anyone who
doesn't touch the setting — this is purely additive.

## Why

A number of users have asked for this toggle to come back (or to be
configurable at all). The old `gsettings set org.cinnamon.muffin
edge-resistance-window false` no longer had any effect once the key was
dropped.

Fixes #657

## Changes

- `data/org.cinnamon.muffin.gschema.xml.in` — add the `edge-resistance-window` key (default `true`)
- `src/meta/prefs.h` — add `META_PREF_EDGE_RESISTANCE_WINDOW` and the getter prototype
- `src/core/prefs.c` — wire up the pref, its string name, and `meta_prefs_get_edge_resistance_window()`
- `src/core/edge-resistance.c` — use the pref to gate the towards-window pixel threshold

## Testing

Built from source and installed as a .deb on Debian Trixie (Cinnamon).
With the key set to `false`, windows drag freely with no edge
resistance; back to `true`, resistance behaves as before.

## Scope

The toggle only affects resistance between **window** edges. Resistance
against **monitor and screen boundaries** is intentionally left intact
and stays active regardless of this setting. This matches the original
behavior of the old key and keeps screen-edge snapping/tiling working as
expected.

## Note

This restores the underlying setting only. Adding a checkbox back to the
Cinnamon settings GUI lives in `linuxmint/cinnamon` and would be a
separate follow-up.