### PR TITLE
Fix desktop zoom scrolling the window under the pointer, and Super opening the menu after zooming

### DIFF
--- a/src/backends/x11/meta-backend-x11.c
+++ b/src/backends/x11/meta-backend-x11.c
@@ -53,6 +53,7 @@
 #include "clutter/x11/clutter-x11.h"
 #include "compositor/compositor-private.h"
 #include "core/display-private.h"
+#include "core/keybindings-private.h"
 #include "meta/meta-cursor-tracker.h"
 #include "meta/util.h"
 
@@ -425,6 +426,12 @@ handle_host_xevent (MetaBackend *backend,
                     meta_backend_notify_keymap_layout_group_changed (backend,
                                                                      layout_group);
                 }
+              if (display &&
+                  (xkb_ev->state.changed & (XkbModifierStateMask |
+                                            XkbModifierBaseMask)))
+                meta_display_process_zoom_modifier_state (display,
+                                                          xkb_ev->state.mods,
+                                                          xkb_ev->state.time);
               break;
             default:
               break;
@@ -579,6 +586,14 @@ meta_backend_x11_post_init (MetaBackend *backend)
                                     &priv->xkb_error_base))
     meta_fatal ("X server doesn't have the XKB extension, version %d.%d or newer\n",
                 XKB_X11_MIN_MAJOR_XKB_VERSION, XKB_X11_MIN_MINOR_XKB_VERSION);
+
+  /* Make sure modifier state changes are among the selected
+   * XkbStateNotify details; the zoom modifier pointer grab depends on
+   * them (see meta_display_process_zoom_modifier_state).  Only the
+   * listed detail bits are affected, existing selections remain. */
+  XkbSelectEventDetails (priv->xdisplay, XkbUseCoreKbd, XkbStateNotify,
+                         XkbModifierStateMask | XkbModifierBaseMask,
+                         XkbModifierStateMask | XkbModifierBaseMask);
 
   META_BACKEND_CLASS (meta_backend_x11_parent_class)->post_init (backend);
 

--- a/src/core/events.c
+++ b/src/core/events.c
@@ -291,6 +291,10 @@ meta_display_handle_event (MetaDisplay        *display,
             meta_display_a11y_zoom (display, FALSE);
           }
 
+        /* Don't let the zoom modifier's release trigger a
+         * modifier-only keybinding (e.g. Super opening the menu) */
+        meta_keybindings_cancel_modifier_only (display);
+
         bypass_wayland = bypass_clutter = TRUE;
         goto out;
       }

--- a/src/core/events.c
+++ b/src/core/events.c
@@ -295,10 +295,19 @@ meta_display_handle_event (MetaDisplay        *display,
          * modifier-only keybinding (e.g. Super opening the menu) */
         meta_keybindings_cancel_modifier_only (display);
 
+        /* On X11, hold the pointer for the duration of the scroll burst
+         * so smooth-scroll events can't leak to the client under the
+         * pointer. */
+        meta_display_zoom_scroll_grab_notify (display,
+                                              clutter_event_get_time (event));
+
         bypass_wayland = bypass_clutter = TRUE;
         goto out;
       }
     }
+
+  if (event->type == CLUTTER_BUTTON_PRESS)
+    meta_display_zoom_grab_break (display, clutter_event_get_time (event));
 
   if (event->type != CLUTTER_DEVICE_ADDED &&
       event->type != CLUTTER_DEVICE_REMOVED)

--- a/src/core/keybindings-private.h
+++ b/src/core/keybindings-private.h
@@ -144,6 +144,7 @@ int      meta_keybindings_get_mouse_zoom_modifiers (MetaDisplay *display);
 ClutterModifierType meta_display_get_window_grab_modifiers (MetaDisplay *display);
 
 uint     meta_keybindings_get_ignored_modifier_mask (MetaDisplay *display);
+void     meta_keybindings_cancel_modifier_only (MetaDisplay *display);
 
 gboolean meta_prefs_add_keybinding          (const char           *name,
                                              GSettings            *settings,

--- a/src/core/keybindings-private.h
+++ b/src/core/keybindings-private.h
@@ -126,6 +126,10 @@ typedef struct
   /* Alt+click button grabs */
   ClutterModifierType window_grab_modifiers;
   ClutterModifierType mouse_zoom_modifiers;
+
+  /* Active pointer grab held during zoom scroll bursts (X11) */
+  gboolean zoom_pointer_grabbed;
+  guint zoom_grab_timeout_id;
 } MetaKeyBindingManager;
 
 void     meta_display_init_keys             (MetaDisplay *display);
