### PR TITLE
clutter: Round widget coordinates and dimensions

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -10625,7 +10625,7 @@ clutter_actor_set_position (ClutterActor *self,
 
   g_return_if_fail (CLUTTER_IS_ACTOR (self));
 
-  graphene_point_init (&new_position, x, y);
+  graphene_point_init (&new_position, roundf (x), roundf (y));
 
   cur_position.x = clutter_actor_get_x (self);
   cur_position.y = clutter_actor_get_y (self);
@@ -11106,7 +11106,7 @@ clutter_actor_set_size (ClutterActor *self,
 
   g_return_if_fail (CLUTTER_IS_ACTOR (self));
 
-  graphene_size_init (&new_size, width, height);
+  graphene_size_init (&new_size, ceilf (width), ceilf (height));
 
   /* minor optimization: if we don't have a duration then we can
    * skip the get_size() below, to avoid the chance of going through


### PR DESCRIPTION
Clutter widgets look blurry when they are positioned on fractional coordinates or when their width or height are not rounded.

Whenever Cinnamon calls set_position(x, y), round x and y to avoid this.

Whenever Cinnamon calls set_size(w, h), ceil w and h. The reason we use ceilf instead of roundf here is to avoid potential clipping. For instance, if a text determines the dimension of an entry, we don't want to round down and take the risk to clip part of the font.