### PR TITLE
wayland: Fix GPU acceleration (wl_drm)

### DIFF
--- a/src/backends/native/meta-cursor-renderer-native.c
+++ b/src/backends/native/meta-cursor-renderer-native.c
@@ -39,6 +39,7 @@
 #include "backends/meta-monitor-manager-private.h"
 #include "backends/meta-output.h"
 #include "backends/native/meta-crtc-kms.h"
+#include "backends/native/meta-gpu-kms.h"
 #include "backends/native/meta-kms-device.h"
 #include "backends/native/meta-kms-update.h"
 #include "backends/native/meta-kms.h"
@@ -98,6 +99,8 @@ typedef struct _MetaCursorRendererNativeGpuData
 
   uint64_t cursor_width;
   uint64_t cursor_height;
+
+  struct gbm_device *kms_gbm_device;
 } MetaCursorRendererNativeGpuData;
 
 typedef enum _MetaCursorGbmBoState
@@ -159,6 +162,15 @@ meta_cursor_renderer_native_gpu_data_from_gpu (MetaGpuKms *gpu_kms)
                              quark_cursor_renderer_native_gpu_data);
 }
 
+static void
+cursor_renderer_native_gpu_data_free (gpointer data)
+{
+  MetaCursorRendererNativeGpuData *cursor_renderer_gpu_data = data;
+
+  g_clear_pointer (&cursor_renderer_gpu_data->kms_gbm_device, gbm_device_destroy);
+  g_free (cursor_renderer_gpu_data);
+}
+
 static MetaCursorRendererNativeGpuData *
 meta_create_cursor_renderer_native_gpu_data (MetaGpuKms *gpu_kms)
 {
@@ -168,7 +180,7 @@ meta_create_cursor_renderer_native_gpu_data (MetaGpuKms *gpu_kms)
   g_object_set_qdata_full (G_OBJECT (gpu_kms),
                            quark_cursor_renderer_native_gpu_data,
                            cursor_renderer_gpu_data,
-                           g_free);
+                           cursor_renderer_native_gpu_data_free);
 
   return cursor_renderer_gpu_data;
 }
@@ -1189,7 +1201,9 @@ load_cursor_sprite_gbm_buffer_for_gpu (MetaCursorRendererNative *native,
       return;
     }
 
-  gbm_device = meta_gbm_device_from_gpu (gpu_kms);
+  gbm_device = cursor_renderer_gpu_data->kms_gbm_device
+               ? cursor_renderer_gpu_data->kms_gbm_device
+               : meta_gbm_device_from_gpu (gpu_kms);
   if (gbm_device_is_format_supported (gbm_device, gbm_format,
                                       GBM_BO_USE_CURSOR | GBM_BO_USE_WRITE))
     {
@@ -1685,6 +1699,12 @@ init_hw_cursor_support_for_gpu (MetaGpuKms *gpu_kms)
 
   cursor_renderer_gpu_data->cursor_width = width;
   cursor_renderer_gpu_data->cursor_height = height;
+
+  cursor_renderer_gpu_data->kms_gbm_device =
+    gbm_create_device (meta_gpu_kms_get_fd (gpu_kms));
+  if (!cursor_renderer_gpu_data->kms_gbm_device)
+    g_warning ("Failed to create KMS GBM device for cursor allocation, "
+               "HW cursor may not work");
 }
 
 static void

--- a/src/backends/native/meta-cursor-renderer-native.c
+++ b/src/backends/native/meta-cursor-renderer-native.c
@@ -1527,7 +1527,7 @@ realize_cursor_sprite_from_wl_buffer_for_gpu (MetaCursorRenderer      *renderer,
           return;
         }
 
