### PR TITLE
[Wayland] meta-cursor-tracker: Add pointer button press event

### DIFF
--- a/src/backends/meta-cursor-tracker-private.h
+++ b/src/backends/meta-cursor-tracker-private.h
@@ -62,6 +62,10 @@ void     meta_cursor_tracker_update_position (MetaCursorTracker *tracker,
                                               float              new_x,
                                               float              new_y);
 
+void     meta_cursor_tracker_update_button (MetaCursorTracker *tracker,
+                                            guint              button,
+                                            gboolean           pressed);
+
 MetaCursorSprite * meta_cursor_tracker_get_displayed_cursor (MetaCursorTracker *tracker);
 
 #endif

--- a/src/backends/meta-cursor-tracker.c
+++ b/src/backends/meta-cursor-tracker.c
@@ -52,6 +52,7 @@ enum
   CURSOR_CHANGED,
   CURSOR_MOVED,
   VISIBILITY_CHANGED,
+  POINTER_BUTTON,
   LAST_SIGNAL
 };
 
@@ -193,6 +194,19 @@ meta_cursor_tracker_class_init (MetaCursorTrackerClass *klass)
                                               G_SIGNAL_RUN_LAST,
                                               0, NULL, NULL, NULL,
                                               G_TYPE_NONE, 0);
+
+  /**
+   * MetaCursorTracker::pointer-button:
+   * @tracker: The #MetaCursorTracker
+   * @button: The button number that changed state
+   * @pressed: %TRUE if the button was pressed, %FALSE if released
+   */
+  signals[POINTER_BUTTON] = g_signal_new ("pointer-button",
+                                          G_TYPE_FROM_CLASS (klass),
+                                          G_SIGNAL_RUN_LAST,
+                                          0, NULL, NULL, NULL,
+                                          G_TYPE_NONE, 2,
+                                          G_TYPE_UINT, G_TYPE_BOOLEAN);
 }
 
 /**
@@ -379,6 +393,16 @@ meta_cursor_tracker_update_position (MetaCursorTracker *tracker,
   meta_cursor_renderer_set_position (cursor_renderer, new_x, new_y);
 
   g_signal_emit (tracker, signals[CURSOR_MOVED], 0, new_x, new_y);
+}
+
+void
+meta_cursor_tracker_update_button (MetaCursorTracker *tracker,
+                                   guint              button,
+                                   gboolean           pressed)
+{
+  g_assert (meta_is_wayland_compositor ());
+
+  g_signal_emit (tracker, signals[POINTER_BUTTON], 0, button, pressed);
 }
 
 static void

--- a/src/core/events.c
+++ b/src/core/events.c
@@ -331,6 +331,18 @@ meta_display_handle_event (MetaDisplay        *display,
 
       display->monitor_cache_invalidated = TRUE;
     }
+
+  if (meta_is_wayland_compositor () &&
+      (event->type == CLUTTER_BUTTON_PRESS ||
+       event->type == CLUTTER_BUTTON_RELEASE))
+    {
+      MetaCursorTracker *cursor_tracker =
+        meta_backend_get_cursor_tracker (backend);
+
+      meta_cursor_tracker_update_button (cursor_tracker,
+                                         clutter_event_get_button (event),
+                                         event->type == CLUTTER_BUTTON_PRESS);
+    }
 #endif
 
   window = get_window_for_event (display, event);


### PR DESCRIPTION
This is necessary to ensure support for the [mouse click effects](https://cinnamon-spices.linuxmint.com/extensions/view/100) extension in Wayland.

Tested working by building on top of latest muffin in a VM with LM 23 Alfa. 