### PR TITLE
Fix alacritty not taking focus on application launch in X11 sessions.

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5594,8 +5594,11 @@ meta_window_raise (MetaWindow  *window)
    * It is important that this runs before meta_stack_raise() because
    * showing a window may overwrite its stacking order based on the
    * stacking rules for newly shown windows.
+   * Skip X11: flushing here can prevent newly mapped windows from
+   * receiving focus.
    */
-  meta_window_flush_calc_showing (window);
+  if (window->client_type != META_WINDOW_CLIENT_TYPE_X11)
+    meta_window_flush_calc_showing (window);
 
   ancestor = meta_window_find_root_ancestor (window);
 


### PR DESCRIPTION
## Related Issues

* #772 

* https://github.com/linuxmint/cinnamon/issues/13382 

## Before

Alacritty does not take focus in X11 session


https://github.com/user-attachments/assets/f986ed3e-0170-448e-9da6-155046e44934



## After

Alacritty does take focus in X11 session. 

https://github.com/user-attachments/assets/ab9bf7dc-4431-48f6-8f81-af97b7bf1f38

## Summary

In  X11 sessions, apps built with winit library (eg: Alacritty) map a new window and immediately raise it. That raise now forces the window to show right away, which skips the usual focus-on-map path. The force-show was added for Wayland activation and isn’t needed on X11.

All credit to @zackgomez for his research on this issue (including suggesting this very fix):

 https://github.com/linuxmint/muffin/issues/772#issuecomment-3865781597