-      gbm_device = meta_gbm_device_from_gpu (gpu_kms);
+      gbm_device = cursor_renderer_gpu_data->kms_gbm_device;
       bo = gbm_bo_import (gbm_device,
                           GBM_BO_IMPORT_WL_BUFFER,
                           buffer,
@@ -1700,11 +1700,11 @@ init_hw_cursor_support_for_gpu (MetaGpuKms *gpu_kms)
   cursor_renderer_gpu_data->cursor_width = width;
   cursor_renderer_gpu_data->cursor_height = height;
 
-  cursor_renderer_gpu_data->kms_gbm_device =
-    gbm_create_device (meta_gpu_kms_get_fd (gpu_kms));
-  if (!cursor_renderer_gpu_data->kms_gbm_device)
-    g_warning ("Failed to create KMS GBM device for cursor allocation, "
-               "HW cursor may not work");
+  if (gbm_device_get_fd (gbm_device) != meta_gpu_kms_get_fd (gpu_kms))
+    {
+      cursor_renderer_gpu_data->hw_cursor_broken = TRUE;
+      return;
+    }
 }
 
 static void

--- a/src/backends/native/meta-drm-buffer-gbm.c
+++ b/src/backends/native/meta-drm-buffer-gbm.c
@@ -27,6 +27,9 @@
 
 #include <drm_fourcc.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <gbm.h>
+#include <unistd.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
@@ -57,6 +60,13 @@ meta_drm_buffer_gbm_get_bo (MetaDrmBufferGbm *buffer_gbm)
   return buffer_gbm->bo;
 }
 
+static void
+close_kms_handle (int kms_fd, uint32_t handle)
+{
+  struct drm_gem_close args = { .handle = handle };
+  drmIoctl (kms_fd, DRM_IOCTL_GEM_CLOSE, &args);
+}
+
 static gboolean
 init_fb_id (MetaDrmBufferGbm  *buffer_gbm,
             struct gbm_bo     *bo,
@@ -64,27 +74,79 @@ init_fb_id (MetaDrmBufferGbm  *buffer_gbm,
             GError           **error)
 {
   MetaGpuKmsFBArgs fb_args = { 0, };
+  int gbm_fd = gbm_device_get_fd (gbm_bo_get_device (bo));
+  int kms_fd = meta_gpu_kms_get_fd (buffer_gbm->gpu_kms);
+  gboolean need_prime = (gbm_fd != kms_fd);
+  uint32_t imported_handles[4] = { 0, 0, 0, 0 };
+  int n_imported = 0;
+  int i;
 
   if (gbm_bo_get_handle_for_plane (bo, 0).s32 == -1)
     {
       /* Failed to fetch handle to plane, falling back to old method */
       fb_args.strides[0] = gbm_bo_get_stride (bo);
-      fb_args.handles[0] = gbm_bo_get_handle (bo).u32;
       fb_args.offsets[0] = 0;
       fb_args.modifiers[0] = DRM_FORMAT_MOD_INVALID;
+
+      if (need_prime)
+        {
+          int prime_fd = -1;
+          if (drmPrimeHandleToFD (gbm_fd, gbm_bo_get_handle (bo).u32,
+                                   DRM_CLOEXEC, &prime_fd) != 0 ||
+              drmPrimeFDToHandle (kms_fd, prime_fd, &imported_handles[0]) != 0)
+            {
+              if (prime_fd >= 0)
+                close (prime_fd);
+              g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                           "Failed to import GBM buffer via prime: %s",
+                           g_strerror (errno));
+              return FALSE;
+            }
+          close (prime_fd);
+          n_imported = 1;
+          fb_args.handles[0] = imported_handles[0];
+        }
+      else
+        {
+          fb_args.handles[0] = gbm_bo_get_handle (bo).u32;
+        }
     }
   else
     {
-      int i;
+      int n_planes = gbm_bo_get_plane_count (bo);
 
-      for (i = 0; i < gbm_bo_get_plane_count (bo); i++)
+      for (i = 0; i < n_planes; i++)
         {
           fb_args.strides[i] = gbm_bo_get_stride_for_plane (bo, i);
-          fb_args.handles[i] = gbm_bo_get_handle_for_plane (bo, i).u32;
           fb_args.offsets[i] = gbm_bo_get_offset (bo, i);
           fb_args.modifiers[i] = gbm_bo_get_modifier (bo);
+
+          if (need_prime)
+            {
+              int prime_fd = -1;
+              if (drmPrimeHandleToFD (gbm_fd,
+                                       gbm_bo_get_handle_for_plane (bo, i).u32,
+                                       DRM_CLOEXEC, &prime_fd) != 0 ||
+                  drmPrimeFDToHandle (kms_fd, prime_fd,
+                                       &imported_handles[i]) != 0)
+                {
+                  if (prime_fd >= 0)
+                    close (prime_fd);
+                  g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                               "Failed to import GBM buffer plane %d via prime: %s",
+                               i, g_strerror (errno));
+                  goto out_close_imported;
+                }
+              close (prime_fd);
+              n_imported = i + 1;
+              fb_args.handles[i] = imported_handles[i];
+            }
+          else
+            {
+              fb_args.handles[i] = gbm_bo_get_handle_for_plane (bo, i).u32;
+            }
         }
-     }
+    }
 
   fb_args.width = gbm_bo_get_width (bo);
   fb_args.height = gbm_bo_get_height (bo);