@@ -145,6 +149,14 @@ ClutterModifierType meta_display_get_window_grab_modifiers (MetaDisplay *display
 
 uint     meta_keybindings_get_ignored_modifier_mask (MetaDisplay *display);
 void     meta_keybindings_cancel_modifier_only (MetaDisplay *display);
+
+void     meta_display_process_zoom_modifier_state (MetaDisplay *display,
+                                                   unsigned int mods,
+                                                   guint32      timestamp);
+void     meta_display_zoom_scroll_grab_notify (MetaDisplay *display,
+                                               guint32      timestamp);
+void     meta_display_zoom_grab_break (MetaDisplay *display,
+                                       guint32      timestamp);
 
 gboolean meta_prefs_add_keybinding          (const char           *name,
                                              GSettings            *settings,

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2474,6 +2474,7 @@ meta_keybindings_process_event (MetaDisplay        *display,
     case CLUTTER_BUTTON_RELEASE:
     case CLUTTER_TOUCH_BEGIN:
     case CLUTTER_TOUCH_END:
+    case CLUTTER_SCROLL:
       modifier_key_only_pressed = FALSE;
       return FALSE;
 
@@ -4205,6 +4206,12 @@ meta_keybindings_get_ignored_modifier_mask (MetaDisplay *display)
     MetaKeyBindingManager *keys = &display->key_binding_manager;
 
     return keys->ignored_modifier_mask;
+}
+
+void
+meta_keybindings_cancel_modifier_only (MetaDisplay *display)
+{
+  modifier_key_only_pressed = FALSE;
 }
 
 static void

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1503,6 +1503,12 @@ meta_display_shutdown_keys (MetaDisplay *display)
   g_hash_table_destroy (keys->key_bindings_index);
   g_hash_table_destroy (keys->key_bindings);
 
+  if (keys->zoom_grab_timeout_id != 0)
+    {
+      g_source_remove (keys->zoom_grab_timeout_id);
+      keys->zoom_grab_timeout_id = 0;
+    }
+
   clear_active_keyboard_layouts (keys);
 }
 
@@ -4213,6 +4219,104 @@ meta_keybindings_cancel_modifier_only (MetaDisplay *display)
 {
   modifier_key_only_pressed = FALSE;
 }
+
+#define ZOOM_SCROLL_GRAB_TIMEOUT_MS 1000
+
+/* While zoom scrolling is in progress on X11 we hold an active grab on
+ * the pointer.  The passive button 4/5 grabs only intercept the emulated
+ * legacy scroll button events; XInput2-aware clients scroll with the
+ * smooth-scroll XI_Motion events, which are delivered before any passive
+ * button grab can activate.  Only an active device grab keeps them from
+ * reaching the client under the pointer.
+ *
+ * The grab is only held for the duration of a scroll burst (released on
+ * a short idle timeout, on a button press, or when the zoom modifier is
+ * released) so that modifier+click interactions keep working.  A click
+ * swallowed by the grab cannot be re-injected: the physical press has
+ * already registered in the master device's button state, so a synthetic
+ * press is discarded as a duplicate.
+ */
+
+void
+meta_display_zoom_grab_break (MetaDisplay *display,
+                              guint32      timestamp)
+{
+  MetaKeyBindingManager *keys = &display->key_binding_manager;
+
+  if (keys->zoom_grab_timeout_id != 0)
+    {
+      g_source_remove (keys->zoom_grab_timeout_id);
+      keys->zoom_grab_timeout_id = 0;
+    }
+
+  if (!keys->zoom_pointer_grabbed)
+    return;
+
+  /* If a compositor or window grab took over in the meantime, our
+   * grab was already replaced; ungrabbing would break theirs. */
+  if (display->event_route == META_EVENT_ROUTE_NORMAL)
+    meta_backend_ungrab_device (keys->backend,
+                                META_VIRTUAL_CORE_POINTER_ID,
+                                timestamp);
+  keys->zoom_pointer_grabbed = FALSE;
+}
+
+static gboolean
+zoom_scroll_grab_timeout (gpointer data)
+{
+  MetaDisplay *display = data;
+  MetaKeyBindingManager *keys = &display->key_binding_manager;
+
+  keys->zoom_grab_timeout_id = 0;
+  meta_display_zoom_grab_break (display, META_CURRENT_TIME);
+  return G_SOURCE_REMOVE;
+}
+
+void
+meta_display_zoom_scroll_grab_notify (MetaDisplay *display,
+                                      guint32      timestamp)
+{
+  MetaKeyBindingManager *keys = &display->key_binding_manager;
+
+  if (meta_is_wayland_compositor ())
+    return;
+
+  if (!keys->zoom_pointer_grabbed &&
+      display->event_route == META_EVENT_ROUTE_NORMAL &&
+      display->grab_op == META_GRAB_OP_NONE)
+    {
+      keys->zoom_pointer_grabbed =
+        meta_backend_grab_device (keys->backend,
+                                  META_VIRTUAL_CORE_POINTER_ID,
+                                  timestamp);
+    }
+
+  if (keys->zoom_pointer_grabbed)
+    {
+      if (keys->zoom_grab_timeout_id != 0)
+        g_source_remove (keys->zoom_grab_timeout_id);
+      keys->zoom_grab_timeout_id = g_timeout_add (ZOOM_SCROLL_GRAB_TIMEOUT_MS,
+                                                  zoom_scroll_grab_timeout,
+                                                  display);
+    }
+}
+
+/* Called on XkbStateNotify: release the scroll grab as soon as the zoom
+ * modifier is no longer held. */
+void
+meta_display_process_zoom_modifier_state (MetaDisplay *display,
+                                          unsigned int mods,
+                                          guint32      timestamp)
+{
+  MetaKeyBindingManager *keys = &display->key_binding_manager;
+
+  if (!keys->zoom_pointer_grabbed)
+    return;
+
+  if ((mods & ~keys->ignored_modifier_mask) != keys->mouse_zoom_modifiers)
+    meta_display_zoom_grab_break (display, timestamp);
+}
+
 
 static void
 init_builtin_key_bindings (MetaDisplay *display)


### PR DESCRIPTION
Fixes #695
Addresses linuxmint/cinnamon#12587 (and the long lineage behind it: linuxmint/cinnamon#5163, #10084, #10148, #11728)

## The bugs

With **Accessibility → Zoom** enabled and a mouse-wheel modifier set, two things go wrong on X11:

1. **Scroll passthrough**: zooming also scrolls the window under the pointer — vertically with Super, horizontally with Shift, app-zoom with Ctrl. As diagnosed in #695, this only affects XInput2-aware clients (GTK3 apps, Chromium/Electron, Firefox with `MOZ_USE_XINPUT2=1`), which is by now nearly everything.
2. **Bonus bug from #695**: with Super as the modifier, releasing Super after zooming pops up the Cinnamon menu.

Note:

1. These issues do not affect Linux Mint 22.3 Wayland except for the super key bringing up the menu.  The first commit solves this issue for both Wayland and X11.
2. With a stable Wayland coming in the next release of Mint, one could argue that this very old bug doesn't really need to be fixed but end of support for 22.x isn't until April 2029.

## Root causes

**Passthrough**: muffin's zoom capture uses passive `XIGrabButton` grabs on buttons 4/5. Those only ever intercept the *emulated legacy* scroll button events. With XI 2.1 smooth scrolling, the X server delivers the smooth-scroll `XI_Motion` valuator event to the client under the pointer *before* the emulated button event activates the passive grab — motion events cannot trigger a passive button grab. So muffin gets the button event (zoom works) **and** the client gets the motion event (window scrolls). This was confirmed with `xev` vs `xinput test-xi2`, and with Firefox/Emacs XInput2 on/off builds (see #695).

**Menu popup**: scroll events consumed by the zoom branch in `events.c` bypass `meta_keybindings_process_event`, so the modifier-only ("overlay key") state is never cancelled; Super-press → zoom → Super-release looks like a bare Super tap.

## The fix

**Commit 1** cancels the pending modifier-only state when a zoom scroll is consumed (and on scroll events generally, matching the existing button/touch behavior). Fixes the menu popup on both X11 and Wayland.

**Commit 2** takes an **active grab on the virtual core pointer for the duration of a zoom scroll burst**. The first consumed zoom scroll engages the grab (via the existing `meta_backend_grab_device()`); each further scroll refreshes a 1 s idle timer. The grab is released on timeout, on a button press, or as soon as the zoom modifier is released (tracked through `XkbStateNotify`, which muffin already receives — no key grabs involved). While the grab is held, smooth-scroll motion events route to muffin and cannot reach the client.

The grab is intentionally *not* held for the whole time the modifier is down. Modifier+click interactions (Shift+click selection, Ctrl+click) must keep working, and re-injecting a swallowed click via XTest is not possible: the physical press has already registered in the master device's button state, so the synthetic press is discarded by the server as a duplicate (verified with `xev`: no `ButtonPress` delivered, `EnterNotify state 0x111`).

Wayland is unaffected by commit 2 (guarded, and not needed — muffin consumes the events before delivery there).

## Known limitations

- The **first scroll event of each burst** can still leak to an XI2 client (it has been processed by the time the grab can engage). Subsequent events in the burst are fully captured.  Using the Super key may be the best choice as it won't interfere with side scrolling, browser zooming etc.
- The engage can fail transiently (`AlreadyGrabbed`) if another client holds a pointer grab (open menu, button held); it retries on the next scroll event and zoom itself keeps working through the passive grabs.
- A click landing within the 1 s idle window after the last zoom scroll is consumed by the grab teardown.

## Testing this PR on the stable 6.6.x series (Mint 22.3)

This PR targets master, but the patches apply cleanly to the current stable release, so anyone affected can try them on a **test installation of** Linux Mint 22.x / muffin 6.6.x:

**Pre-rebased branch** (easiest): a backport onto the `6.6.3` tag is at [`AlexB7/muffin` branch `zoom-fix-6.6.3`](https://github.com/AlexB7/muffin/tree/zoom-fix-6.6.3):

```bash
git clone --branch zoom-fix-6.6.3 https://github.com/AlexB7/muffin
cd muffin
sudo apt build-dep muffin        # needs a deb-src line enabled
dpkg-buildpackage -us -uc -b
sudo apt install ../libmuffin0_*.deb ../muffin_*.deb ../muffin-common_*.deb ../gir1.2-meta-muffin-0.0_*.deb
```

**Or apply this PR's commits yourself**:

```bash
git clone https://github.com/linuxmint/muffin && cd muffin
git checkout -b zoom-test 6.6.3
curl -L https://github.com/linuxmint/muffin/pull/854.patch | git am -3
```

Either way, install the full package set (the fix lives in `libmuffin0`) and log out/in afterwards. To verify: enable **Accessibility → Zoom** with a mouse wheel modifier, hold the modifier and scroll over Chromium or any GTK3 app — the window content should no longer scroll while zooming (apart from at most the first tick of a burst), and with Super as the modifier the menu should no longer open when you release the key.

**Reverting**: the locally built version (`6.6.3`) sorts below the distro's (`6.6.3+<codename>`), so going back to stock is just

```bash
sudo apt install --reinstall --allow-downgrades muffin libmuffin0 muffin-common gir1.2-meta-muffin-0.0
```

and a log out/in. For the same reason, Update Manager will offer to replace the patched build with the stock package at the next update — hold the packages (`sudo apt-mark hold muffin libmuffin0 muffin-common gir1.2-meta-muffin-0.0`) if you want to keep testing through updates, and `unhold` when done.

## Testing done

On Linux Mint 22.3, muffin 6.6.3 + these patches, X11:

- Super/Shift + wheel over Chromium, GNOME Terminal, and `MOZ_USE_XINPUT2=1` Firefox: zoom works, window content no longer scrolls (previously reproduced reliably in all three).
- Super release after zooming no longer opens the menu (also verified over VNC, where only the legacy-button path exists).
- Shift as modifier: Shift+click and Shift+drag text selection in xed work with zoom enabled; Shift horizontal scroll correctly suppressed while zooming.
- Plain Super tap still opens the menu; Alt-Tab, window drag, unmodified scrolling unchanged.
- Wayland session: no regressions; passthrough does not occur there by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)