@@ -94,8 +156,19 @@ init_fb_id (MetaDrmBufferGbm  *buffer_gbm,
                             use_modifiers,
                             &fb_args,
                             &buffer_gbm->fb_id, error))
-    return FALSE;
+    goto out_close_imported;
+
+  /* The kernel now holds a reference to the GEM objects via the FB;
+   * close our local imported handles. */
+  for (i = 0; i < n_imported; i++)
+    close_kms_handle (kms_fd, imported_handles[i]);
+
   return TRUE;
+
+out_close_imported:
+  for (i = 0; i < n_imported; i++)
+    close_kms_handle (kms_fd, imported_handles[i]);
+  return FALSE;
 }
 
 static gboolean

--- a/src/backends/native/meta-kms-impl-device.c
+++ b/src/backends/native/meta-kms-impl-device.c
@@ -417,6 +417,11 @@ meta_kms_impl_device_new (MetaKmsDevice  *device,
       return NULL;
     }
 
+  ret = drmSetClientCap (fd, DRM_CLIENT_CAP_ATOMIC, 1);
+  if (ret != 0)
+    g_warning ("DRM_CLIENT_CAP_ATOMIC not supported on this kernel/device: %s",
+               g_strerror (-ret));
+
   drm_resources = drmModeGetResources (fd);
   if (!drm_resources)
     {

--- a/src/backends/native/meta-renderer-native.c
+++ b/src/backends/native/meta-renderer-native.c
@@ -102,6 +102,7 @@ typedef struct _MetaRendererNativeGpuData
 
   struct {
     struct gbm_device *device;
+    int fd;
   } gbm;
 
 #ifdef HAVE_EGL_DEVICE
@@ -283,6 +284,8 @@ meta_renderer_native_gpu_data_free (MetaRendererNativeGpuData *renderer_gpu_data
     meta_egl_terminate (egl, renderer_gpu_data->egl_display, NULL);
 
   g_clear_pointer (&renderer_gpu_data->gbm.device, gbm_device_destroy);
+  if (renderer_gpu_data->gbm.fd >= 0)
+    close (renderer_gpu_data->gbm.fd);
   g_free (renderer_gpu_data);
 }
 
@@ -322,7 +325,9 @@ meta_renderer_native_get_primary_gpu (MetaRendererNative *renderer_native)
 static MetaRendererNativeGpuData *
 meta_create_renderer_native_gpu_data (MetaGpuKms *gpu_kms)
 {
-  return g_new0 (MetaRendererNativeGpuData, 1);
+  MetaRendererNativeGpuData *data = g_new0 (MetaRendererNativeGpuData, 1);
+  data->gbm.fd = -1;
+  return data;
 }
 
 static MetaEgl *
@@ -3442,6 +3447,7 @@ init_secondary_gpu_data_gpu (MetaRendererNativeGpuData *renderer_gpu_data,
     }
 
   renderer_str = (const char *) glGetString (GL_RENDERER);
+  g_message ("GL renderer: %s", renderer_str);
   if (g_str_has_prefix (renderer_str, "llvmpipe") ||
       g_str_has_prefix (renderer_str, "softpipe") ||
       g_str_has_prefix (renderer_str, "swrast"))
@@ -3569,12 +3575,34 @@ create_renderer_gpu_data_gbm (MetaRendererNative  *renderer_native,
 {
   struct gbm_device *gbm_device;
   int kms_fd;
+  int gbm_fd = -1;
+  char *render_node_path;
   MetaRendererNativeGpuData *renderer_gpu_data;
   g_autoptr (GError) local_error = NULL;
 
   kms_fd = meta_gpu_kms_get_fd (gpu_kms);
 
-  gbm_device = gbm_create_device (kms_fd);
+  /* Open the render node directly so GBM gets a clean fd with no KMS client
+   * caps set on it. This matches how wlroots-based compositors initialize
+   * rendering and avoids hardware-specific issues with reusing the KMS fd. */
+  render_node_path = drmGetRenderDeviceNameFromFd (kms_fd);
+  if (render_node_path)
+    {
+      do
+        gbm_fd = open (render_node_path, O_RDWR | O_CLOEXEC);
+      while (gbm_fd < 0 && errno == EINTR);
+      free (render_node_path);
+    }
+
+  gbm_device = gbm_create_device (gbm_fd >= 0 ? gbm_fd : kms_fd);
+  if (!gbm_device && gbm_fd >= 0)
+    {
+      g_warning ("Failed to create gbm device from render node, retrying with primary fd");
+      close (gbm_fd);
+      gbm_fd = -1;
+      gbm_device = gbm_create_device (kms_fd);
+    }
+
   if (!gbm_device)
     {
       g_set_error (error, G_IO_ERROR,
@@ -3586,6 +3614,7 @@ create_renderer_gpu_data_gbm (MetaRendererNative  *renderer_native,
   renderer_gpu_data = meta_create_renderer_native_gpu_data (gpu_kms);
   renderer_gpu_data->renderer_native = renderer_native;
   renderer_gpu_data->gbm.device = gbm_device;
+  renderer_gpu_data->gbm.fd = gbm_fd;
   renderer_gpu_data->mode = META_RENDERER_NATIVE_MODE_GBM;
 
   renderer_gpu_data->egl_display = init_gbm_egl_display (renderer_native,
@@ -3593,9 +3622,9 @@ create_renderer_gpu_data_gbm (MetaRendererNative  *renderer_native,
                                                          &local_error);
   if (renderer_gpu_data->egl_display == EGL_NO_DISPLAY)
     {
-      g_debug ("GBM EGL init for %s failed: %s",
-               meta_gpu_kms_get_file_path (gpu_kms),
-               local_error->message);
+      g_warning ("GBM EGL init for %s failed: %s",
+                 meta_gpu_kms_get_file_path (gpu_kms),
+                 local_error->message);
 
       init_secondary_gpu_data_cpu (renderer_gpu_data);
       return renderer_gpu_data;

--- a/src/meson.build
+++ b/src/meson.build
@@ -511,6 +511,8 @@ if have_wayland
     'wayland/meta-wayland-data-source-primary.h',
     'wayland/meta-wayland-dma-buf.c',
     'wayland/meta-wayland-dma-buf.h',
+    'wayland/meta-wayland-drm.c',
+    'wayland/meta-wayland-drm.h',
     'wayland/meta-wayland-dnd-surface.c',
     'wayland/meta-wayland-dnd-surface.h',
     'wayland/meta-wayland-gtk-shell.c',
@@ -842,6 +844,7 @@ if have_wayland
     ['xdg-toplevel-icon-v1', 'private', ],
     ['xapp-shell', 'private', ],
     ['xwayland-keyboard-grab', 'unstable', 'v1', ],
+    ['wayland-drm', 'private', ],
   ]
   if have_wayland_eglstream
     wayland_eglstream_protocols_dir = wayland_eglstream_protocols_dep.get_variable(pkgconfig: 'pkgdatadir')

--- a/src/wayland/meta-wayland-drm.c
+++ b/src/wayland/meta-wayland-drm.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "wayland/meta-wayland-drm.h"
+
+#include <xf86drm.h>
+
+#include "backends/meta-backend-private.h"
+#include "backends/native/meta-gpu-kms.h"
+#include "wayland/meta-wayland-private.h"
+
+#include "wayland-drm-server-protocol.h"
+
+static void
+drm_authenticate (struct wl_client   *client,
+                  struct wl_resource *resource,
+                  uint32_t            id)
+{
+  /* We advertise the render node, which doesn't require authentication.
+   * Just respond immediately so clients don't stall. */
+  wl_drm_send_authenticated (resource);
+}
+
+static void
+drm_create_buffer (struct wl_client   *client,
+                   struct wl_resource *resource,
+                   uint32_t            id,
+                   uint32_t            name,
+                   int32_t             width,
+                   int32_t             height,
+                   uint32_t            stride,
+                   uint32_t            format)
+{
+  wl_resource_post_error (resource, WL_DRM_ERROR_INVALID_NAME,
+                          "flink buffer creation not supported");
+}
+
+static void
+drm_create_planar_buffer (struct wl_client   *client,
+                          struct wl_resource *resource,
+                          uint32_t            id,
+                          uint32_t            name,
+                          int32_t             width,
+                          int32_t             height,
+                          uint32_t            format,
+                          int32_t             offset0,
+                          int32_t             stride0,
+                          int32_t             offset1,
+                          int32_t             stride1,
+                          int32_t             offset2,
+                          int32_t             stride2)
+{
+  wl_resource_post_error (resource, WL_DRM_ERROR_INVALID_NAME,
+                          "flink buffer creation not supported");
+}
+
+static void
+drm_create_prime_buffer (struct wl_client   *client,
+                         struct wl_resource *resource,
+                         uint32_t            id,
+                         int32_t             name,
+                         int32_t             width,
+                         int32_t             height,
+                         uint32_t            format,
+                         int32_t             offset0,
+                         int32_t             stride0,
+                         int32_t             offset1,
+                         int32_t             stride1,
+                         int32_t             offset2,
+                         int32_t             stride2)
+{
+  wl_resource_post_error (resource, WL_DRM_ERROR_INVALID_NAME,
+                          "prime buffer creation not supported");
+}
+
+static const struct wl_drm_interface drm_implementation = {
+  drm_authenticate,
+  drm_create_buffer,
+  drm_create_planar_buffer,
+  drm_create_prime_buffer,
+};
+
+static void
+drm_bind (struct wl_client *client,
+          void             *data,
+          uint32_t          version,
+          uint32_t          id)
+{
+  const char *device_path = data;
+  struct wl_resource *resource;
+
+  resource = wl_resource_create (client, &wl_drm_interface, version, id);
+  wl_resource_set_implementation (resource, &drm_implementation, NULL, NULL);
+
+  wl_drm_send_device (resource, device_path);
+  wl_drm_send_capabilities (resource, WL_DRM_CAPABILITY_PRIME);
+}
+
+void
+meta_wayland_drm_init (MetaWaylandCompositor *compositor)
+{
+  MetaBackend *backend = meta_get_backend ();
+  GList *gpus;
+  MetaGpuKms *gpu_kms;
+  int kms_fd;
+  char *render_node_path;
+
+  gpus = meta_backend_get_gpus (backend);
+  if (!gpus)
+    return;
+
+  gpu_kms = META_GPU_KMS (gpus->data);
+  kms_fd = meta_gpu_kms_get_fd (gpu_kms);
+  render_node_path = drmGetRenderDeviceNameFromFd (kms_fd);
+
+  if (!render_node_path)
+    {
+      g_warning ("wl_drm: could not get render node path, skipping");
+      return;
+    }
+
+  wl_global_create (compositor->wayland_display,
+                    &wl_drm_interface,
+                    2,
+                    render_node_path,
+                    drm_bind);
+
+  g_message ("wl_drm: advertising render node %s", render_node_path);
+  /* render_node_path is intentionally leaked — it lives for the lifetime
+   * of the global and there is no teardown path for Wayland globals here. */
+}

--- a/src/wayland/meta-wayland-drm.h
+++ b/src/wayland/meta-wayland-drm.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Linux Mint
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+#ifndef META_WAYLAND_DRM_H
+#define META_WAYLAND_DRM_H
+
+#include "wayland/meta-wayland-types.h"
+
+void meta_wayland_drm_init (MetaWaylandCompositor *compositor);
+
+#endif /* META_WAYLAND_DRM_H */

--- a/src/wayland/meta-wayland.c
+++ b/src/wayland/meta-wayland.c
@@ -36,6 +36,7 @@
 #include "wayland/meta-wayland-cursor-shape.h"
 #include "wayland/meta-wayland-data-device.h"
 #include "wayland/meta-wayland-dma-buf.h"
+#include "wayland/meta-wayland-drm.h"
 #include "wayland/meta-wayland-egl-stream.h"
 #include "wayland/meta-wayland-idle-inhibit.h"
 #include "wayland/meta-wayland-inhibit-shortcuts-dialog.h"
@@ -444,6 +445,7 @@ meta_wayland_compositor_setup (MetaWaylandCompositor *wayland_compositor)
   meta_wayland_xdg_foreign_init (compositor);
   meta_wayland_legacy_xdg_foreign_init (compositor);
   meta_wayland_dma_buf_init (compositor);
+  meta_wayland_drm_init (compositor);
   meta_wayland_init_single_pixel_buffer_manager (compositor);
   meta_wayland_keyboard_shortcuts_inhibit_init (compositor);
   meta_wayland_surface_inhibit_shortcuts_dialog_init ();

--- a/src/wayland/protocol/wayland-drm.xml
+++ b/src/wayland/protocol/wayland-drm.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="drm">
+
+  <copyright>
+    Copyright © 2008-2011 Kristian Høgsberg
+    Copyright © 2010-2011 Intel Corporation
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that\n the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <!-- drm support. This object is created by the server and published
+       using the display's global event. -->
+  <interface name="wl_drm" version="2">
+    <enum name="error">
+      <entry name="authenticate_fail" value="0"/>
+      <entry name="invalid_format" value="1"/>
+      <entry name="invalid_name" value="2"/>
+    </enum>
+
+    <enum name="format">
+      <!-- The drm format codes match the #defines in drm_fourcc.h.
+           The formats actually supported by the compositor will be
+           reported by the format event. New codes must not be added,
+           unless directly taken from drm_fourcc.h. -->
+      <entry name="c8" value="0x20203843"/>
+      <entry name="rgb332" value="0x38424752"/>
+      <entry name="bgr233" value="0x38524742"/>
+      <entry name="xrgb4444" value="0x32315258"/>
+      <entry name="xbgr4444" value="0x32314258"/>
+      <entry name="rgbx4444" value="0x32315852"/>
+      <entry name="bgrx4444" value="0x32315842"/>
+      <entry name="argb4444" value="0x32315241"/>
+      <entry name="abgr4444" value="0x32314241"/>
+      <entry name="rgba4444" value="0x32314152"/>
+      <entry name="bgra4444" value="0x32314142"/>
+      <entry name="xrgb1555" value="0x35315258"/>
+      <entry name="xbgr1555" value="0x35314258"/>
+      <entry name="rgbx5551" value="0x35315852"/>
+      <entry name="bgrx5551" value="0x35315842"/>
+      <entry name="argb1555" value="0x35315241"/>
+      <entry name="abgr1555" value="0x35314241"/>
+      <entry name="rgba5551" value="0x35314152"/>
+      <entry name="bgra5551" value="0x35314142"/>
+      <entry name="rgb565" value="0x36314752"/>
+      <entry name="bgr565" value="0x36314742"/>
+      <entry name="rgb888" value="0x34324752"/>
+      <entry name="bgr888" value="0x34324742"/>
+      <entry name="xrgb8888" value="0x34325258"/>
+      <entry name="xbgr8888" value="0x34324258"/>
+      <entry name="rgbx8888" value="0x34325852"/>
+      <entry name="bgrx8888" value="0x34325842"/>
+      <entry name="argb8888" value="0x34325241"/>
+      <entry name="abgr8888" value="0x34324241"/>
+      <entry name="rgba8888" value="0x34324152"/>
+      <entry name="bgra8888" value="0x34324142"/>
+      <entry name="xrgb2101010" value="0x30335258"/>
+      <entry name="xbgr2101010" value="0x30334258"/>
+      <entry name="rgbx1010102" value="0x30335852"/>
+      <entry name="bgrx1010102" value="0x30335842"/>
+      <entry name="argb2101010" value="0x30335241"/>
+      <entry name="abgr2101010" value="0x30334241"/>
+      <entry name="rgba1010102" value="0x30334152"/>
+      <entry name="bgra1010102" value="0x30334142"/>
+      <entry name="yuyv" value="0x56595559"/>
+      <entry name="yvyu" value="0x55595659"/>
+      <entry name="uyvy" value="0x59565955"/>
+      <entry name="vyuy" value="0x59555956"/>
+      <entry name="ayuv" value="0x56555941"/>
+      <entry name="xyuv8888" value="0x56555958"/>
+      <entry name="nv12" value="0x3231564e"/>
+      <entry name="nv21" value="0x3132564e"/>
+      <entry name="nv16" value="0x3631564e"/>
+      <entry name="nv61" value="0x3136564e"/>
+      <entry name="yuv410" value="0x39565559"/>
+      <entry name="yvu410" value="0x39555659"/>
+      <entry name="yuv411" value="0x31315559"/>
+      <entry name="yvu411" value="0x31315659"/>
+      <entry name="yuv420" value="0x32315559"/>
+      <entry name="yvu420" value="0x32315659"/>
+      <entry name="yuv422" value="0x36315559"/>
+      <entry name="yvu422" value="0x36315659"/>
+      <entry name="yuv444" value="0x34325559"/>
+      <entry name="yvu444" value="0x34325659"/>
+      <entry name="abgr16f" value="0x48344241"/>
+      <entry name="xbgr16f" value="0x48344258"/>
+    </enum>
+
+    <!-- Call this request with the magic received from drmGetMagic().
+         It will be passed on to the drmAuthMagic() or
+         DRIAuthConnection() call.  This authentication must be
+         completed before create_buffer could be used. -->
+    <request name="authenticate">
+      <arg name="id" type="uint"/>
+    </request>
+
+    <!-- Create a wayland buffer for the named DRM buffer.  The DRM
+         surface must have a name using the flink ioctl -->
+    <request name="create_buffer">
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="name" type="uint"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="stride" type="uint"/>
+      <arg name="format" type="uint"/>
+    </request>
+
+    <!-- Create a wayland buffer for the named DRM buffer.  The DRM
+         surface must have a name using the flink ioctl -->
+    <request name="create_planar_buffer">
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="name" type="uint"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="format" type="uint"/>
+      <arg name="offset0" type="int"/>
+      <arg name="stride0" type="int"/>
+      <arg name="offset1" type="int"/>
+      <arg name="stride1" type="int"/>
+      <arg name="offset2" type="int"/>
+      <arg name="stride2" type="int"/>
+    </request>
+
+    <!-- Notification of the path of the drm device which is used by
+         the server.  The client should use this device for creating
+         local buffers.  Only buffers created from this device should
+         be be passed to the server using this drm object's
+         create_buffer request. -->
+    <event name="device">
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="format">
+      <arg name="format" type="uint"/>
+    </event>
+
+    <!-- Raised if the authenticate request succeeded -->
+    <event name="authenticated"/>
+
+    <enum name="capability" since="2">
+      <description summary="wl_drm capability bitmask">
+        Bitmask of capabilities.
+      </description>
+      <entry name="prime" value="1" summary="wl_drm prime available"/>
+    </enum>
+
+    <event name="capabilities">
+      <arg name="value" type="uint"/>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <!-- Create a wayland buffer for the prime fd.  Use for regular and planar
+         buffers.  Pass 0 for offset and stride for unused planes. -->
+    <request name="create_prime_buffer" since="2">
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="name" type="fd"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+      <arg name="format" type="uint"/>
+      <arg name="offset0" type="int"/>
+      <arg name="stride0" type="int"/>
+      <arg name="offset1" type="int"/>
+      <arg name="stride1" type="int"/>
+      <arg name="offset2" type="int"/>
+      <arg name="stride2" type="int"/>
+    </request>
+
+  </interface>
+
+</protocol>


### PR DESCRIPTION
This is a collection of multiple fixes to bring acceleration to Wayland and XWayland.

It's only a temporary solution for now using wl_drm implementation. We need a better implementation which supports zwp_linux_dmabuf_v1 v4/5.

Fixes XWayland acceleration, acceleration in games like Supertuxkart, playing videos in Slack... I think Vulkan already worked before that. Doesn't fix acceleration in direct GL apps such as glmark2-es2-wayland.